### PR TITLE
Add the “requires_internet” mark to a few more tests

### DIFF
--- a/tests/backend/dep/test_core.py
+++ b/tests/backend/dep/test_core.py
@@ -1,5 +1,7 @@
 import sys
 
+import pytest
+
 from packaging.requirements import Requirement
 
 from hatch.venv.core import TempVirtualEnv
@@ -16,12 +18,14 @@ def test_dependency_not_found(platform):
         assert not dependencies_in_sync([Requirement('binary')], venv.sys_path)
 
 
+@pytest.mark.requires_internet
 def test_dependency_found(platform):
     with TempVirtualEnv(sys.executable, platform) as venv:
         platform.run_command(['pip', 'install', 'binary'], check=True, capture_output=True)
         assert dependencies_in_sync([Requirement('binary')], venv.sys_path)
 
 
+@pytest.mark.requires_internet
 def test_version_unmet(platform):
     with TempVirtualEnv(sys.executable, platform) as venv:
         platform.run_command(['pip', 'install', 'binary'], check=True, capture_output=True)
@@ -38,24 +42,28 @@ def test_marker_unmet(platform):
         assert not dependencies_in_sync([Requirement('binary; python_version > "1"')], venv.sys_path)
 
 
+@pytest.mark.requires_internet
 def test_extra_no_dependencies(platform):
     with TempVirtualEnv(sys.executable, platform) as venv:
         platform.run_command(['pip', 'install', 'binary'], check=True, capture_output=True)
         assert not dependencies_in_sync([Requirement('binary[foo]')], venv.sys_path)
 
 
+@pytest.mark.requires_internet
 def test_unknown_extra(platform):
     with TempVirtualEnv(sys.executable, platform) as venv:
         platform.run_command(['pip', 'install', 'requests[security]==2.25.1'], check=True, capture_output=True)
         assert not dependencies_in_sync([Requirement('requests[foo]')], venv.sys_path)
 
 
+@pytest.mark.requires_internet
 def test_extra_unmet(platform):
     with TempVirtualEnv(sys.executable, platform) as venv:
         platform.run_command(['pip', 'install', 'requests==2.25.1'], check=True, capture_output=True)
         assert not dependencies_in_sync([Requirement('requests[security]==2.25.1')], venv.sys_path)
 
 
+@pytest.mark.requires_internet
 def test_extra_met(platform):
     with TempVirtualEnv(sys.executable, platform) as venv:
         platform.run_command(['pip', 'install', 'requests[security]==2.25.1'], check=True, capture_output=True)

--- a/tests/backend/dep/test_core.py
+++ b/tests/backend/dep/test_core.py
@@ -1,7 +1,6 @@
 import sys
 
 import pytest
-
 from packaging.requirements import Requirement
 
 from hatch.venv.core import TempVirtualEnv


### PR DESCRIPTION
I didn’t notice these before because I had the idea that the tests in `tests/backend` belonged strictly to Hatchling and shouldn’t be run in the Hatch RPM build on Fedora Linux—but I’ve been re-thinking that, and so I found a few more tests that I missed handling in #171.

In offline build environments, fixes six test failures similar to:

```
>               raise CalledProcessError(retcode, process.args,
                                         output=stdout, stderr=stderr)
E               subprocess.CalledProcessError: Command '['pip', 'install', 'requests[security]==2.25.1']' returned non-zero exit status 1.

/usr/lib64/python3.10/subprocess.py:524: CalledProcessError
```

```
FAILED tests/backend/dep/test_core.py::test_dependency_found - subprocess.Cal...
FAILED tests/backend/dep/test_core.py::test_extra_no_dependencies - subproces...
FAILED tests/backend/dep/test_core.py::test_extra_unmet - subprocess.CalledPr...
FAILED tests/backend/dep/test_core.py::test_unknown_extra - subprocess.Called...
FAILED tests/backend/dep/test_core.py::test_version_unmet - subprocess.Called...
FAILED tests/backend/dep/test_core.py::test_extra_met - subprocess.CalledProc...
```