### PR TITLE
Support `-h`/`--help` flag for the `run` command

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Unreleased
 
+***Fixed:***
+
+- Support `-h`/`--help` flag for the `run` command
+
 ### [1.3.0](https://github.com/pypa/hatch/releases/tag/hatch-v1.3.0) - 2022-07-10 ### {: #hatch-v1.3.0 }
 
 ***Changed:***

--- a/src/hatch/cli/run/__init__.py
+++ b/src/hatch/cli/run/__init__.py
@@ -50,6 +50,10 @@ def run(ctx, app, args):
     would execute `pytest` in the environments `test.py310-42` and `test.py310-3.14`.
     Note that `py` may be used as an alias for `python`.
     """
+    if args[0] in ('-h', '--help'):
+        app.display_info(ctx.get_help())
+        return
+
     from hatch.cli.env.run import run as run_command
 
     command_start = 0

--- a/tests/cli/run/test_run.py
+++ b/tests/cli/run/test_run.py
@@ -7,6 +7,16 @@ from hatch.project.core import Project
 from hatch.utils.structures import EnvVars
 
 
+def test_help(hatch):
+    short = hatch('run', '-h')
+    assert short.exit_code == 0, short.output
+
+    long = hatch('run', '--help')
+    assert long.exit_code == 0, long.output
+
+    assert short.output == long.output
+
+
 def test_automatic_creation(hatch, helpers, temp_dir, config_file):
     config_file.model.template.plugins['default']['tests'] = False
     config_file.save()


### PR DESCRIPTION
resolves #348 