### PR TITLE
Retroactively support `License-File` core metadata

### DIFF
--- a/backend/src/hatchling/metadata/spec.py
+++ b/backend/src/hatchling/metadata/spec.py
@@ -110,6 +110,10 @@ def construct_metadata_file_2_1(metadata, extra_dependencies=()):
             else:
                 metadata_file += f'{indent}{line}\n'
 
+    if metadata.core.license_files:
+        for license_file in metadata.core.license_files:
+            metadata_file += f'License-File: {license_file}\n'
+
     if metadata.core.keywords:
         metadata_file += f"Keywords: {','.join(metadata.core.keywords)}\n"
 
@@ -181,6 +185,10 @@ def construct_metadata_file_2_2(metadata, extra_dependencies=()):
                 metadata_file += f'{line}\n'
             else:
                 metadata_file += f'{indent}{line}\n'
+
+    if metadata.core.license_files:
+        for license_file in metadata.core.license_files:
+            metadata_file += f'License-File: {license_file}\n'
 
     if metadata.core.keywords:
         metadata_file += f"Keywords: {','.join(metadata.core.keywords)}\n"

--- a/docs/history.md
+++ b/docs/history.md
@@ -172,6 +172,7 @@ This is the first stable release of Hatch v1, a complete rewrite. Enjoy!
 
 - Add `metadata` command to view PEP 621 project metadata
 - Improve error messages for SPDX license errors
+- Retroactively support `License-File` for core metadata starting at version 2.1
 
 ***Fixed:***
 

--- a/tests/backend/metadata/test_spec.py
+++ b/tests/backend/metadata/test_spec.py
@@ -674,9 +674,9 @@ class TestCoreMetadataV21:
             """
         )
 
-    def test_all(self, constructor, isolation, helpers):
+    def test_all(self, constructor, isolation, helpers, temp_dir):
         metadata = ProjectMetadata(
-            str(isolation),
+            str(temp_dir),
             None,
             {
                 'project': {
@@ -703,6 +703,8 @@ class TestCoreMetadataV21:
             },
         )
 
+        (temp_dir / 'LICENSE.txt').touch()
+
         assert constructor(metadata) == helpers.dedent(
             """
             Metadata-Version: 2.1
@@ -715,6 +717,7 @@ class TestCoreMetadataV21:
             Maintainer-email: foo <bar@domain>
             License: foo
                     bar
+            License-File: LICENSE.txt
             Keywords: bar,foo
             Classifier: Programming Language :: Python :: 3.9
             Classifier: Programming Language :: Python :: 3.11
@@ -1073,9 +1076,9 @@ class TestCoreMetadataV22:
             """
         )
 
-    def test_all(self, constructor, isolation, helpers):
+    def test_all(self, constructor, isolation, helpers, temp_dir):
         metadata = ProjectMetadata(
-            str(isolation),
+            str(temp_dir),
             None,
             {
                 'project': {
@@ -1102,6 +1105,8 @@ class TestCoreMetadataV22:
             },
         )
 
+        (temp_dir / 'LICENSE.txt').touch()
+
         assert constructor(metadata) == helpers.dedent(
             """
             Metadata-Version: 2.2
@@ -1114,6 +1119,7 @@ class TestCoreMetadataV22:
             Maintainer-email: foo <bar@domain>
             License: foo
                     bar
+            License-File: LICENSE.txt
             Keywords: bar,foo
             Classifier: Programming Language :: Python :: 3.9
             Classifier: Programming Language :: Python :: 3.11

--- a/tests/helpers/templates/sdist/standard_default.py
+++ b/tests/helpers/templates/sdist/standard_default.py
@@ -19,6 +19,7 @@ def get_files(**kwargs):
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 """,
         )
     )

--- a/tests/helpers/templates/sdist/standard_default_build_script_artifacts.py
+++ b/tests/helpers/templates/sdist/standard_default_build_script_artifacts.py
@@ -46,6 +46,7 @@ class CustomHook(BuildHookInterface):
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 """,
         )
     )

