### PR TITLE
Note the `allow-direct-references` option in the relevant error messages

### DIFF
--- a/backend/src/hatchling/metadata/core.py
+++ b/backend/src/hatchling/metadata/core.py
@@ -999,7 +999,8 @@ class CoreMetadata:
                 else:
                     if requirement.url and not self.hatch_metadata.allow_direct_references:
                         raise ValueError(
-                            f'Dependency #{i} of field `project.dependencies` cannot be a direct reference'
+                            f'Dependency #{i} of field `project.dependencies` cannot be a direct reference unless '
+                            f'field `tool.hatch.metadata.allow-direct-references` is set to `true`'
                         )
 
                     dependencies_complex[get_normalized_dependency(requirement)] = requirement
@@ -1074,7 +1075,8 @@ class CoreMetadata:
                         if requirement.url and not self.hatch_metadata.allow_direct_references:
                             raise ValueError(
                                 f'Dependency #{i} of option `{option}` of field `project.optional-dependencies` '
-                                f'cannot be a direct reference'
+                                f'cannot be a direct reference unless field '
+                                f'`tool.hatch.metadata.allow-direct-references` is set to `true`'
                             )
 
                         entries[get_normalized_dependency(requirement)] = requirement

--- a/docs/history.md
+++ b/docs/history.md
@@ -137,6 +137,7 @@ This is the first stable release of Hatch v1, a complete rewrite. Enjoy!
 ***Fixed:***
 
 - Add better error message for `wheel` target dev mode installations that define path rewrites with the `sources` option
+- Note the `allow-direct-references` option in the relevant error messages
 
 ### [1.6.0](https://github.com/pypa/hatch/releases/tag/hatchling-v1.6.0) - 2022-07-23 ### {: #hatchling-v1.6.0 }
 

--- a/tests/backend/metadata/test_core.py
+++ b/tests/backend/metadata/test_core.py
@@ -1092,7 +1092,11 @@ class TestDependencies:
         )
 
         with pytest.raises(
-            ValueError, match='Dependency #1 of field `project.dependencies` cannot be a direct reference'
+            ValueError,
+            match=(
+                'Dependency #1 of field `project.dependencies` cannot be a direct reference unless '
+                'field `tool.hatch.metadata.allow-direct-references` is set to `true`'
+            ),
         ):
             _ = metadata.core.dependencies
 
@@ -1230,7 +1234,10 @@ class TestOptionalDependencies:
 
         with pytest.raises(
             ValueError,
-            match='Dependency #1 of option `foo` of field `project.optional-dependencies` cannot be a direct reference',
+            match=(
+                'Dependency #1 of option `foo` of field `project.optional-dependencies` cannot be a direct reference '
+                'unless field `tool.hatch.metadata.allow-direct-references` is set to `true`'
+            ),
         ):
             _ = metadata.core.optional_dependencies
 


### PR DESCRIPTION
resolves:

- https://github.com/NTIA/tekrsa-api-wrap/pull/10
- https://github.com/NTIA/scos-tekrsa/pull/21