### PR TITLE
Add `strict-naming` option for  `sdist` and `wheel` targets

### DIFF
--- a/backend/src/hatchling/builders/plugin/interface.py
+++ b/backend/src/hatchling/builders/plugin/interface.py
@@ -354,7 +354,6 @@ class BuilderInterface(ABC):
     @property
     def project_id(self):
         if self.__project_id is None:
-            # https://discuss.python.org/t/clarify-naming-of-dist-info-directories/5565
             self.__project_id = f'{self.normalize_file_name_component(self.metadata.core.name)}-{self.metadata.version}'
 
         return self.__project_id

--- a/docs/history.md
+++ b/docs/history.md
@@ -103,6 +103,7 @@ This is the first stable release of Hatch v1, a complete rewrite. Enjoy!
 ***Added:***
 
 - Support the final draft of PEP 639
+- Add `strict-naming` option for  `sdist` and `wheel` targets
 
 ***Fixed:***
 

--- a/docs/plugins/builder/sdist.md
+++ b/docs/plugins/builder/sdist.md
@@ -25,6 +25,7 @@ The builder plugin name is `sdist`.
 | Option | Default | Description |
 | --- | --- | --- |
 | `core-metadata-version` | `"2.1"` | The version of [core metadata](https://packaging.python.org/specifications/core-metadata/) to use |
+| `strict-naming` | `true` | Whether or not file names should contain the normalized version of the project name |
 | `support-legacy` | `false` | Whether or not to include a `setup.py` file to support legacy installation mechanisms |
 
 ## Versions

--- a/docs/plugins/builder/wheel.md
+++ b/docs/plugins/builder/wheel.md
@@ -27,6 +27,7 @@ The builder plugin name is `wheel`.
 | `core-metadata-version` | `"2.1"` | The version of [core metadata](https://packaging.python.org/specifications/core-metadata/) to use |
 | `shared-data` | | A mapping similar to the [forced inclusion](../../config/build.md#forced-inclusion) option corresponding to [data](https://peps.python.org/pep-0427/#the-data-directory) that will be installed globally in a given Python environment, usually under `#!python sys.prefix` |
 | `extra-metadata` | | A mapping similar to the [forced inclusion](../../config/build.md#forced-inclusion) option corresponding to extra [metadata](https://peps.python.org/pep-0427/#the-dist-info-directory) that will be shipped in a directory named `extra_metadata` |
+| `strict-naming` | `true` | Whether or not file names should contain the normalized version of the project name |
 
 ## Versions
 


### PR DESCRIPTION
resolves #330 