--- a/tests/helpers/templates/sdist/standard_default_build_script_extra_dependencies.py
+++ b/tests/helpers/templates/sdist/standard_default_build_script_extra_dependencies.py
@@ -47,6 +47,7 @@ class CustomHook(BuildHookInterface):
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 Requires-Dist: binary
 """,
         )

--- a/tests/helpers/templates/sdist/standard_default_support_legacy.py
+++ b/tests/helpers/templates/sdist/standard_default_support_legacy.py
@@ -19,6 +19,7 @@ def get_files(**kwargs):
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 """,
         )
     )

--- a/tests/helpers/templates/sdist/standard_default_vcs_git_exclusion_files.py
+++ b/tests/helpers/templates/sdist/standard_default_vcs_git_exclusion_files.py
@@ -30,6 +30,7 @@ def get_files(**kwargs):
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 """,
         )
     )

--- a/tests/helpers/templates/sdist/standard_default_vcs_mercurial_exclusion_files.py
+++ b/tests/helpers/templates/sdist/standard_default_vcs_mercurial_exclusion_files.py
@@ -36,6 +36,7 @@ syntax: glob
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 """,
         )
     )

--- a/tests/helpers/templates/sdist/standard_include.py
+++ b/tests/helpers/templates/sdist/standard_include.py
@@ -21,6 +21,7 @@ def get_files(**kwargs):
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 Description-Content-Type: text/markdown
 
 # My.App

--- a/tests/helpers/templates/sdist/standard_include_config_file.py
+++ b/tests/helpers/templates/sdist/standard_include_config_file.py
@@ -22,6 +22,7 @@ def get_files(**kwargs):
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 Description-Content-Type: text/markdown
 
 # My.App

--- a/tests/helpers/templates/wheel/standard_default_build_script.py
+++ b/tests/helpers/templates/wheel/standard_default_build_script.py
@@ -38,6 +38,7 @@ Tag: {kwargs.get('tag', '')}
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 Requires-Python: >3
 """,
         )

--- a/tests/helpers/templates/wheel/standard_default_build_script_artifacts.py
+++ b/tests/helpers/templates/wheel/standard_default_build_script_artifacts.py
@@ -39,6 +39,7 @@ Tag: {kwargs.get('tag', '')}
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 Requires-Python: >3
 """,
         )

--- a/tests/helpers/templates/wheel/standard_default_build_script_artifacts_with_src_layout.py
+++ b/tests/helpers/templates/wheel/standard_default_build_script_artifacts_with_src_layout.py
@@ -40,6 +40,7 @@ Tag: {kwargs.get('tag', '')}
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 Requires-Python: >3
 """,
         )

--- a/tests/helpers/templates/wheel/standard_default_build_script_configured_build_hooks.py
+++ b/tests/helpers/templates/wheel/standard_default_build_script_configured_build_hooks.py
@@ -39,6 +39,7 @@ Tag: {kwargs.get('tag', '')}
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 Requires-Python: >3
 """,
         )

--- a/tests/helpers/templates/wheel/standard_default_build_script_extra_dependencies.py
+++ b/tests/helpers/templates/wheel/standard_default_build_script_extra_dependencies.py
@@ -39,6 +39,7 @@ Tag: {kwargs.get('tag', '')}
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 Requires-Python: >3
 Requires-Dist: binary
 """,

--- a/tests/helpers/templates/wheel/standard_default_build_script_force_include.py
+++ b/tests/helpers/templates/wheel/standard_default_build_script_force_include.py
@@ -40,6 +40,7 @@ Tag: {kwargs.get('tag', '')}
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 Requires-Python: >3
 """,
         )

--- a/tests/helpers/templates/wheel/standard_default_extra_metadata.py
+++ b/tests/helpers/templates/wheel/standard_default_extra_metadata.py
@@ -40,6 +40,7 @@ Tag: py3-none-any
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 Requires-Python: >3
 """,
         )

--- a/tests/helpers/templates/wheel/standard_default_license_multiple.py
+++ b/tests/helpers/templates/wheel/standard_default_license_multiple.py
@@ -41,6 +41,8 @@ Tag: py3-none-any
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSES/Apache-2.0.txt
+License-File: LICENSES/MIT.txt
 """,
         )
     )

--- a/tests/helpers/templates/wheel/standard_default_license_single.py
+++ b/tests/helpers/templates/wheel/standard_default_license_single.py
@@ -39,6 +39,7 @@ Tag: py3-none-any
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 """,
         )
     )

--- a/tests/helpers/templates/wheel/standard_default_namespace_package.py
+++ b/tests/helpers/templates/wheel/standard_default_namespace_package.py
@@ -41,6 +41,7 @@ Tag: py3-none-any
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 """,
         )
     )

