### PR TITLE
The `strict-naming` option now also applies to the metadata directory of `wheel` targets

### DIFF
--- a/backend/src/hatchling/builders/wheel.py
+++ b/backend/src/hatchling/builders/wheel.py
@@ -304,7 +304,9 @@ class WheelBuilder(BuilderInterface):
             else:
                 build_data['tag'] = self.get_default_tag()
 
-        with WheelArchive(self.project_id, self.config.reproducible) as archive, closing(StringIO()) as records:
+        with WheelArchive(self.artifact_project_id, self.config.reproducible) as archive, closing(
+            StringIO()
+        ) as records:
             for included_file in self.recurse_included_files():
                 record = archive.add_file(included_file)
                 records.write(self.format_record(record))
@@ -328,7 +330,9 @@ class WheelBuilder(BuilderInterface):
     def build_editable_detection(self, directory, **build_data):
         build_data['tag'] = self.get_default_tag()
 
-        with WheelArchive(self.project_id, self.config.reproducible) as archive, closing(StringIO()) as records:
+        with WheelArchive(self.artifact_project_id, self.config.reproducible) as archive, closing(
+            StringIO()
+        ) as records:
             exposed_packages = {}
             for included_file in self.recurse_project_files():
                 if not included_file.path.endswith('.py'):
@@ -393,7 +397,9 @@ class WheelBuilder(BuilderInterface):
     def build_editable_explicit(self, directory, **build_data):
         build_data['tag'] = self.get_default_tag()
 
-        with WheelArchive(self.project_id, self.config.reproducible) as archive, closing(StringIO()) as records:
+        with WheelArchive(self.artifact_project_id, self.config.reproducible) as archive, closing(
+            StringIO()
+        ) as records:
             directories = sorted(
                 os.path.normpath(os.path.join(self.root, relative_directory))
                 for relative_directory in self.config.dev_mode_dirs

--- a/docs/history.md
+++ b/docs/history.md
@@ -119,6 +119,7 @@ This is the first stable release of Hatch v1, a complete rewrite. Enjoy!
 ***Fixed:***
 
 - Fix removing `sources` using an empty string value in the mapping
+- The `strict-naming` option now also applies to the metadata directory of `wheel` targets
 
 ### [1.5.0](https://github.com/pypa/hatch/releases/tag/hatchling-v1.5.0) - 2022-07-11 ### {: #hatchling-v1.5.0 }
 

--- a/tests/backend/builders/test_wheel.py
+++ b/tests/backend/builders/test_wheel.py
@@ -2602,8 +2602,8 @@ class TestBuildStandard:
         with zipfile.ZipFile(str(expected_artifact), 'r') as zip_archive:
             zip_archive.extractall(str(extraction_directory))
 
-        metadata_directory = f'{builder.project_id}.dist-info'
+        metadata_directory = f'{builder.artifact_project_id}.dist-info'
         expected_files = helpers.get_template_files(
-            'wheel.standard_default_license_single', project_name, metadata_directory=metadata_directory
+            'wheel.standard_no_strict_naming', project_name, metadata_directory=metadata_directory
         )
         helpers.assert_files(extraction_directory, expected_files, check_contents=True)

--- a/tests/helpers/templates/wheel/standard_no_strict_naming.py
+++ b/tests/helpers/templates/wheel/standard_no_strict_naming.py
@@ -1,0 +1,50 @@
+from hatch.template import File
+from hatch.utils.fs import Path
+from hatchling.__about__ import __version__
+from hatchling.metadata.spec import DEFAULT_METADATA_VERSION
+
+from ..new.default import get_files as get_template_files
+from .utils import update_record_file_contents
+
+
+def get_files(**kwargs):
+    metadata_directory = kwargs.get('metadata_directory', '')
+
+    files = []
+    for f in get_template_files(**kwargs):
+        if str(f.path) == 'LICENSE.txt':
+            files.append(File(Path(metadata_directory, 'licenses', f.path), f.contents))
+
+        if f.path.parts[0] != kwargs['package_name']:
+            continue
+
+        files.append(f)
+
+    files.append(
+        File(
+            Path(metadata_directory, 'WHEEL'),
+            f"""\
+Wheel-Version: 1.0
+Generator: hatchling {__version__}
+Root-Is-Purelib: true
+Tag: py2-none-any
+Tag: py3-none-any
+""",
+        )
+    )
+    files.append(
+        File(
+            Path(metadata_directory, 'METADATA'),
+            f"""\
+Metadata-Version: {DEFAULT_METADATA_VERSION}
+Name: {kwargs['project_name']}
+Version: 0.0.1
+""",
+        )
+    )
+
+    record_file = File(Path(metadata_directory, 'RECORD'), '')
+    update_record_file_contents(record_file, files)
+    files.append(record_file)
+
+    return files


### PR DESCRIPTION
resolves #361 