### PR TITLE
Fix handling of top level data_files in migration

### DIFF
--- a/src/hatch/cli/new/migrate.py
+++ b/src/hatch/cli/new/migrate.py
@@ -235,7 +235,8 @@ def setup(**kwargs):
             for relative_directory, files in sorted(relative_files.items()):
                 if not os.path.isdir(relative_directory) or set(os.listdir(relative_directory)) != set(files):
                     for filename in sorted(files):
-                        shared_data[f'{relative_directory}/{filename}'] = f'{shared_directory}/{filename}'
+                        local_path = os.path.join(relative_directory, filename)
+                        shared_data[local_path] = f'{shared_directory}/{filename}'
                 else:
                     shared_data[relative_directory] = shared_directory
 

--- a/src/hatch/cli/new/migrate.py
+++ b/src/hatch/cli/new/migrate.py
@@ -235,7 +235,7 @@ def setup(**kwargs):
             for relative_directory, files in sorted(relative_files.items()):
                 if not os.path.isdir(relative_directory) or set(os.listdir(relative_directory)) != set(files):
                     for filename in sorted(files):
-                        local_path = os.path.join(relative_directory, filename)
+                        local_path = os.path.join(relative_directory, filename).replace('\\', '/')
                         shared_data[local_path] = f'{shared_directory}/{filename}'
                 else:
                     shared_data[relative_directory] = shared_directory


### PR DESCRIPTION
Seen while migrating https://github.com/jupyterlab/extension-cookiecutter-ts.

We have a top level `install.json` file that was being mapped to `/install.json`, which was being interpreted as an absolute file path.

```toml
[tool.hatch.build.targets.wheel.shared-data]
"/install.json" = "share/jupyter/labextensions/test/install.json"
```