### PR TITLE
Add deprecated option to allow ambiguous features

### DIFF
--- a/backend/src/hatchling/metadata/core.py
+++ b/backend/src/hatchling/metadata/core.py
@@ -1149,7 +1149,10 @@ class CoreMetadata:
 
                         entries[get_normalized_dependency(requirement)] = requirement
 
-                normalized_option = normalize_project_name(option)
+                if self.hatch_metadata.allow_ambiguous_features:
+                    normalized_option = option
+                else:
+                    normalized_option = normalize_project_name(option)
                 if normalized_option in normalized_options:
                     raise ValueError(
                         f'Optional dependency groups `{normalized_options[normalized_option]}` and `{option}` of '
@@ -1345,6 +1348,7 @@ class HatchMetadataSettings:
         self.plugin_manager = plugin_manager
 
         self._allow_direct_references = None
+        self._allow_ambiguous_features = None
         self._hook_config = None
         self._hooks = None
 
@@ -1358,6 +1362,18 @@ class HatchMetadataSettings:
             self._allow_direct_references = allow_direct_references
 
         return self._allow_direct_references
+
+    @property
+    def allow_ambiguous_features(self):
+        # TODO: remove in the first minor release after Jan 1, 2024
+        if self._allow_ambiguous_features is None:
+            allow_ambiguous_features = self.config.get('allow-ambiguous-features', False)
+            if not isinstance(allow_ambiguous_features, bool):
+                raise TypeError('Field `tool.hatch.metadata.allow-ambiguous-features` must be a boolean')
+
+            self._allow_ambiguous_features = allow_ambiguous_features
+
+        return self._allow_ambiguous_features
 
     @property
     def hook_config(self):

--- a/docs/config/metadata.md
+++ b/docs/config/metadata.md
@@ -293,3 +293,24 @@ By default, [dependencies](#dependencies) are not allowed to define [direct refe
     [metadata]
     allow-direct-references = true
     ```
+
+### Allowing ambiguous features
+
+By default, names of [optional dependencies](#optional) are normalized to prevent ambiguity. To disable this normalization, set `allow-ambiguous-features` to `true`:
+
+=== ":octicons-file-code-16: pyproject.toml"
+
+    ```toml
+    [tool.hatch.metadata]
+    allow-ambiguous-features = true
+    ```
+
+=== ":octicons-file-code-16: hatch.toml"
+
+    ```toml
+    [metadata]
+    allow-ambiguous-features = true
+    ```
+
+!!! danger "Deprecated"
+    This option temporarily exists to provide better interoperability with tools that do not yet support [PEP 685](https://peps.python.org/pep-0685/) and will be removed in the first minor release after Jan 1, 2024.

--- a/docs/history.md
+++ b/docs/history.md
@@ -178,6 +178,7 @@ This is the first stable release of Hatch v1, a complete rewrite. Enjoy!
 ***Added:***
 
 - Add the following to the list of directories that cannot be traversed: `__pypackages__`, `.hg`, `.hatch`, `.tox`, `.nox`
+- Add deprecated option to allow ambiguous features
 
 ***Fixed:***
 

--- a/tests/backend/metadata/test_core.py
+++ b/tests/backend/metadata/test_core.py
@@ -1296,6 +1296,18 @@ class TestOptionalDependencies:
         ):
             _ = metadata.core.optional_dependencies
 
+    def test_allow_ambiguity(self, isolation):
+        metadata = ProjectMetadata(
+            str(isolation),
+            None,
+            {
+                'project': {'optional-dependencies': {'foo_bar': [], 'foo.bar': []}},
+                'tool': {'hatch': {'metadata': {'allow-ambiguous-features': True}}},
+            },
+        )
+
+        assert metadata.core.optional_dependencies == {'foo_bar': [], 'foo.bar': []}
+
     def test_direct_reference(self, isolation):
         metadata = ProjectMetadata(
             str(isolation),

--- a/tests/backend/metadata/test_hatch.py
+++ b/tests/backend/metadata/test_hatch.py
@@ -156,3 +156,24 @@ class TestMetadataAllowDirectReferences:
         metadata = HatchMetadata(str(isolation), config, None)
 
         assert metadata.metadata.allow_direct_references is True
+
+
+class TestMetadataAllowAmbiguousFeatures:
+    def test_default(self, isolation):
+        config = {}
+        metadata = HatchMetadata(str(isolation), config, None)
+
+        assert metadata.metadata.allow_ambiguous_features is metadata.metadata.allow_ambiguous_features is False
+
+    def test_not_boolean(self, isolation):
+        config = {'metadata': {'allow-ambiguous-features': 9000}}
+        metadata = HatchMetadata(str(isolation), config, None)
+
+        with pytest.raises(TypeError, match='Field `tool.hatch.metadata.allow-ambiguous-features` must be a boolean'):
+            _ = metadata.metadata.allow_ambiguous_features
+
+    def test_correct(self, isolation):
+        config = {'metadata': {'allow-ambiguous-features': True}}
+        metadata = HatchMetadata(str(isolation), config, None)
+
+        assert metadata.metadata.allow_ambiguous_features is True


### PR DESCRIPTION
resolves https://github.com/pypa/hatch/issues/274

also required by Twisted https://github.com/twisted/twisted/pull/11656