--- a/tests/helpers/templates/wheel/standard_default_python_constraint.py
+++ b/tests/helpers/templates/wheel/standard_default_python_constraint.py
@@ -38,6 +38,7 @@ Tag: py3-none-any
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 Requires-Python: >3
 """,
         )

--- a/tests/helpers/templates/wheel/standard_default_shared_data.py
+++ b/tests/helpers/templates/wheel/standard_default_shared_data.py
@@ -41,6 +41,7 @@ Tag: py3-none-any
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 Requires-Python: >3
 """,
         )

--- a/tests/helpers/templates/wheel/standard_default_single_module.py
+++ b/tests/helpers/templates/wheel/standard_default_single_module.py
@@ -35,6 +35,7 @@ Tag: py3-none-any
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 """,
         )
     )

--- a/tests/helpers/templates/wheel/standard_default_symlink.py
+++ b/tests/helpers/templates/wheel/standard_default_symlink.py
@@ -39,6 +39,7 @@ Tag: {kwargs.get('tag', '')}
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 Requires-Python: >3
 """,
         )

--- a/tests/helpers/templates/wheel/standard_editable_exact.py
+++ b/tests/helpers/templates/wheel/standard_editable_exact.py
@@ -47,6 +47,7 @@ Tag: py3-none-any
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 Requires-Dist: editables~=0.3
 """,
         )

--- a/tests/helpers/templates/wheel/standard_editable_exact_extra_dependencies.py
+++ b/tests/helpers/templates/wheel/standard_editable_exact_extra_dependencies.py
@@ -47,6 +47,7 @@ Tag: py3-none-any
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 Requires-Dist: binary
 Requires-Dist: editables~=0.3
 """,

--- a/tests/helpers/templates/wheel/standard_editable_exact_force_include.py
+++ b/tests/helpers/templates/wheel/standard_editable_exact_force_include.py
@@ -49,6 +49,7 @@ Tag: py3-none-any
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 Requires-Dist: editables~=0.3
 """,
         )

--- a/tests/helpers/templates/wheel/standard_editable_pth.py
+++ b/tests/helpers/templates/wheel/standard_editable_pth.py
@@ -37,6 +37,7 @@ Tag: py3-none-any
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 """,
         )
     )

--- a/tests/helpers/templates/wheel/standard_editable_pth_extra_dependencies.py
+++ b/tests/helpers/templates/wheel/standard_editable_pth_extra_dependencies.py
@@ -37,6 +37,7 @@ Tag: py3-none-any
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 Requires-Dist: binary
 """,
         )

--- a/tests/helpers/templates/wheel/standard_editable_pth_force_include.py
+++ b/tests/helpers/templates/wheel/standard_editable_pth_force_include.py
@@ -39,6 +39,7 @@ Tag: py3-none-any
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 """,
         )
     )

--- a/tests/helpers/templates/wheel/standard_entry_points.py
+++ b/tests/helpers/templates/wheel/standard_entry_points.py
@@ -49,6 +49,7 @@ Tag: py3-none-any
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 """,
         )
     )

--- a/tests/helpers/templates/wheel/standard_no_strict_naming.py
+++ b/tests/helpers/templates/wheel/standard_no_strict_naming.py
@@ -39,6 +39,7 @@ Tag: py3-none-any
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 """,
         )
     )

--- a/tests/helpers/templates/wheel/standard_only_packages_artifact_override.py
+++ b/tests/helpers/templates/wheel/standard_only_packages_artifact_override.py
@@ -41,6 +41,7 @@ Tag: py3-none-any
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 """,
         )
     )

--- a/tests/helpers/templates/wheel/standard_tests.py
+++ b/tests/helpers/templates/wheel/standard_tests.py
@@ -39,6 +39,7 @@ Tag: py3-none-any
 Metadata-Version: {DEFAULT_METADATA_VERSION}
 Name: {kwargs['project_name']}
 Version: 0.0.1
+License-File: LICENSE.txt
 """,
         )
     )


### PR DESCRIPTION
resolves #455 