### PR TITLE
Context Formatting Support for Environments

### DIFF
--- a/src/hatch/cli/env/show.py
+++ b/src/hatch/cli/env/show.py
@@ -29,7 +29,9 @@ def show(app, envs, force_ascii, as_json):
         if config.get('extra-dependencies'):
             dependencies.extend(config['extra-dependencies'])
         if dependencies:
-            columns['Dependencies'][i] = '\n'.join(get_normalized_dependencies(dependencies))
+            columns['Dependencies'][i] = '\n'.join(
+                get_normalized_dependencies(dependencies, context=app.project.metadata.context)
+            )
 
         if config.get('env-vars'):
             columns['Environment variables'][i] = '\n'.join(

--- a/src/hatch/utils/dep.py
+++ b/src/hatch/utils/dep.py
@@ -8,7 +8,7 @@ def normalize_marker_quoting(text):
     return text.replace('"', "'")
 
 
-def get_normalized_dependencies(dependencies, context = None):
+def get_normalized_dependencies(dependencies, context=None):
     """Normalizes dependencies, optionally context can be provided to perform context
     formatting before normalization"""
     if context:

--- a/src/hatch/utils/dep.py
+++ b/src/hatch/utils/dep.py
@@ -8,6 +8,11 @@ def normalize_marker_quoting(text):
     return text.replace('"', "'")
 
 
-def get_normalized_dependencies(dependencies):
+def get_normalized_dependencies(dependencies, context = None):
+    """Normalizes dependencies, optionally context can be provided to perform context
+    formatting before normalization"""
+    if context:
+        dependencies = [context.format(dependency) for dependency in dependencies]
+
     normalized_dependencies = {get_normalized_dependency(Requirement(dependency)) for dependency in dependencies}
     return sorted(normalized_dependencies)

--- a/tests/cli/env/test_show.py
+++ b/tests/cli/env/test_show.py
@@ -382,6 +382,7 @@ occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim 
         """  # noqa: E501
     )
 
+
 def test_context_formatting_deps(hatch, helpers, temp_dir, config_file):
     config_file.model.template.plugins['default']['tests'] = False
     config_file.save()
@@ -397,7 +398,7 @@ def test_context_formatting_deps(hatch, helpers, temp_dir, config_file):
     data_path = temp_dir / 'data'
     data_path.mkdir()
 
-    project = Project(project_path, config={"dependencies": ['project @ {root:uri}']})
+    project = Project(project_path, config={'dependencies': ['project @ {root:uri}']})
     helpers.update_project_environment(
         project,
         'foo',
@@ -409,6 +410,6 @@ def test_context_formatting_deps(hatch, helpers, temp_dir, config_file):
     with project_path.as_cwd():
         result = hatch('env', 'show', '--ascii')
 
-    uri = (project_path / "bar").as_uri()
+    uri = (project_path / 'bar').as_uri()
     assert result.exit_code == 0, result.output
     assert uri in result.output

--- a/tests/cli/env/test_show.py
+++ b/tests/cli/env/test_show.py
@@ -409,24 +409,6 @@ def test_context_formatting_deps(hatch, helpers, temp_dir, config_file):
     with project_path.as_cwd():
         result = hatch('env', 'show', '--ascii')
 
+    uri = (project_path / "bar").as_uri()
     assert result.exit_code == 0, result.output
-
-    row_length = len(result.output.split()[1])
-    row_start = "| foo     | virtual | bar@ "
-    # Padding length is 1 less than required, as we add "|" to the end
-    uri = (project_path / "bar").as_uri().ljust(row_length - len(row_start) - 1)
-    row = f"{row_start}{uri}|"
-
-    assert helpers.remove_trailing_spaces(result.output) == helpers.dedent(
-        f"""
-                                  Standalone
-        +---------+---------+-----------------------------------------+
-        | Name    | Type    | Dependencies                            |
-        +=========+=========+=========================================+
-        | default | virtual |                                         |
-        +---------+---------+-----------------------------------------+
-        {row}
-        |         |         | baz                                     |
-        +---------+---------+-----------------------------------------+
-        """  # noqa: E501
-    )
+    assert uri in result.output

--- a/tests/cli/env/test_show.py
+++ b/tests/cli/env/test_show.py
@@ -402,7 +402,7 @@ def test_context_formatting_deps(hatch, helpers, temp_dir, config_file):
         project,
         'foo',
         {
-            'extra-dependencies': ['foo @ {root:uri}/foo'],
+            'extra-dependencies': ['bar @ {root:uri}/bar', 'baz'],
         },
     )
 
@@ -412,9 +412,9 @@ def test_context_formatting_deps(hatch, helpers, temp_dir, config_file):
     assert result.exit_code == 0, result.output
 
     row_length = len(result.output.split()[1])
-    row_start = "| foo     | virtual | foo@ "
+    row_start = "| foo     | virtual | bar@ "
     # Padding length is 1 less than required, as we add "|" to the end
-    uri = (project_path / "foo").as_uri().ljust(row_length - len(row_start) - 1)
+    uri = (project_path / "bar").as_uri().ljust(row_length - len(row_start) - 1)
     row = f"{row_start}{uri}|"
 
     assert helpers.remove_trailing_spaces(result.output) == helpers.dedent(
@@ -426,6 +426,7 @@ def test_context_formatting_deps(hatch, helpers, temp_dir, config_file):
         | default | virtual |                                         |
         +---------+---------+-----------------------------------------+
         {row}
+        |         |         | baz                                     |
         +---------+---------+-----------------------------------------+
         """  # noqa: E501
     )


### PR DESCRIPTION
PR adds in support for context formatting in the `hatch env show` command.

Not sure if this is the best way to do it, but it does this by modifying `hatch.utils.dep.get_normalized_dependencies` by adding an optional `context` kwarg which (if provided) runs context formatting on the dependencies list, passing the kwarg in for the env show cli call.

Also added a test with a project that has an environment `foo` with `{'extra-dependencies': ['bar @ {root:uri}/bar', 'baz']}`, the expected result is:

```
                           Standalone                           
+---------+---------+-----------------------------------------+
| Name    | Type    | Dependencies                            |
+=========+=========+=========================================+
| default | virtual |                                         |
+---------+---------+-----------------------------------------+
| foo     | virtual | bar@ file:///tmp/tmp3cab4ud3/my-app/bar |
|         |         | baz                                     |
+---------+---------+-----------------------------------------+
```

Which seems correct. Any suggestions welcome :pray: 

Fixes #476