### PR TITLE
Fix PKG-INFO location assumption error

### DIFF
--- a/src/hatch/publish/pypi.py
+++ b/src/hatch/publish/pypi.py
@@ -235,20 +235,23 @@ def get_wheel_form_data(app, artifact):
 
 def get_sdist_form_data(app, artifact):
     import tarfile
+    import os.path
 
     with tarfile.open(str(artifact), 'r:gz') as tar_archive:
-        pkg_info_dir_parts = []
+        # This should be invalid.  Being invalid will trigger a failure below
+        # while attempting to extract the contents.
+        pkg_info_path = "PKG-INFO"
         for tar_info in tar_archive:
             if tar_info.isfile():
-                pkg_info_dir_parts.append(tar_info.name.split('/', 1)[0])
-                break
+                # Find the first instance of PKG-INFO within the tarball.
+                if "PKG-INFO" == os.path.basename(tar_info.name):
+                    pkg_info_path = tar_info.name
+                    break
             else:  # no cov
                 pass
         else:  # no cov
             app.abort(f'Could not find any files in sdist: {artifact}')
 
-        pkg_info_dir_parts.append('PKG-INFO')
-        pkg_info_path = '/'.join(pkg_info_dir_parts)
         try:
             with tar_archive.extractfile(pkg_info_path) as tar_file:
                 metadata_file_contents = tar_file.read().decode('utf-8')

--- a/tests/cli/publish/test_publish_related.py
+++ b/tests/cli/publish/test_publish_related.py
@@ -1,0 +1,34 @@
+import os
+import tarfile
+
+import hatch.publish.pypi as pypi
+
+def test_tar_layout(hatch, temp_dir):
+    class TarTestApp():
+        def __init__(self):
+            pass
+
+        def abort(self, message):
+            raise Exception(message)
+
+    app = TarTestApp()
+    with temp_dir.as_cwd():
+        deep = os.path.join('tartest-1.0', 'tartest')
+        os.makedirs(deep)
+        dummy_path = os.path.join(deep, "dummy")
+        pkg_info_path = os.path.join("tartest-1.0", "PKG-INFO")
+
+        with open(dummy_path, "w") as fobj:
+            fobj.write("Dummy file.  It just has to exist")
+
+        with open(pkg_info_path, "w") as fobj:
+            fobj.write("Name: tartest\nVersion: 1.0\n")
+
+        with tarfile.open("/tmp/tartest-1.0.tar.gz", "w:gz") as tar_archive:
+            tar_archive.add(dummy_path)
+            tar_archive.add(pkg_info_path)
+
+        headers = pypi.get_sdist_form_data(app, "/tmp/tartest-1.0.tar.gz")
+
+        assert headers["name"] == "tartest"
+        assert headers["version"] == "1.0"


### PR DESCRIPTION
The current get_sdist_form_data locates the first file within the tarball and uses that same directory as the location for the PKG-INFO file.  This is not always the case.  This patch instead looks for a PKG-INFO file explicitly and uses the first one found within the tarball.

For example a project I was trying to publish has a layout like this which was causing a failure to find the PKG-INFO file.  The existing function was looking for cp_nagios_plugins-0.5/libnagios/PKG-INFO.

`$ tar tzf cp_nagios_plugins-0.5.tar.gz`
`cp_nagios_plugins-0.5/libnagios/__init__.py`
`cp_nagios_plugins-0.5/libnagios/plugin.py`
`cp_nagios_plugins-0.5/libnagios/checks/__init__.py`
`cp_nagios_plugins-0.5/libnagios/checks/bitlocker.py`
`cp_nagios_plugins-0.5/libnagios/checks/cpu.py`
`cp_nagios_plugins-0.5/libnagios/checks/disk.py`
`cp_nagios_plugins-0.5/libnagios/checks/load.py`
`cp_nagios_plugins-0.5/libnagios/checks/ssh.py`
`cp_nagios_plugins-0.5/libnagios/checks/swap.py`
`cp_nagios_plugins-0.5/.gitignore`
`cp_nagios_plugins-0.5/LICENSE`
`cp_nagios_plugins-0.5/README.rst`
`cp_nagios_plugins-0.5/pyproject.toml`
`cp_nagios_plugins-0.5/PKG-INFO`
