### PR TITLE
Improve module compatibility for CodeSource plugin

### DIFF
--- a/backend/src/hatchling/version/source/code.py
+++ b/backend/src/hatchling/version/source/code.py
@@ -24,7 +24,9 @@ class CodeSource(VersionSourceInterface):
         with open(path, 'r', encoding='utf-8') as f:
             contents = f.read()
 
-        global_variables = {}
+        # Ensure predefined module attributes are available.
+        # https://docs.python.org/3/reference/datamodel.html#the-standard-type-hierarchy.
+        global_variables = {'__file__': path, '__annotations__': dict()}
 
         # Load the file
         exec(contents, global_variables)


### PR DESCRIPTION
Ensure predefined module attributes are available.

Seen while migrating `jupyterlab/extension-cookiecutter-ts` which uses the `__file__` [attribute](https://github.com/jupyterlab/extension-cookiecutter-ts/blob/d9c1017d2ee76bba1c34368a1ebfb539ef22e00f/%7B%7Bcookiecutter.python_name%7D%7D/%7B%7Bcookiecutter.python_name%7D%7D/_version.py#L7).