### PR TITLE
Don't write empty entry points file for `wheel` targets if there are no entry points defined

### DIFF
--- a/backend/src/hatchling/builders/wheel.py
+++ b/backend/src/hatchling/builders/wheel.py
@@ -449,8 +449,10 @@ Root-Is-Purelib: {'true' if build_data['pure_python'] else 'false'}
         records.write(self.format_record(record))
 
     def write_entry_points_file(self, archive, records):
-        record = archive.write_metadata('entry_points.txt', self.construct_entry_points_file())
-        records.write(self.format_record(record))
+        entry_points_file = self.construct_entry_points_file()
+        if entry_points_file:
+            record = archive.write_metadata('entry_points.txt', entry_points_file)
+            records.write(self.format_record(record))
 
     def write_project_metadata(self, archive, records, extra_dependencies=()):
         record = archive.write_metadata(

--- a/docs/history.md
+++ b/docs/history.md
@@ -76,6 +76,10 @@ This is the first stable release of Hatch v1, a complete rewrite. Enjoy!
 
 - Support PEP 561
 
+***Fixed:***
+
+- Don't write empty entry points file for `wheel` targets if there are no entry points defined
+
 ### [1.3.1](https://github.com/pypa/hatch/releases/tag/hatchling-v1.3.1) - 2022-05-30 ### {: #hatchling-v1.3.1 }
 
 ***Fixed:***

--- a/tests/helpers/templates/wheel/standard_default_build_script.py
+++ b/tests/helpers/templates/wheel/standard_default_build_script.py
@@ -20,7 +20,6 @@ def get_files(**kwargs):
 
         files.append(f)
 
-    files.append(File(Path(metadata_directory, 'entry_points.txt'), ''))
     files.append(
         File(
             Path(metadata_directory, 'WHEEL'),

--- a/tests/helpers/templates/wheel/standard_default_build_script_artifacts.py
+++ b/tests/helpers/templates/wheel/standard_default_build_script_artifacts.py
@@ -21,7 +21,6 @@ def get_files(**kwargs):
         files.append(f)
 
     files.append(File(Path(kwargs['package_name'], 'lib.so'), ''))
-    files.append(File(Path(metadata_directory, 'entry_points.txt'), ''))
     files.append(
         File(
             Path(metadata_directory, 'WHEEL'),

--- a/tests/helpers/templates/wheel/standard_default_build_script_artifacts_with_src_layout.py
+++ b/tests/helpers/templates/wheel/standard_default_build_script_artifacts_with_src_layout.py
@@ -22,7 +22,6 @@ def get_files(**kwargs):
 
     files.append(File(Path(kwargs['package_name'], 'lib.so'), ''))
     files.append(File(Path('lib.pyd'), ''))
-    files.append(File(Path(metadata_directory, 'entry_points.txt'), ''))
     files.append(
         File(
             Path(metadata_directory, 'WHEEL'),

--- a/tests/helpers/templates/wheel/standard_default_build_script_configured_build_hooks.py
+++ b/tests/helpers/templates/wheel/standard_default_build_script_configured_build_hooks.py
@@ -21,7 +21,6 @@ def get_files(**kwargs):
         files.append(f)
 
     files.append(File(Path(kwargs['package_name'], 'lib.so'), 'custom'))
-    files.append(File(Path(metadata_directory, 'entry_points.txt'), ''))
     files.append(
         File(
             Path(metadata_directory, 'WHEEL'),

--- a/tests/helpers/templates/wheel/standard_default_build_script_extra_dependencies.py
+++ b/tests/helpers/templates/wheel/standard_default_build_script_extra_dependencies.py
@@ -21,7 +21,6 @@ def get_files(**kwargs):
         files.append(f)
 
     files.append(File(Path(kwargs['package_name'], 'lib.so'), ''))
-    files.append(File(Path(metadata_directory, 'entry_points.txt'), ''))
     files.append(
         File(
             Path(metadata_directory, 'WHEEL'),

--- a/tests/helpers/templates/wheel/standard_default_extra_metadata.py
+++ b/tests/helpers/templates/wheel/standard_default_extra_metadata.py
@@ -22,7 +22,6 @@ def get_files(**kwargs):
 
     files.append(File(Path(metadata_directory, 'extra_metadata', 'foo.txt'), ''))
     files.append(File(Path(metadata_directory, 'extra_metadata', 'nested', 'bar.txt'), ''))
-    files.append(File(Path(metadata_directory, 'entry_points.txt'), ''))
     files.append(
         File(
             Path(metadata_directory, 'WHEEL'),

--- a/tests/helpers/templates/wheel/standard_default_license_multiple.py
+++ b/tests/helpers/templates/wheel/standard_default_license_multiple.py
@@ -22,7 +22,6 @@ def get_files(**kwargs):
 
         files.append(f)
 
-    files.append(File(Path(metadata_directory, 'entry_points.txt'), ''))
     files.append(
         File(
             Path(metadata_directory, 'WHEEL'),

--- a/tests/helpers/templates/wheel/standard_default_license_single.py
+++ b/tests/helpers/templates/wheel/standard_default_license_single.py
@@ -20,7 +20,6 @@ def get_files(**kwargs):
 
         files.append(f)
 
-    files.append(File(Path(metadata_directory, 'entry_points.txt'), ''))
     files.append(
         File(
             Path(metadata_directory, 'WHEEL'),

--- a/tests/helpers/templates/wheel/standard_default_namespace_package.py
+++ b/tests/helpers/templates/wheel/standard_default_namespace_package.py
@@ -22,7 +22,6 @@ def get_files(**kwargs):
         f.path = Path(namespace_package, f.path)
         files.append(f)
 
-    files.append(File(Path(metadata_directory, 'entry_points.txt'), ''))
     files.append(
         File(
             Path(metadata_directory, 'WHEEL'),

--- a/tests/helpers/templates/wheel/standard_default_python_constraint.py
+++ b/tests/helpers/templates/wheel/standard_default_python_constraint.py
@@ -20,7 +20,6 @@ def get_files(**kwargs):
 
         files.append(f)
 
-    files.append(File(Path(metadata_directory, 'entry_points.txt'), ''))
     files.append(
         File(
             Path(metadata_directory, 'WHEEL'),

--- a/tests/helpers/templates/wheel/standard_default_shared_data.py
+++ b/tests/helpers/templates/wheel/standard_default_shared_data.py
@@ -23,7 +23,6 @@ def get_files(**kwargs):
 
     files.append(File(Path(shared_data_directory, 'data', 'foo.txt'), ''))
     files.append(File(Path(shared_data_directory, 'data', 'nested', 'bar.txt'), ''))
-    files.append(File(Path(metadata_directory, 'entry_points.txt'), ''))
     files.append(
         File(
             Path(metadata_directory, 'WHEEL'),

--- a/tests/helpers/templates/wheel/standard_default_symlink.py
+++ b/tests/helpers/templates/wheel/standard_default_symlink.py
@@ -21,7 +21,6 @@ def get_files(**kwargs):
         files.append(f)
 
     files.append(File(Path(kwargs['package_name'], 'lib.so'), 'data'))
-    files.append(File(Path(metadata_directory, 'entry_points.txt'), ''))
     files.append(
         File(
             Path(metadata_directory, 'WHEEL'),

--- a/tests/helpers/templates/wheel/standard_editable_exact.py
+++ b/tests/helpers/templates/wheel/standard_editable_exact.py
@@ -28,7 +28,6 @@ F.install()
 F.map_module({kwargs['package_name']!r}, {package_root!r})""",
         )
     )
-    files.append(File(Path(metadata_directory, 'entry_points.txt'), ''))
     files.append(
         File(
             Path(metadata_directory, 'WHEEL'),

--- a/tests/helpers/templates/wheel/standard_editable_exact_extra_dependencies.py
+++ b/tests/helpers/templates/wheel/standard_editable_exact_extra_dependencies.py
@@ -28,7 +28,6 @@ F.install()
 F.map_module({kwargs['package_name']!r}, {package_root!r})""",
         )
     )
-    files.append(File(Path(metadata_directory, 'entry_points.txt'), ''))
     files.append(
         File(
             Path(metadata_directory, 'WHEEL'),

--- a/tests/helpers/templates/wheel/standard_editable_exact_force_include.py
+++ b/tests/helpers/templates/wheel/standard_editable_exact_force_include.py
@@ -30,7 +30,6 @@ F.install()
 F.map_module({kwargs['package_name']!r}, {package_root!r})""",
         )
     )
-    files.append(File(Path(metadata_directory, 'entry_points.txt'), ''))
     files.append(
         File(
             Path(metadata_directory, 'WHEEL'),

--- a/tests/helpers/templates/wheel/standard_editable_pth.py
+++ b/tests/helpers/templates/wheel/standard_editable_pth.py
@@ -18,7 +18,6 @@ def get_files(**kwargs):
 
     pth_file_name = f"{kwargs['package_name']}.pth"
     files.append(File(Path(pth_file_name), '\n'.join(package_paths)))
-    files.append(File(Path(metadata_directory, 'entry_points.txt'), ''))
     files.append(
         File(
             Path(metadata_directory, 'WHEEL'),

--- a/tests/helpers/templates/wheel/standard_editable_pth_extra_dependencies.py
+++ b/tests/helpers/templates/wheel/standard_editable_pth_extra_dependencies.py
@@ -18,7 +18,6 @@ def get_files(**kwargs):
 
     pth_file_name = f"{kwargs['package_name']}.pth"
     files.append(File(Path(pth_file_name), '\n'.join(package_paths)))
-    files.append(File(Path(metadata_directory, 'entry_points.txt'), ''))
     files.append(
         File(
             Path(metadata_directory, 'WHEEL'),

--- a/tests/helpers/templates/wheel/standard_editable_pth_force_include.py
+++ b/tests/helpers/templates/wheel/standard_editable_pth_force_include.py
@@ -20,7 +20,6 @@ def get_files(**kwargs):
 
     pth_file_name = f"{kwargs['package_name']}.pth"
     files.append(File(Path(pth_file_name), '\n'.join(package_paths)))
-    files.append(File(Path(metadata_directory, 'entry_points.txt'), ''))
     files.append(
         File(
             Path(metadata_directory, 'WHEEL'),

--- a/tests/helpers/templates/wheel/standard_entry_points.py
+++ b/tests/helpers/templates/wheel/standard_entry_points.py
@@ -20,16 +20,25 @@ def get_files(**kwargs):
 
         files.append(f)
 
-    files.append(File(Path(kwargs['package_name'], 'lib.so'), ''))
-    files.append(File(Path(kwargs['package_name'], 'lib.h'), ''))
+    files.append(
+        File(
+            Path(metadata_directory, 'entry_points.txt'),
+            """\
+[console_scripts]
+bar = pkg:foo
+foo = pkg:bar
+""",
+        )
+    )
     files.append(
         File(
             Path(metadata_directory, 'WHEEL'),
             f"""\
 Wheel-Version: 1.0
 Generator: hatchling {__version__}
-Root-Is-Purelib: false
-Tag: {kwargs.get('tag', '')}
+Root-Is-Purelib: true
+Tag: py2-none-any
+Tag: py3-none-any
 """,
         )
     )
@@ -40,7 +49,6 @@ Tag: {kwargs.get('tag', '')}
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name_normalized']}
 Version: 0.0.1
-Requires-Python: >3
 """,
         )
     )

--- a/tests/helpers/templates/wheel/standard_only_packages_artifact_override.py
+++ b/tests/helpers/templates/wheel/standard_only_packages_artifact_override.py
@@ -22,7 +22,6 @@ def get_files(**kwargs):
 
         files.append(f)
 
-    files.append(File(Path(metadata_directory, 'entry_points.txt'), ''))
     files.append(
         File(
             Path(metadata_directory, 'WHEEL'),

--- a/tests/helpers/templates/wheel/standard_tests.py
+++ b/tests/helpers/templates/wheel/standard_tests.py
@@ -20,7 +20,6 @@ def get_files(**kwargs):
 
         files.append(f)
 
-    files.append(File(Path(metadata_directory, 'entry_points.txt'), ''))
     files.append(
         File(
             Path(metadata_directory, 'WHEEL'),


### PR DESCRIPTION
So `importlib.metadata` can avoid a read