### PR TITLE
Improve the `code` version source

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -109,6 +109,12 @@ This is the first stable release of Hatch v1, a complete rewrite. Enjoy!
 ***Changed:***
 
 - When no build targets are specified on the command line, now default to `sdist` and `wheel` targets rather than what happens to be defined in config
+- The `code` version source now only supports files with known extensions
+
+***Added:***
+
+- The `code` version source now supports loading extension modules
+- Add `search-paths` option for the `code` version source
 
 ***Fixed:***
 

--- a/docs/plugins/version-source/code.md
+++ b/docs/plugins/version-source/code.md
@@ -28,5 +28,6 @@ The version source plugin name is `code`.
 
 | Option | Description |
 | --- | --- |
-| `path` (required) | A relative path to a Python file that will be loaded |
+| `path` (required) | A relative path to a Python file or extension module that will be loaded |
 | `expression` | A Python expression that when evaluated in the context of the loaded file returns the version. The default expression is simply `__version__`. |
+| `search-paths` | A list of directories that will be prepended to Python's search path |

--- a/tests/backend/version/source/test_code.py
+++ b/tests/backend/version/source/test_code.py
@@ -18,16 +18,16 @@ def test_path_not_string(isolation):
 
 
 def test_path_nonexistent(isolation):
-    source = CodeSource(str(isolation), {'path': 'a/b'})
+    source = CodeSource(str(isolation), {'path': 'a/b.py'})
 
-    with pytest.raises(OSError, match='file does not exist: a/b'):
+    with pytest.raises(OSError, match='file does not exist: a/b.py'):
         source.get_version_data()
 
 
 def test_expression_not_string(temp_dir):
-    source = CodeSource(str(temp_dir), {'path': 'a/b', 'expression': 23})
+    source = CodeSource(str(temp_dir), {'path': 'a/b.py', 'expression': 23})
 
-    file_path = temp_dir / 'a' / 'b'
+    file_path = temp_dir / 'a' / 'b.py'
     file_path.ensure_parent_dir_exists()
     file_path.touch()
 
@@ -35,10 +35,32 @@ def test_expression_not_string(temp_dir):
         source.get_version_data()
 
 
-def test_match_default_expression(temp_dir, helpers):
-    source = CodeSource(str(temp_dir), {'path': 'a/b'})
+def test_search_paths_not_array(temp_dir):
+    source = CodeSource(str(temp_dir), {'path': 'a/b.py', 'search-paths': 23})
 
-    file_path = temp_dir / 'a' / 'b'
+    file_path = temp_dir / 'a' / 'b.py'
+    file_path.ensure_parent_dir_exists()
+    file_path.touch()
+
+    with pytest.raises(TypeError, match='option `search-paths` must be an array'):
+        source.get_version_data()
+
+
+def test_search_paths_entry_not_string(temp_dir):
+    source = CodeSource(str(temp_dir), {'path': 'a/b.py', 'search-paths': [23]})
+
+    file_path = temp_dir / 'a' / 'b.py'
+    file_path.ensure_parent_dir_exists()
+    file_path.touch()
+
+    with pytest.raises(TypeError, match='entry #1 of option `search-paths` must be a string'):
+        source.get_version_data()
+
+
+def test_match_default_expression(temp_dir, helpers):
+    source = CodeSource(str(temp_dir), {'path': 'a/b.py'})
+
+    file_path = temp_dir / 'a' / 'b.py'
     file_path.ensure_parent_dir_exists()
     file_path.write_text('__version__ = "0.0.1"')
 
@@ -47,9 +69,9 @@ def test_match_default_expression(temp_dir, helpers):
 
 
 def test_match_custom_expression_basic(temp_dir):
-    source = CodeSource(str(temp_dir), {'path': 'a/b', 'expression': 'VER'})
+    source = CodeSource(str(temp_dir), {'path': 'a/b.py', 'expression': 'VER'})
 
-    file_path = temp_dir / 'a' / 'b'
+    file_path = temp_dir / 'a' / 'b.py'
     file_path.ensure_parent_dir_exists()
     file_path.write_text('VER = "0.0.1"')
 
@@ -58,9 +80,9 @@ def test_match_custom_expression_basic(temp_dir):
 
 
 def test_match_custom_expression_complex(temp_dir, helpers):
-    source = CodeSource(str(temp_dir), {'path': 'a/b', 'expression': 'foo()'})
+    source = CodeSource(str(temp_dir), {'path': 'a/b.py', 'expression': 'foo()'})
 
-    file_path = temp_dir / 'a' / 'b'
+    file_path = temp_dir / 'a' / 'b.py'
     file_path.ensure_parent_dir_exists()
     file_path.write_text(
         helpers.dedent(
@@ -69,6 +91,34 @@ def test_match_custom_expression_complex(temp_dir, helpers):
 
             def foo():
                 return '.'.join(str(part) for part in __version_info__)
+            """
+        )
+    )
+
+    with temp_dir.as_cwd():
+        assert source.get_version_data()['version'] == '1.0.0.1.dev0'
+
+
+def test_search_paths(temp_dir, helpers):
+    source = CodeSource(str(temp_dir), {'path': 'a/b.py', 'search-paths': ['.']})
+
+    parent_dir = temp_dir / 'a'
+    parent_dir.mkdir()
+    (parent_dir / '__init__.py').touch()
+    (parent_dir / 'b.py').write_text(
+        helpers.dedent(
+            """
+            from a.c import foo
+
+            __version__ = foo((1, 0, 0, 1, 'dev0'))
+            """
+        )
+    )
+    (parent_dir / 'c.py').write_text(
+        helpers.dedent(
+            """
+            def foo(version_info):
+                return '.'.join(str(part) for part in version_info)
             """
         )
     )


### PR DESCRIPTION
Many packages rely on `python setup.py ...` putting the current directory in `sys.path` https://github.com/pypa/hatch/issues/338#issuecomment-1179639559

Thus the `search-paths` option, which is necessary to port Django https://github.com/django/django/blob/4.0.6/django/__init__.py