### PR TITLE
Retrieve current window size in SIGWINCH handler

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Acknowledge `extra-dependencies` for the `env show` command
 - Fix locating executables within virtual environments on Debian
+- Fix managing the terminal size inside the `shell` command
 
 ### [1.3.1](https://github.com/pypa/hatch/releases/tag/hatch-v1.3.1) - 2022-07-11 ### {: #hatch-v1.3.1 }
 

--- a/src/hatch/utils/shells.py
+++ b/src/hatch/utils/shells.py
@@ -73,7 +73,8 @@ class ShellManager:
         terminal = pexpect.spawn(path, args=args, dimensions=(lines, columns))
 
         def sigwinch_passthrough(sig, data):
-            terminal.setwinsize(lines, columns)
+            new_columns, new_lines = shutil.get_terminal_size()
+            terminal.setwinsize(new_lines, new_columns)
 
         signal.signal(signal.SIGWINCH, sigwinch_passthrough)
 


### PR DESCRIPTION
`spawn_linux_shell` was using the original dimensions to update the terminal window size instead of retrieving the current dimensions. Based on the notes in the [`pexpect.interact` documentation] using `shutil` to retrieve the size instead of `ioctl`.

I couldn't find a test suite associated with the shell spawning functionality so I modified my local installed copy and verified the functionality.

This PR addresses #381 .

[`pexpect.interact` documentation]: https://pexpect.readthedocs.io/en/stable/api/pexpect.html#pexpect.spawn.interact