### PR TITLE
Expand Use of Type Hints

### DIFF
--- a/backend/scripts/update_classifiers.py
+++ b/backend/scripts/update_classifiers.py
@@ -6,7 +6,7 @@ from io import StringIO
 import trove_classifiers
 
 
-def main():
+def main() -> None:
     project_root = pathlib.Path(__file__).resolve().parent.parent
     data_file = project_root / 'src' / 'hatchling' / 'metadata' / 'classifiers.py'
 

--- a/backend/scripts/update_classifiers.py
+++ b/backend/scripts/update_classifiers.py
@@ -3,7 +3,7 @@ from contextlib import closing
 from importlib.metadata import version
 from io import StringIO
 
-import trove_classifiers
+import trove_classifiers  # type: ignore
 
 
 def main() -> None:

--- a/backend/scripts/update_licenses.py
+++ b/backend/scripts/update_licenses.py
@@ -3,6 +3,7 @@ import pathlib
 import time
 from contextlib import closing
 from io import StringIO
+from typing import Union
 
 import httpx
 
@@ -11,7 +12,7 @@ LICENSES_URL = 'https://raw.githubusercontent.com/spdx/license-list-data/v{}/jso
 EXCEPTIONS_URL = 'https://raw.githubusercontent.com/spdx/license-list-data/v{}/json/exceptions.json'
 
 
-def download_data(url):
+def download_data(url: Union[httpx.URL, str]):
     for _ in range(600):
         try:
             response = httpx.get(url)
@@ -25,7 +26,7 @@ def download_data(url):
         raise Exception('Download failed')
 
 
-def main():
+def main() -> None:
     latest_version = download_data(LATEST_API)['tag_name'][1:]
 
     licenses = {}

--- a/backend/src/hatchling/bridge/app.py
+++ b/backend/src/hatchling/bridge/app.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import pickle
 import sys
@@ -116,7 +118,7 @@ class Application:
 
 
 class SafeApplication:
-    def __init__(self, app: Union[InvokedApplication, Application]) -> None:
+    def __init__(self, app: InvokedApplication | Application) -> None:
         self.abort = app.abort
         self.display_always = app.display_always
         self.display_info = app.display_info
@@ -134,7 +136,7 @@ def format_app_command(method: str, *args, **kwargs) -> str:
     return f"__HATCH__:{''.join('%02x' % i for i in procedure)}"
 
 
-def get_application(called_by_app: bool) -> Union[InvokedApplication, Application]:
+def get_application(called_by_app: bool) -> InvokedApplication | Application:
     return InvokedApplication() if called_by_app else Application()
 
 

--- a/backend/src/hatchling/bridge/app.py
+++ b/backend/src/hatchling/bridge/app.py
@@ -34,7 +34,7 @@ class InvokedApplication:
         send_app_command('abort', *args, **kwargs)
         sys.exit(kwargs.get('code', 1))
 
-    def get_safe_application(self) -> "SafeApplication":
+    def get_safe_application(self) -> 'SafeApplication':
         return SafeApplication(self)
 
 
@@ -112,7 +112,7 @@ class Application:
 
         sys.exit(code)
 
-    def get_safe_application(self) -> "SafeApplication":
+    def get_safe_application(self) -> 'SafeApplication':
         return SafeApplication(self)
 
 

--- a/backend/src/hatchling/bridge/app.py
+++ b/backend/src/hatchling/bridge/app.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 import pickle
 import sys
-from typing import Union
 
 
 class InvokedApplication:
@@ -51,39 +50,39 @@ class Application:
     def __init__(self) -> None:
         self.__verbosity = int(os.environ.get('HATCH_VERBOSE', '0')) - int(os.environ.get('HATCH_QUIET', '0'))
 
-    def display_always(self, message: str='', **kwargs) -> None:
+    def display_always(self, message: str = '', **kwargs) -> None:
         # Do not document
         print(message)
 
-    def display_info(self, message: str='', **kwargs) -> None:
+    def display_info(self, message: str = '', **kwargs) -> None:
         """
         Meant to be used for messages conveying basic information.
         """
         if self.__verbosity >= 0:
             print(message)
 
-    def display_waiting(self, message: str='', **kwargs) -> None:
+    def display_waiting(self, message: str = '', **kwargs) -> None:
         """
         Meant to be used for messages shown before potentially time consuming operations.
         """
         if self.__verbosity >= 0:
             print(message)
 
-    def display_success(self, message: str='', **kwargs) -> None:
+    def display_success(self, message: str = '', **kwargs) -> None:
         """
         Meant to be used for messages indicating some positive outcome.
         """
         if self.__verbosity >= 0:
             print(message)
 
-    def display_warning(self, message: str='', **kwargs) -> None:
+    def display_warning(self, message: str = '', **kwargs) -> None:
         """
         Meant to be used for messages conveying important information.
         """
         if self.__verbosity >= -1:
             print(message)
 
-    def display_error(self, message: str='', **kwargs) -> None:
+    def display_error(self, message: str = '', **kwargs) -> None:
         """
         Meant to be used for messages indicating some unrecoverable error.
         """
@@ -100,11 +99,11 @@ class Application:
         elif self.__verbosity >= level:
             print(message)
 
-    def display_mini_header(self, message: str='', **kwargs) -> None:
+    def display_mini_header(self, message: str = '', **kwargs) -> None:
         if self.__verbosity >= 0:
             print(f'[{message}]')
 
-    def abort(self, message: str='', code: int=1, **kwargs) -> None:
+    def abort(self, message: str = '', code: int = 1, **kwargs) -> None:
         """
         Terminate the program with the given return code.
         """

--- a/backend/src/hatchling/bridge/app.py
+++ b/backend/src/hatchling/bridge/app.py
@@ -1,38 +1,39 @@
 import os
 import pickle
 import sys
+from typing import Union
 
 
 class InvokedApplication:
-    def display_always(self, *args, **kwargs):
+    def display_always(self, *args, **kwargs) -> None:
         send_app_command('display_always', *args, **kwargs)
 
-    def display_info(self, *args, **kwargs):
+    def display_info(self, *args, **kwargs) -> None:
         send_app_command('display_info', *args, **kwargs)
 
-    def display_waiting(self, *args, **kwargs):
+    def display_waiting(self, *args, **kwargs) -> None:
         send_app_command('display_waiting', *args, **kwargs)
 
-    def display_success(self, *args, **kwargs):
+    def display_success(self, *args, **kwargs) -> None:
         send_app_command('display_success', *args, **kwargs)
 
-    def display_warning(self, *args, **kwargs):
+    def display_warning(self, *args, **kwargs) -> None:
         send_app_command('display_warning', *args, **kwargs)
 
-    def display_error(self, *args, **kwargs):
+    def display_error(self, *args, **kwargs) -> None:
         send_app_command('display_error', *args, **kwargs)
 
-    def display_debug(self, *args, **kwargs):
+    def display_debug(self, *args, **kwargs) -> None:
         send_app_command('display_debug', *args, **kwargs)
 
-    def display_mini_header(self, *args, **kwargs):
+    def display_mini_header(self, *args, **kwargs) -> None:
         send_app_command('display_mini_header', *args, **kwargs)
 
-    def abort(self, *args, **kwargs):
+    def abort(self, *args, **kwargs) -> None:
         send_app_command('abort', *args, **kwargs)
         sys.exit(kwargs.get('code', 1))
 
-    def get_safe_application(self):
+    def get_safe_application(self) -> "SafeApplication":
         return SafeApplication(self)
 
 
@@ -45,49 +46,49 @@ class Application:
         the capabilities herein and will grant access via an attribute.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.__verbosity = int(os.environ.get('HATCH_VERBOSE', '0')) - int(os.environ.get('HATCH_QUIET', '0'))
 
-    def display_always(self, message='', **kwargs):
+    def display_always(self, message: str='', **kwargs) -> None:
         # Do not document
         print(message)
 
-    def display_info(self, message='', **kwargs):
+    def display_info(self, message: str='', **kwargs) -> None:
         """
         Meant to be used for messages conveying basic information.
         """
         if self.__verbosity >= 0:
             print(message)
 
-    def display_waiting(self, message='', **kwargs):
+    def display_waiting(self, message: str='', **kwargs) -> None:
         """
         Meant to be used for messages shown before potentially time consuming operations.
         """
         if self.__verbosity >= 0:
             print(message)
 
-    def display_success(self, message='', **kwargs):
+    def display_success(self, message: str='', **kwargs) -> None:
         """
         Meant to be used for messages indicating some positive outcome.
         """
         if self.__verbosity >= 0:
             print(message)
 
-    def display_warning(self, message='', **kwargs):
+    def display_warning(self, message: str='', **kwargs) -> None:
         """
         Meant to be used for messages conveying important information.
         """
         if self.__verbosity >= -1:
             print(message)
 
-    def display_error(self, message='', **kwargs):
+    def display_error(self, message: str='', **kwargs) -> None:
         """
         Meant to be used for messages indicating some unrecoverable error.
         """
         if self.__verbosity >= -2:
             print(message)
 
-    def display_debug(self, message='', level=1, **kwargs):
+    def display_debug(self, message: str = '', level: int = 1, **kwargs) -> None:
         """
         Meant to be used for messages that are not useful for most user experiences.
         The `level` option must be between 1 and 3 (inclusive).
@@ -97,11 +98,11 @@ class Application:
         elif self.__verbosity >= level:
             print(message)
 
-    def display_mini_header(self, message='', **kwargs):
+    def display_mini_header(self, message: str='', **kwargs) -> None:
         if self.__verbosity >= 0:
             print(f'[{message}]')
 
-    def abort(self, message='', code=1, **kwargs):
+    def abort(self, message: str='', code: int=1, **kwargs) -> None:
         """
         Terminate the program with the given return code.
         """
@@ -110,12 +111,12 @@ class Application:
 
         sys.exit(code)
 
-    def get_safe_application(self):
+    def get_safe_application(self) -> "SafeApplication":
         return SafeApplication(self)
 
 
 class SafeApplication:
-    def __init__(self, app):
+    def __init__(self, app: Union[InvokedApplication, Application]) -> None:
         self.abort = app.abort
         self.display_always = app.display_always
         self.display_info = app.display_info
@@ -127,19 +128,19 @@ class SafeApplication:
         self.display_mini_header = app.display_mini_header
 
 
-def format_app_command(method, *args, **kwargs):
+def format_app_command(method: str, *args, **kwargs) -> str:
     procedure = pickle.dumps((method, args, kwargs), 4)
 
     return f"__HATCH__:{''.join('%02x' % i for i in procedure)}"
 
 
-def get_application(called_by_app):
+def get_application(called_by_app: bool) -> Union[InvokedApplication, Application]:
     return InvokedApplication() if called_by_app else Application()
 
 
-def send_app_command(method, *args, **kwargs):
+def send_app_command(method: str, *args, **kwargs) -> None:
     _send_app_command(format_app_command(method, *args, **kwargs))
 
 
-def _send_app_command(command):
+def _send_app_command(command) -> None:
     print(command)

--- a/backend/src/hatchling/build.py
+++ b/backend/src/hatchling/build.py
@@ -11,7 +11,7 @@ def get_requires_for_build_sdist(config_settings=None):
     return builder.config.dependencies
 
 
-def build_sdist(sdist_directory, config_settings=None):
+def build_sdist(sdist_directory: str, config_settings = None) -> str:
     """
     https://peps.python.org/pep-0517/#build-sdist
     """

--- a/backend/src/hatchling/build.py
+++ b/backend/src/hatchling/build.py
@@ -11,7 +11,7 @@ def get_requires_for_build_sdist(config_settings=None):
     return builder.config.dependencies
 
 
-def build_sdist(sdist_directory: str, config_settings = None) -> str:
+def build_sdist(sdist_directory: str, config_settings=None) -> str:
     """
     https://peps.python.org/pep-0517/#build-sdist
     """

--- a/backend/src/hatchling/builders/config.py
+++ b/backend/src/hatchling/builders/config.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 from contextlib import contextmanager
-from typing import List
 
 import pathspec
 

--- a/backend/src/hatchling/builders/config.py
+++ b/backend/src/hatchling/builders/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from contextlib import contextmanager
+from typing import List
 
 import pathspec
 
@@ -788,7 +789,7 @@ class BuilderConfig:
     def default_packages(self):
         return []
 
-    def default_only_include(self):
+    def default_only_include(self) -> list:
         return []
 
     def default_global_exclude(self) -> list[str]:

--- a/backend/src/hatchling/builders/config.py
+++ b/backend/src/hatchling/builders/config.py
@@ -74,7 +74,7 @@ class BuilderConfig:
     def target_config(self):
         return self.__target_config
 
-    def include_path(self, relative_path, *, explicit: bool=False, is_package: bool=True):
+    def include_path(self, relative_path, *, explicit: bool = False, is_package: bool = True):
         return (
             self.path_is_build_artifact(relative_path)
             or self.path_is_artifact(relative_path)
@@ -831,7 +831,7 @@ class BuilderConfig:
             self.build_reserved_paths.clear()
 
 
-def env_var_enabled(env_var: str, default: bool=False):
+def env_var_enabled(env_var: str, default: bool = False):
     if env_var in os.environ:
         return os.environ[env_var] in ('1', 'true')
     else:

--- a/backend/src/hatchling/builders/config.py
+++ b/backend/src/hatchling/builders/config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from contextlib import contextmanager
 
@@ -10,7 +12,7 @@ from hatchling.utils.fs import locate_file
 
 
 class BuilderConfig:
-    def __init__(self, builder, root, plugin_name, build_config, target_config):
+    def __init__(self, builder, root, plugin_name, build_config, target_config) -> None:
         self.__builder = builder
         self.__root = root
         self.__plugin_name = plugin_name
@@ -71,7 +73,7 @@ class BuilderConfig:
     def target_config(self):
         return self.__target_config
 
-    def include_path(self, relative_path, *, explicit=False, is_package=True):
+    def include_path(self, relative_path, *, explicit: bool=False, is_package: bool=True):
         return (
             self.path_is_build_artifact(relative_path)
             or self.path_is_artifact(relative_path)
@@ -746,7 +748,7 @@ class BuilderConfig:
 
         return self.__vcs_exclusion_files
 
-    def load_vcs_exclusion_patterns(self):
+    def load_vcs_exclusion_patterns(self) -> list[str]:
         patterns = []
 
         # https://git-scm.com/docs/gitignore#_pattern_format
@@ -789,7 +791,7 @@ class BuilderConfig:
     def default_only_include(self):
         return []
 
-    def default_global_exclude(self):
+    def default_global_exclude(self) -> list[str]:
         patterns = ['*.py[cdo]', f'/{DEFAULT_BUILD_DIRECTORY}']
         patterns.sort()
         return patterns
@@ -828,7 +830,7 @@ class BuilderConfig:
             self.build_reserved_paths.clear()
 
 
-def env_var_enabled(env_var, default=False):
+def env_var_enabled(env_var: str, default: bool=False):
     if env_var in os.environ:
         return os.environ[env_var] in ('1', 'true')
     else:

--- a/backend/src/hatchling/builders/constants.py
+++ b/backend/src/hatchling/builders/constants.py
@@ -1,8 +1,8 @@
-from typing import FrozenSet
+from __future__ import annotations
 
 DEFAULT_BUILD_DIRECTORY = 'dist'
 
-EXCLUDED_DIRECTORIES: FrozenSet[str] = frozenset(
+EXCLUDED_DIRECTORIES: frozenset[str] = frozenset(
     (
         # Python bytecode
         '__pycache__',

--- a/backend/src/hatchling/builders/constants.py
+++ b/backend/src/hatchling/builders/constants.py
@@ -1,6 +1,8 @@
+from typing import FrozenSet
+
 DEFAULT_BUILD_DIRECTORY = 'dist'
 
-EXCLUDED_DIRECTORIES = frozenset(
+EXCLUDED_DIRECTORIES: FrozenSet[str] = frozenset(
     (
         # Python bytecode
         '__pycache__',

--- a/backend/src/hatchling/builders/hooks/plugin/interface.py
+++ b/backend/src/hatchling/builders/hooks/plugin/interface.py
@@ -30,7 +30,7 @@ class BuildHookInterface:  # no cov
     PLUGIN_NAME = ''
     """The name used for selection."""
 
-    def __init__(self, root, config, build_config, metadata, directory, target_name, app=None):
+    def __init__(self, root, config, build_config, metadata, directory, target_name, app=None) -> None:
         self.__root = root
         self.__config = config
         self.__build_config = build_config
@@ -105,21 +105,21 @@ class BuildHookInterface:  # no cov
         """
         return self.__target_name
 
-    def clean(self, versions):
+    def clean(self, versions) -> None:
         """
         This occurs before the build process if the `-c`/`--clean` flag was passed to
         the [`build`](../../cli/reference.md#hatch-build) command, or when invoking
         the [`clean`](../../cli/reference.md#hatch-clean) command.
         """
 
-    def initialize(self, version, build_data):
+    def initialize(self, version, build_data) -> None:
         """
         This occurs immediately before each build.
 
         Any modifications to the build data will be seen by the build target.
         """
 
-    def finalize(self, version, build_data, artifact_path):
+    def finalize(self, version, build_data, artifact_path) -> None:
         """
         This occurs immediately after each build and will not run if the `--hooks-only` flag
         was passed to the [`build`](../../cli/reference.md#hatch-build) command.

--- a/backend/src/hatchling/builders/hooks/version.py
+++ b/backend/src/hatchling/builders/hooks/version.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict, List, Optional, Union
+
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 from hatchling.version.core import VersionFile
 
@@ -5,15 +7,15 @@ from hatchling.version.core import VersionFile
 class VersionBuildHook(BuildHookInterface):
     PLUGIN_NAME = 'version'
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-        self.__config_path = None
-        self.__config_template = None
-        self.__config_pattern = None
+        self.__config_path: Optional[str] = None
+        self.__config_template: Optional[str] = None
+        self.__config_pattern: Optional[Union[str, bool]] = None
 
     @property
-    def config_path(self):
+    def config_path(self) -> str:
         if self.__config_path is None:
             path = self.config.get('path', '')
             if not isinstance(path, str):
@@ -26,7 +28,7 @@ class VersionBuildHook(BuildHookInterface):
         return self.__config_path
 
     @property
-    def config_template(self):
+    def config_template(self) -> str:
         if self.__config_template is None:
             template = self.config.get('template', '')
             if not isinstance(template, str):
@@ -37,7 +39,7 @@ class VersionBuildHook(BuildHookInterface):
         return self.__config_template
 
     @property
-    def config_pattern(self):
+    def config_pattern(self) -> Union[str, bool]:
         if self.__config_pattern is None:
             pattern = self.config.get('pattern', '')
             if not isinstance(pattern, (str, bool)):
@@ -47,7 +49,7 @@ class VersionBuildHook(BuildHookInterface):
 
         return self.__config_pattern
 
-    def initialize(self, version, build_data):
+    def initialize(self, version: List[Any], build_data: Dict[str, List[Any]]) -> None:
         version_file = VersionFile(self.root, self.config_path)
         if self.config_pattern:
             version_file.read(self.config_pattern)

--- a/backend/src/hatchling/builders/hooks/version.py
+++ b/backend/src/hatchling/builders/hooks/version.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict, List, Optional, Union
+from __future__ import annotations
+
+from typing import Any
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 from hatchling.version.core import VersionFile
@@ -10,9 +12,9 @@ class VersionBuildHook(BuildHookInterface):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-        self.__config_path: Optional[str] = None
-        self.__config_template: Optional[str] = None
-        self.__config_pattern: Optional[Union[str, bool]] = None
+        self.__config_path: str | None = None
+        self.__config_template: str | None = None
+        self.__config_pattern: str | bool | None = None
 
     @property
     def config_path(self) -> str:
@@ -39,7 +41,7 @@ class VersionBuildHook(BuildHookInterface):
         return self.__config_template
 
     @property
-    def config_pattern(self) -> Union[str, bool]:
+    def config_pattern(self) -> str | bool:
         if self.__config_pattern is None:
             pattern = self.config.get('pattern', '')
             if not isinstance(pattern, (str, bool)):
@@ -49,7 +51,7 @@ class VersionBuildHook(BuildHookInterface):
 
         return self.__config_pattern
 
-    def initialize(self, version: List[Any], build_data: Dict[str, List[Any]]) -> None:
+    def initialize(self, version: list[Any], build_data: dict[str, list[Any]]) -> None:
         version_file = VersionFile(self.root, self.config_path)
         if self.config_pattern:
             version_file.read(self.config_pattern)

--- a/backend/src/hatchling/builders/plugin/interface.py
+++ b/backend/src/hatchling/builders/plugin/interface.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import re
 from abc import ABC, abstractmethod
-from typing import Callable, Generator, List
+from collections.abc import Callable, Generator
 
 from hatchling.builders.config import BuilderConfig, env_var_enabled
 from hatchling.builders.constants import EXCLUDED_DIRECTORIES, BuildEnvVars
@@ -384,7 +384,7 @@ class BuilderInterface(ABC):
         The return value must be the absolute path to the built artifact.
         """
 
-    def get_default_versions(self) -> List[str]:
+    def get_default_versions(self) -> list[str]:
         """
         A list of versions to build when users do not specify any, defaulting to all versions.
         """

--- a/backend/src/hatchling/builders/plugin/interface.py
+++ b/backend/src/hatchling/builders/plugin/interface.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import re
 from abc import ABC, abstractmethod
-from typing import Callable, Generator
+from typing import Callable, Generator, List
 
 from hatchling.builders.config import BuilderConfig, env_var_enabled
 from hatchling.builders.constants import EXCLUDED_DIRECTORIES, BuildEnvVars
@@ -13,7 +13,7 @@ from hatchling.builders.utils import get_relative_path, safe_walk
 class IncludedFile:
     __slots__ = ('path', 'relative_path', 'distribution_path')
 
-    def __init__(self, path, relative_path, distribution_path):
+    def __init__(self, path, relative_path, distribution_path) -> None:
         self.path = path
         self.relative_path = relative_path
         self.distribution_path = distribution_path
@@ -51,7 +51,7 @@ class BuilderInterface(ABC):
     PLUGIN_NAME = ''
     """The name used for selection."""
 
-    def __init__(self, root, plugin_manager=None, config=None, metadata=None, app=None):
+    def __init__(self, root, plugin_manager=None, config=None, metadata=None, app=None) -> None:
         self.__root = root
         self.__plugin_manager = plugin_manager
         self.__raw_config = config
@@ -74,7 +74,7 @@ class BuilderInterface(ABC):
         hooks_only=None,
         clean=None,
         clean_hooks_after=None,
-        clean_only=False,
+        clean_only: bool=False,
     ) -> Generator[str, None, None]:
         # Fail early for invalid project metadata
         self.metadata.validate_fields()
@@ -384,7 +384,7 @@ class BuilderInterface(ABC):
         The return value must be the absolute path to the built artifact.
         """
 
-    def get_default_versions(self):
+    def get_default_versions(self) -> List[str]:
         """
         A list of versions to build when users do not specify any, defaulting to all versions.
         """
@@ -396,11 +396,11 @@ class BuilderInterface(ABC):
         """
         return {}
 
-    def set_build_data_defaults(self, build_data):
+    def set_build_data_defaults(self, build_data) -> None:
         build_data.setdefault('artifacts', [])
         build_data.setdefault('force_include', {})
 
-    def clean(self, directory, versions):
+    def clean(self, directory, versions) -> None:
         """
         Called before builds if the `-c`/`--clean` flag was passed to the
         [`build`](../../cli/reference.md#hatch-build) command.
@@ -414,7 +414,7 @@ class BuilderInterface(ABC):
         return BuilderConfig
 
     @staticmethod
-    def normalize_file_name_component(file_name):
+    def normalize_file_name_component(file_name) -> str:
         """
         https://peps.python.org/pep-0427/#escaping-and-unicode
         """

--- a/backend/src/hatchling/builders/plugin/interface.py
+++ b/backend/src/hatchling/builders/plugin/interface.py
@@ -48,7 +48,7 @@ class BuilderInterface(ABC):
         ```
     """
 
-    PLUGIN_NAME = ''
+    PLUGIN_NAME: str = ''
     """The name used for selection."""
 
     def __init__(self, root, plugin_manager=None, config=None, metadata=None, app=None) -> None:

--- a/backend/src/hatchling/builders/plugin/interface.py
+++ b/backend/src/hatchling/builders/plugin/interface.py
@@ -74,7 +74,7 @@ class BuilderInterface(ABC):
         hooks_only=None,
         clean=None,
         clean_hooks_after=None,
-        clean_only: bool=False,
+        clean_only: bool = False,
     ) -> Generator[str, None, None]:
         # Fail early for invalid project metadata
         self.metadata.validate_fields()

--- a/backend/src/hatchling/builders/sdist.py
+++ b/backend/src/hatchling/builders/sdist.py
@@ -69,7 +69,7 @@ class SdistArchive:
         setattr(self, name, attr)
         return attr
 
-    def __enter__(self) -> "SdistArchive":
+    def __enter__(self) -> 'SdistArchive':
         return self
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:

--- a/backend/src/hatchling/builders/sdist.py
+++ b/backend/src/hatchling/builders/sdist.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gzip
 import os
 import tarfile
@@ -6,7 +8,6 @@ from contextlib import closing
 from copy import copy
 from io import BytesIO
 from time import time as get_current_timestamp
-from typing import List, Type
 
 from hatchling.builders.config import BuilderConfig
 from hatchling.builders.plugin.interface import BuilderInterface
@@ -143,7 +144,7 @@ class SdistBuilder(BuilderInterface):
     def get_version_api(self):
         return {'standard': self.build_standard}
 
-    def get_default_versions(self) -> List[str]:
+    def get_default_versions(self) -> list[str]:
         return ['standard']
 
     def clean(self, directory, versions) -> None:
@@ -329,5 +330,5 @@ class SdistBuilder(BuilderInterface):
         return build_data
 
     @classmethod
-    def get_config_class(cls) -> Type[SdistBuilderConfig]:
+    def get_config_class(cls) -> type[SdistBuilderConfig]:
         return SdistBuilderConfig

--- a/backend/src/hatchling/builders/sdist.py
+++ b/backend/src/hatchling/builders/sdist.py
@@ -43,7 +43,7 @@ class SdistArchive:
     def create_file(self, contents: str, *relative_paths) -> None:
         contents_bytes = contents.encode('utf-8')
         tar_info = tarfile.TarInfo(normalize_archive_path(os.path.join(self.name, *relative_paths)))
-        tar_info.mtime = self.timestamp if self.reproducible else int(get_current_timestamp())
+        tar_info.mtime = self.timestamp if self.reproducible else int(get_current_timestamp())  # type: ignore
         tar_info.size = len(contents_bytes)
 
         with closing(BytesIO(contents_bytes)) as buffer:

--- a/backend/src/hatchling/builders/utils.py
+++ b/backend/src/hatchling/builders/utils.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import os
 import shutil
 from base64 import urlsafe_b64encode
-from typing import TYPE_CHECKING, Dict, Iterator, List, Tuple
+from collections.abc import Iterator
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from zipfile import ZipInfo
@@ -18,7 +21,7 @@ def replace_file(src: str, dst: str) -> None:
 
 def safe_walk(
     path: str,
-) -> Iterator[Tuple[str, List[str], List[str]]]:
+) -> Iterator[tuple[str, list[str], list[str]]]:
     seen = set()
     for root, dirs, files in os.walk(path, followlinks=True):
         stat = os.stat(root)
@@ -53,7 +56,7 @@ def normalize_relative_directory(path: str) -> str:
     return normalize_relative_path(path) + os.sep
 
 
-def normalize_inclusion_map(inclusion_map: Dict[str, str], root: str) -> Dict[str, str]:
+def normalize_inclusion_map(inclusion_map: dict[str, str], root: str) -> dict[str, str]:
     normalized_inclusion_map = {}
 
     for source, relative_path in inclusion_map.items():

--- a/backend/src/hatchling/builders/utils.py
+++ b/backend/src/hatchling/builders/utils.py
@@ -108,7 +108,7 @@ def normalize_file_permissions(st_mode: int) -> int:
     return new_mode
 
 
-def set_zip_info_mode(zip_info: "ZipInfo", mode: int = 0o644) -> None:
+def set_zip_info_mode(zip_info: 'ZipInfo', mode: int = 0o644) -> None:
     """
     https://github.com/takluyver/flit/commit/3889583719888aef9f28baaa010e698cb7884904
     """

--- a/backend/src/hatchling/builders/utils.py
+++ b/backend/src/hatchling/builders/utils.py
@@ -1,9 +1,13 @@
 import os
 import shutil
 from base64 import urlsafe_b64encode
+from typing import TYPE_CHECKING, Dict, Iterator, List, Tuple
+
+if TYPE_CHECKING:
+    from zipfile import ZipInfo
 
 
-def replace_file(src, dst):
+def replace_file(src: str, dst: str) -> None:
     try:
         os.replace(src, dst)
     # Happens when on different filesystems like /tmp or caused by layering in containers
@@ -12,7 +16,9 @@ def replace_file(src, dst):
         os.remove(src)
 
 
-def safe_walk(path):
+def safe_walk(
+    path: str,
+) -> Iterator[Tuple[str, List[str], List[str]]]:
     seen = set()
     for root, dirs, files in os.walk(path, followlinks=True):
         stat = os.stat(root)
@@ -25,11 +31,11 @@ def safe_walk(path):
         yield root, dirs, files
 
 
-def get_known_python_major_versions():
+def get_known_python_major_versions() -> map:
     return map(str, sorted((2, 3)))
 
 
-def get_relative_path(path, start):
+def get_relative_path(path: str, start: str) -> str:
     relative_path = os.path.relpath(path, start)
 
     # First iteration of `os.walk`
@@ -39,15 +45,15 @@ def get_relative_path(path, start):
     return relative_path
 
 
-def normalize_relative_path(path):
+def normalize_relative_path(path: str) -> str:
     return os.path.normpath(path).strip(os.sep)
 
 
-def normalize_relative_directory(path):
+def normalize_relative_directory(path: str) -> str:
     return normalize_relative_path(path) + os.sep
 
 
-def normalize_inclusion_map(inclusion_map, root):
+def normalize_inclusion_map(inclusion_map: Dict[str, str], root: str) -> Dict[str, str]:
     normalized_inclusion_map = {}
 
     for source, relative_path in inclusion_map.items():
@@ -60,19 +66,19 @@ def normalize_inclusion_map(inclusion_map, root):
     return dict(sorted(normalized_inclusion_map.items(), key=lambda item: (item[1].count(os.sep), item[1], item[0])))
 
 
-def normalize_archive_path(path):
+def normalize_archive_path(path: str) -> str:
     if os.sep != '/':
         return path.replace(os.sep, '/')
 
     return path
 
 
-def format_file_hash(digest):
+def format_file_hash(digest: bytes) -> str:
     # https://peps.python.org/pep-0427/#signed-wheel-files
     return urlsafe_b64encode(digest).decode('ascii').rstrip('=')
 
 
-def get_reproducible_timestamp():
+def get_reproducible_timestamp() -> int:
     """
     Returns an `int` derived from the `SOURCE_DATE_EPOCH` environment variable; see
     https://reproducible-builds.org/specs/source-date-epoch/.
@@ -82,7 +88,7 @@ def get_reproducible_timestamp():
     return int(os.environ.get('SOURCE_DATE_EPOCH', '1580601600'))
 
 
-def normalize_file_permissions(st_mode):
+def normalize_file_permissions(st_mode: int) -> int:
     """
     https://github.com/takluyver/flit/blob/6a2a8c6462e49f584941c667b70a6f48a7b3f9ab/flit_core/flit_core/common.py#L257
 
@@ -99,7 +105,7 @@ def normalize_file_permissions(st_mode):
     return new_mode
 
 
-def set_zip_info_mode(zip_info, mode=0o644):
+def set_zip_info_mode(zip_info: "ZipInfo", mode: int = 0o644) -> None:
     """
     https://github.com/takluyver/flit/commit/3889583719888aef9f28baaa010e698cb7884904
     """

--- a/backend/src/hatchling/builders/wheel.py
+++ b/backend/src/hatchling/builders/wheel.py
@@ -73,7 +73,7 @@ class WheelArchive:
         relative_path = normalize_archive_path(included_file.distribution_path)
         file_stat = os.stat(included_file.path)
 
-        if self.reproducible:
+        if self.reproducible and self.time_tuple:
             zip_info = zipfile.ZipInfo(relative_path, self.time_tuple)
 
             # https://github.com/takluyver/flit/pull/66
@@ -310,6 +310,7 @@ class WheelBuilder(BuilderInterface):
     """
 
     PLUGIN_NAME = 'wheel'
+    config: WheelBuilderConfig
 
     def get_version_api(self):
         return {'standard': self.build_standard, 'editable': self.build_editable}

--- a/backend/src/hatchling/builders/wheel.py
+++ b/backend/src/hatchling/builders/wheel.py
@@ -550,7 +550,8 @@ Root-Is-Purelib: {'true' if build_data['pure_python'] else 'false'}
         supported_python_versions = []
         for major_version in get_known_python_major_versions():
             for minor_version in range(100):
-                if self.metadata.core.python_constraint.contains(f'{major_version}.{minor_version}'):
+                python_constraint = self.metadata.core.python_constraint
+                if python_constraint and python_constraint.contains(f'{major_version}.{minor_version}'):
                     supported_python_versions.append(f'py{major_version}')
                     break
 

--- a/backend/src/hatchling/cli/__init__.py
+++ b/backend/src/hatchling/cli/__init__.py
@@ -6,7 +6,7 @@ from hatchling.cli.metadata import metadata_command
 from hatchling.cli.version import version_command
 
 
-def hatchling():
+def hatchling() -> None:
     parser = argparse.ArgumentParser(prog='hatchling', allow_abbrev=False)
     subparsers = parser.add_subparsers()
 

--- a/backend/src/hatchling/cli/build/__init__.py
+++ b/backend/src/hatchling/cli/build/__init__.py
@@ -1,7 +1,17 @@
 import argparse
+from typing import Dict, List
 
 
-def build_impl(called_by_app, directory, targets, hooks_only, no_hooks, clean, clean_hooks_after, clean_only):
+def build_impl(
+    called_by_app: bool,
+    directory: str,
+    targets: List[str],
+    hooks_only: bool,
+    no_hooks: bool,
+    clean: bool,
+    clean_hooks_after: bool,
+    clean_only: bool,
+) -> None:
     import os
 
     from hatchling.bridge.app import get_application
@@ -18,7 +28,7 @@ def build_impl(called_by_app, directory, targets, hooks_only, no_hooks, clean, c
     plugin_manager = PluginManager()
     metadata = ProjectMetadata(root, plugin_manager)
 
-    target_data = {}
+    target_data: Dict[str, List] = {}
     if targets:
         for data in targets:
             target_name, _, version_data = data.partition(':')
@@ -73,14 +83,10 @@ def build_impl(called_by_app, directory, targets, hooks_only, no_hooks, clean, c
                 app.display_info(artifact)
 
 
-def build_command(subparsers, defaults):
+def build_command(subparsers: argparse._SubParsersAction, defaults: Dict[str, str]) -> None:
     parser = subparsers.add_parser('build')
     parser.add_argument(
-        '-d',
-        '--directory',
-        dest='directory',
-        help='The directory in which to build artifacts',
-        **defaults
+        '-d', '--directory', dest='directory', help='The directory in which to build artifacts', **defaults
     )
     parser.add_argument(
         '-t',
@@ -88,7 +94,7 @@ def build_command(subparsers, defaults):
         dest='targets',
         action='append',
         help='Comma-separated list of targets to build, overriding project defaults',
-        **defaults
+        **defaults,
     )
     parser.add_argument('--hooks-only', dest='hooks_only', action='store_true', default=None)
     parser.add_argument('--no-hooks', dest='no_hooks', action='store_true', default=None)

--- a/backend/src/hatchling/cli/build/__init__.py
+++ b/backend/src/hatchling/cli/build/__init__.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import argparse
-from typing import Dict, List
 
 
 def build_impl(
@@ -28,7 +29,7 @@ def build_impl(
     plugin_manager = PluginManager()
     metadata = ProjectMetadata(root, plugin_manager)
 
-    target_data: Dict[str, List] = {}
+    target_data: dict[str, list] = {}
     if targets:
         for data in targets:
             target_name, _, version_data = data.partition(':')
@@ -83,7 +84,7 @@ def build_impl(
                 app.display_info(artifact)
 
 
-def build_command(subparsers: argparse._SubParsersAction, defaults: Dict[str, str]) -> None:
+def build_command(subparsers: argparse._SubParsersAction, defaults: dict[str, str]) -> None:
     parser = subparsers.add_parser('build')
     parser.add_argument(
         '-d', '--directory', dest='directory', help='The directory in which to build artifacts', **defaults

--- a/backend/src/hatchling/cli/build/__init__.py
+++ b/backend/src/hatchling/cli/build/__init__.py
@@ -6,7 +6,7 @@ import argparse
 def build_impl(
     called_by_app: bool,
     directory: str,
-    targets: List[str],
+    targets: list[str],
     hooks_only: bool,
     no_hooks: bool,
     clean: bool,

--- a/backend/src/hatchling/cli/dep/__init__.py
+++ b/backend/src/hatchling/cli/dep/__init__.py
@@ -1,7 +1,11 @@
 import sys
+from typing import TYPE_CHECKING, Dict
+
+if TYPE_CHECKING:
+    from argparse import _SubParsersAction
 
 
-def synced_impl(dependencies, python):
+def synced_impl(dependencies, python) -> None:
     import subprocess
     from ast import literal_eval
 
@@ -14,17 +18,17 @@ def synced_impl(dependencies, python):
         output = subprocess.check_output([python, '-c', 'import sys;print([path for path in sys.path if path])'])
         sys_path = literal_eval(output.strip().decode('utf-8'))
 
-    sys.exit(0 if dependencies_in_sync(map(Requirement, dependencies), sys_path) else 1)
+    sys.exit(0 if dependencies_in_sync(list(map(Requirement, dependencies)), sys_path) else 1)
 
 
-def synced_command(subparsers, defaults):
+def synced_command(subparsers: "_SubParsersAction", defaults: Dict[str, str]) -> None:
     parser = subparsers.add_parser('synced')
     parser.add_argument('dependencies', nargs='+')
     parser.add_argument('-p', '--python', dest='python', **defaults)
     parser.set_defaults(func=synced_impl)
 
 
-def dep_command(subparsers, defaults):
+def dep_command(subparsers: "_SubParsersAction", defaults: Dict[str, str]) -> None:
     parser = subparsers.add_parser('dep')
     subparsers = parser.add_subparsers()
 

--- a/backend/src/hatchling/cli/dep/__init__.py
+++ b/backend/src/hatchling/cli/dep/__init__.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import sys
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from argparse import _SubParsersAction
@@ -21,14 +23,14 @@ def synced_impl(dependencies, python) -> None:
     sys.exit(0 if dependencies_in_sync(list(map(Requirement, dependencies)), sys_path) else 1)
 
 
-def synced_command(subparsers: "_SubParsersAction", defaults: Dict[str, str]) -> None:
+def synced_command(subparsers: "_SubParsersAction", defaults: dict[str, str]) -> None:
     parser = subparsers.add_parser('synced')
     parser.add_argument('dependencies', nargs='+')
     parser.add_argument('-p', '--python', dest='python', **defaults)
     parser.set_defaults(func=synced_impl)
 
 
-def dep_command(subparsers: "_SubParsersAction", defaults: Dict[str, str]) -> None:
+def dep_command(subparsers: "_SubParsersAction", defaults: dict[str, str]) -> None:
     parser = subparsers.add_parser('dep')
     subparsers = parser.add_subparsers()
 

--- a/backend/src/hatchling/cli/dep/__init__.py
+++ b/backend/src/hatchling/cli/dep/__init__.py
@@ -23,14 +23,14 @@ def synced_impl(dependencies, python) -> None:
     sys.exit(0 if dependencies_in_sync(list(map(Requirement, dependencies)), sys_path) else 1)
 
 
-def synced_command(subparsers: "_SubParsersAction", defaults: dict[str, str]) -> None:
+def synced_command(subparsers: '_SubParsersAction', defaults: dict[str, str]) -> None:
     parser = subparsers.add_parser('synced')
     parser.add_argument('dependencies', nargs='+')
     parser.add_argument('-p', '--python', dest='python', **defaults)
     parser.set_defaults(func=synced_impl)
 
 
-def dep_command(subparsers: "_SubParsersAction", defaults: dict[str, str]) -> None:
+def dep_command(subparsers: '_SubParsersAction', defaults: dict[str, str]) -> None:
     parser = subparsers.add_parser('dep')
     subparsers = parser.add_subparsers()
 

--- a/backend/src/hatchling/cli/metadata/__init__.py
+++ b/backend/src/hatchling/cli/metadata/__init__.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import argparse
-from typing import Dict
 
 
 def metadata_impl(called_by_app: bool, field: None, compact: bool) -> None:
@@ -42,7 +43,7 @@ def metadata_impl(called_by_app: bool, field: None, compact: bool) -> None:
         app.display_always(json.dumps(metadata, indent=4))
 
 
-def metadata_command(subparsers: argparse._SubParsersAction, defaults: Dict[str, str]) -> None:
+def metadata_command(subparsers: argparse._SubParsersAction, defaults: dict[str, str]) -> None:
     parser = subparsers.add_parser('metadata')
     parser.add_argument('field', nargs='?')
     parser.add_argument('-c', '--compact', action='store_true')

--- a/backend/src/hatchling/cli/metadata/__init__.py
+++ b/backend/src/hatchling/cli/metadata/__init__.py
@@ -1,7 +1,8 @@
 import argparse
+from typing import Dict
 
 
-def metadata_impl(called_by_app, field, compact):
+def metadata_impl(called_by_app: bool, field: None, compact: bool) -> None:
     import json
     import os
 
@@ -39,7 +40,7 @@ def metadata_impl(called_by_app, field, compact):
         app.display_always(json.dumps(metadata, indent=4))
 
 
-def metadata_command(subparsers, defaults):
+def metadata_command(subparsers: argparse._SubParsersAction, defaults: Dict[str, str]) -> None:
     parser = subparsers.add_parser('metadata')
     parser.add_argument('field', nargs='?')
     parser.add_argument('-c', '--compact', action='store_true')

--- a/backend/src/hatchling/cli/metadata/__init__.py
+++ b/backend/src/hatchling/cli/metadata/__init__.py
@@ -21,13 +21,15 @@ def metadata_impl(called_by_app: bool, field: None, compact: bool) -> None:
     if field:  # no cov
         if field not in metadata:
             app.abort(f'Unknown metadata field: {field}')
-        elif field == 'readme':
-            app.display_always(metadata[field]['text'])
-        elif isinstance(metadata[field], str):
-            app.display_always(metadata[field])
-        else:
-            app.display_always(json.dumps(metadata[field], indent=4))
 
+        md_field = metadata[field]
+
+        if field == 'readme':
+            app.display_always(md_field['text'])  # type: ignore
+        elif isinstance(md_field, str):
+            app.display_always(md_field)
+        else:
+            app.display_always(json.dumps(md_field, indent=4))
         return
 
     for key, value in list(metadata.items()):

--- a/backend/src/hatchling/cli/version/__init__.py
+++ b/backend/src/hatchling/cli/version/__init__.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import argparse
-from typing import Dict
 
 
 def version_impl(called_by_app, desired_version) -> None:
@@ -38,7 +39,7 @@ def version_impl(called_by_app, desired_version) -> None:
     app.display_info(f'New: {updated_version}')
 
 
-def version_command(subparsers: argparse._SubParsersAction, defaults: Dict[str, str]) -> None:
+def version_command(subparsers: argparse._SubParsersAction, defaults: dict[str, str]) -> None:
     parser = subparsers.add_parser('version')
     parser.add_argument('desired_version', default='', nargs='?', **defaults)
     parser.add_argument('--app', dest='called_by_app', action='store_true', help=argparse.SUPPRESS)

--- a/backend/src/hatchling/cli/version/__init__.py
+++ b/backend/src/hatchling/cli/version/__init__.py
@@ -19,7 +19,7 @@ def version_impl(called_by_app, desired_version) -> None:
         if desired_version:
             app.abort('Cannot set version when it is statically defined by the `project.version` field')
         else:
-            app.display_always(app.project.metadata.core.version)
+            app.display_always(app.project.metadata.core.version)  # type: ignore
             return
 
     source = metadata.hatch.version.source

--- a/backend/src/hatchling/cli/version/__init__.py
+++ b/backend/src/hatchling/cli/version/__init__.py
@@ -1,7 +1,8 @@
 import argparse
+from typing import Dict
 
 
-def version_impl(called_by_app, desired_version):
+def version_impl(called_by_app, desired_version) -> None:
     import os
 
     from hatchling.bridge.app import get_application
@@ -37,7 +38,7 @@ def version_impl(called_by_app, desired_version):
     app.display_info(f'New: {updated_version}')
 
 
-def version_command(subparsers, defaults):
+def version_command(subparsers: argparse._SubParsersAction, defaults: Dict[str, str]) -> None:
     parser = subparsers.add_parser('version')
     parser.add_argument('desired_version', default='', nargs='?', **defaults)
     parser.add_argument('--app', dest='called_by_app', action='store_true', help=argparse.SUPPRESS)

--- a/backend/src/hatchling/dep/core.py
+++ b/backend/src/hatchling/dep/core.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import re
 import sys
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 from packaging.markers import default_environment
 from packaging.requirements import Requirement
@@ -12,13 +14,13 @@ else:
 
 
 class DistributionCache:
-    def __init__(self, sys_path: List[str]) -> None:
+    def __init__(self, sys_path: list[str]) -> None:
         self._resolver = Distribution.discover(context=DistributionFinder.Context(path=sys_path))
         self._distributions = {}
         self._search_exhausted = False
         self._canonical_regex = re.compile(r'[-_.]+')
 
-    def __getitem__(self, item: str) -> Optional[Union["PathDistribution", "Distribution"]]:
+    def __getitem__(self, item: str) -> "PathDistribution" | "Distribution" | None:
         item = self._canonical_regex.sub('-', item).lower()
         possible_distribution = self._distributions.get(item)
         if possible_distribution is not None:
@@ -38,7 +40,7 @@ class DistributionCache:
 
 
 def dependency_in_sync(
-    requirement: Requirement, environment: Dict[str, str], installed_distributions: DistributionCache
+    requirement: Requirement, environment: dict[str, str], installed_distributions: DistributionCache
 ) -> bool:
     if requirement.marker and not requirement.marker.evaluate(environment):
         return True
@@ -101,9 +103,9 @@ def dependency_in_sync(
 
 
 def dependencies_in_sync(
-    requirements: List[Union[Requirement, Any]],
-    sys_path: Optional[List[str]] = None,
-    environment: Optional[Dict[str, str]] = None,
+    requirements: list[Requirement | Any],
+    sys_path: list[str] | None = None,
+    environment: dict[str, str] | None = None,
 ) -> bool:
     if sys_path is None:
         sys_path = sys.path

--- a/backend/src/hatchling/dep/core.py
+++ b/backend/src/hatchling/dep/core.py
@@ -18,7 +18,7 @@ class DistributionCache:
         self._search_exhausted = False
         self._canonical_regex = re.compile(r'[-_.]+')
 
-    def __getitem__(self, item: str) -> Optional["PathDistribution"]:
+    def __getitem__(self, item: str) -> Optional[Union["PathDistribution", "Distribution"]]:
         item = self._canonical_regex.sub('-', item).lower()
         possible_distribution = self._distributions.get(item)
         if possible_distribution is not None:
@@ -29,7 +29,7 @@ class DistributionCache:
             return
 
         for distribution in self._resolver:
-            name = self._canonical_regex.sub('-', distribution.metadata.get('Name')).lower()
+            name = self._canonical_regex.sub('-', distribution.metadata.__getitem__('Name')).lower()
             self._distributions[name] = distribution
             if name == item:
                 return distribution

--- a/backend/src/hatchling/dep/core.py
+++ b/backend/src/hatchling/dep/core.py
@@ -20,7 +20,7 @@ class DistributionCache:
         self._search_exhausted = False
         self._canonical_regex = re.compile(r'[-_.]+')
 
-    def __getitem__(self, item: str) -> "PathDistribution" | "Distribution" | None:
+    def __getitem__(self, item: str) -> 'PathDistribution' | 'Distribution' | None:
         item = self._canonical_regex.sub('-', item).lower()
         possible_distribution = self._distributions.get(item)
         if possible_distribution is not None:

--- a/backend/src/hatchling/licenses/parse.py
+++ b/backend/src/hatchling/licenses/parse.py
@@ -74,7 +74,7 @@ def normalize_license_expression(raw_license_expression: str) -> str:
             if token not in valid_licenses:
                 raise ValueError(f'unknown license: {token}')
 
-            normalized_tokens.append(valid_licenses[token]['id'] + suffix)
+            normalized_tokens.append(str(valid_licenses[token]['id']) + suffix)
 
     # Construct the normalized expression
     normalized_expression = ' '.join(normalized_tokens)

--- a/backend/src/hatchling/licenses/parse.py
+++ b/backend/src/hatchling/licenses/parse.py
@@ -1,9 +1,9 @@
-from typing import Dict, Union
+from __future__ import annotations
 
 from hatchling.licenses.supported import EXCEPTIONS, LICENSES
 
 
-def get_valid_licenses() -> Dict[str, Dict[str, Union[bool, str]]]:
+def get_valid_licenses() -> dict[str, dict[str, bool | str]]:
     valid_licenses = LICENSES.copy()
 
     # https://peps.python.org/pep-0639/#should-custom-license-identifiers-be-allowed

--- a/backend/src/hatchling/licenses/parse.py
+++ b/backend/src/hatchling/licenses/parse.py
@@ -1,7 +1,9 @@
+from typing import Dict, Union
+
 from hatchling.licenses.supported import EXCEPTIONS, LICENSES
 
 
-def get_valid_licenses():
+def get_valid_licenses() -> Dict[str, Dict[str, Union[bool, str]]]:
     valid_licenses = LICENSES.copy()
 
     # https://peps.python.org/pep-0639/#should-custom-license-identifiers-be-allowed
@@ -14,7 +16,7 @@ def get_valid_licenses():
     return valid_licenses
 
 
-def normalize_license_expression(raw_license_expression):
+def normalize_license_expression(raw_license_expression: str) -> str:
     if not raw_license_expression:
         return raw_license_expression
 

--- a/backend/src/hatchling/metadata/classifiers.py
+++ b/backend/src/hatchling/metadata/classifiers.py
@@ -1,4 +1,4 @@
-from typing import Set
+from __future__ import annotations
 
 VERSION = '2022.8.7'
 
@@ -809,7 +809,7 @@ SORTED_CLASSIFIERS = [
     'Typing :: Stubs Only',
     'Typing :: Typed',
 ]
-KNOWN_CLASSIFIERS: Set[str] = set(SORTED_CLASSIFIERS)
+KNOWN_CLASSIFIERS: set[str] = set(SORTED_CLASSIFIERS)
 
 
 def is_private(classifier: str) -> bool:

--- a/backend/src/hatchling/metadata/classifiers.py
+++ b/backend/src/hatchling/metadata/classifiers.py
@@ -1,3 +1,5 @@
+from typing import Set
+
 VERSION = '2022.8.7'
 
 SORTED_CLASSIFIERS = [
@@ -807,8 +809,8 @@ SORTED_CLASSIFIERS = [
     'Typing :: Stubs Only',
     'Typing :: Typed',
 ]
-KNOWN_CLASSIFIERS = set(SORTED_CLASSIFIERS)
+KNOWN_CLASSIFIERS: Set[str] = set(SORTED_CLASSIFIERS)
 
 
-def is_private(classifier):
+def is_private(classifier: str) -> bool:
     return classifier.lower().startswith('private ::')

--- a/backend/src/hatchling/metadata/core.py
+++ b/backend/src/hatchling/metadata/core.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from copy import deepcopy
+from typing import Any, Dict
 
 from hatchling.metadata.utils import get_normalized_dependency, is_valid_project_name, normalize_project_name
 from hatchling.utils.constants import DEFAULT_CONFIG_FILE
@@ -12,13 +13,13 @@ else:
     import tomli as tomllib
 
 
-def load_toml(path):
+def load_toml(path) -> Dict[str, Any]:
     with open(path, encoding='utf-8') as f:
         return tomllib.loads(f.read())
 
 
 class ProjectMetadata:
-    def __init__(self, root, plugin_manager, config=None):
+    def __init__(self, root, plugin_manager, config=None) -> None:
         self.root = root
         self.plugin_manager = plugin_manager
         self._config = config
@@ -186,7 +187,7 @@ class ProjectMetadata:
 
         return self._hatch
 
-    def _set_version(self, core_metadata=None):
+    def _set_version(self, core_metadata=None) -> None:
         if core_metadata is None:
             core_metadata = self.core
 
@@ -210,7 +211,7 @@ class ProjectMetadata:
         else:
             self._version = normalized_version
 
-    def validate_fields(self):
+    def validate_fields(self) -> None:
         _ = self.version
         self.core.validate_fields()
 
@@ -220,7 +221,7 @@ class BuildMetadata:
     https://peps.python.org/pep-0517/
     """
 
-    def __init__(self, root, config):
+    def __init__(self, root, config) -> None:
         self.root = root
         self.config = config
 
@@ -292,7 +293,7 @@ class CoreMetadata:
     https://peps.python.org/pep-0621/
     """
 
-    def __init__(self, root, config, hatch_metadata, context):
+    def __init__(self, root, config, hatch_metadata, context) -> None:
         self.root = root
         self.config = config
         self.hatch_metadata = hatch_metadata
@@ -1188,17 +1189,17 @@ class CoreMetadata:
 
         return self._dynamic
 
-    def add_known_classifiers(self, classifiers):
+    def add_known_classifiers(self, classifiers) -> None:
         self._extra_classifiers.update(classifiers)
 
-    def validate_fields(self):
+    def validate_fields(self) -> None:
         # Trigger validation for everything
         for attribute in dir(self):
             getattr(self, attribute)
 
 
 class HatchMetadata:
-    def __init__(self, root, config, plugin_manager):
+    def __init__(self, root, config, plugin_manager) -> None:
         self.root = root
         self.config = config
         self.plugin_manager = plugin_manager
@@ -1257,7 +1258,7 @@ class HatchMetadata:
 
 
 class HatchVersionConfig:
-    def __init__(self, root, config, plugin_manager):
+    def __init__(self, root, config, plugin_manager) -> None:
         self.root = root
         self.config = config
         self.plugin_manager = plugin_manager
@@ -1342,7 +1343,7 @@ class HatchVersionConfig:
 
 
 class HatchMetadataSettings:
-    def __init__(self, root, config, plugin_manager):
+    def __init__(self, root, config, plugin_manager) -> None:
         self.root = root
         self.config = config
         self.plugin_manager = plugin_manager

--- a/backend/src/hatchling/metadata/core.py
+++ b/backend/src/hatchling/metadata/core.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import os
 import sys
 from copy import deepcopy
-from typing import Any, Dict
+from typing import Any
 
 from hatchling.metadata.utils import get_normalized_dependency, is_valid_project_name, normalize_project_name
 from hatchling.utils.constants import DEFAULT_CONFIG_FILE
@@ -13,7 +15,7 @@ else:
     import tomli as tomllib
 
 
-def load_toml(path) -> Dict[str, Any]:
+def load_toml(path) -> dict[str, Any]:
     with open(path, encoding='utf-8') as f:
         return tomllib.loads(f.read())
 

--- a/backend/src/hatchling/metadata/core.py
+++ b/backend/src/hatchling/metadata/core.py
@@ -40,6 +40,8 @@ class ProjectMetadata:
 
     def has_project_file(self):
         _ = self.config
+        if not self._project_file:
+            return False
         return os.path.isfile(self._project_file)
 
     @property

--- a/backend/src/hatchling/metadata/plugin/interface.py
+++ b/backend/src/hatchling/metadata/plugin/interface.py
@@ -35,7 +35,7 @@ class MetadataHookInterface(ABC):  # no cov
     PLUGIN_NAME = ''
     """The name used for selection."""
 
-    def __init__(self, root, config):
+    def __init__(self, root, config) -> None:
         self.__root = root
         self.__config = config
 

--- a/backend/src/hatchling/metadata/utils.py
+++ b/backend/src/hatchling/metadata/utils.py
@@ -1,19 +1,25 @@
 import re
+from typing import TYPE_CHECKING, Dict, List, Union
+
+if TYPE_CHECKING:
+    from packaging.requirements import Requirement
+
+    from hatchling.metadata.core import ProjectMetadata
 
 # NOTE: this module should rarely be changed because it is likely to be used by other packages like Hatch
 
 
-def is_valid_project_name(project_name):
+def is_valid_project_name(project_name: str) -> bool:
     # https://peps.python.org/pep-0508/#names
     return re.search('^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$', project_name, re.IGNORECASE) is not None
 
 
-def normalize_project_name(project_name):
+def normalize_project_name(project_name: str) -> str:
     # https://peps.python.org/pep-0503/#normalized-names
     return re.sub(r'[-_.]+', '-', project_name).lower()
 
 
-def get_normalized_dependency(requirement):
+def get_normalized_dependency(requirement: "Requirement") -> str:
     # Changes to this function affect reproducibility between versions
     from packaging.specifiers import SpecifierSet
 
@@ -29,7 +35,9 @@ def get_normalized_dependency(requirement):
     return str(requirement).replace('"', "'")
 
 
-def resolve_metadata_fields(metadata):
+def resolve_metadata_fields(
+    metadata: "ProjectMetadata",
+) -> Dict[str, Union[str, Dict[str, str], List[Dict[str, str]], List[str]]]:
     # https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
     return {
         'name': metadata.core.name,

--- a/backend/src/hatchling/metadata/utils.py
+++ b/backend/src/hatchling/metadata/utils.py
@@ -1,5 +1,8 @@
+# TODO: tidy up complex type hints
+from __future__ import annotations
+
 import re
-from typing import TYPE_CHECKING, Dict, List, Union
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from packaging.requirements import Requirement
@@ -37,7 +40,7 @@ def get_normalized_dependency(requirement: "Requirement") -> str:
 
 def resolve_metadata_fields(
     metadata: "ProjectMetadata",
-) -> Dict[str, Union[str, Dict[str, str], List[Dict[str, str]], List[str]]]:
+) -> dict[str, str | dict[str, str] | list[dict[str, str]] | list[str]]:
     # https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
     return {
         'name': metadata.core.name,

--- a/backend/src/hatchling/metadata/utils.py
+++ b/backend/src/hatchling/metadata/utils.py
@@ -22,7 +22,7 @@ def normalize_project_name(project_name: str) -> str:
     return re.sub(r'[-_.]+', '-', project_name).lower()
 
 
-def get_normalized_dependency(requirement: "Requirement") -> str:
+def get_normalized_dependency(requirement: 'Requirement') -> str:
     # Changes to this function affect reproducibility between versions
     from packaging.specifiers import SpecifierSet
 
@@ -39,7 +39,7 @@ def get_normalized_dependency(requirement: "Requirement") -> str:
 
 
 def resolve_metadata_fields(
-    metadata: "ProjectMetadata",
+    metadata: 'ProjectMetadata',
 ) -> dict[str, str | dict[str, str] | list[dict[str, str]] | list[str]]:
     # https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
     return {

--- a/backend/src/hatchling/metadata/utils.py
+++ b/backend/src/hatchling/metadata/utils.py
@@ -56,4 +56,4 @@ def resolve_metadata_fields(
         'entry-points': metadata.core.entry_points,
         'dependencies': metadata.core.dependencies,
         'optional-dependencies': metadata.core.optional_dependencies,
-    }
+    }  # type: ignore

--- a/backend/src/hatchling/ouroboros.py
+++ b/backend/src/hatchling/ouroboros.py
@@ -84,14 +84,18 @@ def build_editable(wheel_directory, config_settings=None, metadata_directory=Non
     return os.path.basename(next(builder.build(wheel_directory, ['editable'])))
 
 
-def get_requires_for_build_sdist(config_settings=None) -> dict[str, dict[str, str]] | dict[str, str] | list[dict[str, str]] | list[str] | str:
+def get_requires_for_build_sdist(
+    config_settings=None,
+) -> dict[str, dict[str, str]] | dict[str, str] | list[dict[str, str]] | list[str] | str:
     """
     https://peps.python.org/pep-0517/#get-requires-for-build-sdist
     """
     return CONFIG['project']['dependencies']
 
 
-def get_requires_for_build_wheel(config_settings=None) -> dict[str, dict[str, str]] | dict[str, str] | list[dict[str, str]] | list[str] | str:
+def get_requires_for_build_wheel(
+    config_settings=None,
+) -> dict[str, dict[str, str]] | dict[str, str] | list[dict[str, str]] | list[str] | str:
     """
     https://peps.python.org/pep-0517/#get-requires-for-build-wheel
     """
@@ -116,7 +120,9 @@ def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
     return os.path.basename(directory)
 
 
-def get_requires_for_build_editable(config_settings=None) -> dict[str, dict[str, str]] | dict[str, str] | list[dict[str, str]] | list[str] | str:
+def get_requires_for_build_editable(
+    config_settings=None,
+) -> dict[str, dict[str, str]] | dict[str, str] | list[dict[str, str]] | list[str] | str:
     """
     https://peps.python.org/pep-0660/#get-requires-for-build-editable
     """

--- a/backend/src/hatchling/ouroboros.py
+++ b/backend/src/hatchling/ouroboros.py
@@ -1,4 +1,5 @@
 import os
+from typing import Dict, List, Union
 
 CONFIG = {
     'project': {
@@ -81,14 +82,14 @@ def build_editable(wheel_directory, config_settings=None, metadata_directory=Non
     return os.path.basename(next(builder.build(wheel_directory, ['editable'])))
 
 
-def get_requires_for_build_sdist(config_settings=None):
+def get_requires_for_build_sdist(config_settings=None) -> Union[Dict[str, Dict[str, str]], Dict[str, str], List[Dict[str, str]], List[str], str]:
     """
     https://peps.python.org/pep-0517/#get-requires-for-build-sdist
     """
     return CONFIG['project']['dependencies']
 
 
-def get_requires_for_build_wheel(config_settings=None):
+def get_requires_for_build_wheel(config_settings=None) -> Union[Dict[str, Dict[str, str]], Dict[str, str], List[Dict[str, str]], List[str], str]:
     """
     https://peps.python.org/pep-0517/#get-requires-for-build-wheel
     """
@@ -113,7 +114,7 @@ def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
     return os.path.basename(directory)
 
 
-def get_requires_for_build_editable(config_settings=None):
+def get_requires_for_build_editable(config_settings=None) -> Union[Dict[str, Dict[str, str]], Dict[str, str], List[Dict[str, str]], List[str], str]:
     """
     https://peps.python.org/pep-0660/#get-requires-for-build-editable
     """

--- a/backend/src/hatchling/ouroboros.py
+++ b/backend/src/hatchling/ouroboros.py
@@ -1,5 +1,7 @@
+# TODO: fix complex type hints
+from __future__ import annotations
+
 import os
-from typing import Dict, List, Union
 
 CONFIG = {
     'project': {
@@ -82,14 +84,14 @@ def build_editable(wheel_directory, config_settings=None, metadata_directory=Non
     return os.path.basename(next(builder.build(wheel_directory, ['editable'])))
 
 
-def get_requires_for_build_sdist(config_settings=None) -> Union[Dict[str, Dict[str, str]], Dict[str, str], List[Dict[str, str]], List[str], str]:
+def get_requires_for_build_sdist(config_settings=None) -> dict[str, dict[str, str]] | dict[str, str] | list[dict[str, str]] | list[str] | str:
     """
     https://peps.python.org/pep-0517/#get-requires-for-build-sdist
     """
     return CONFIG['project']['dependencies']
 
 
-def get_requires_for_build_wheel(config_settings=None) -> Union[Dict[str, Dict[str, str]], Dict[str, str], List[Dict[str, str]], List[str], str]:
+def get_requires_for_build_wheel(config_settings=None) -> dict[str, dict[str, str]] | dict[str, str] | list[dict[str, str]] | list[str] | str:
     """
     https://peps.python.org/pep-0517/#get-requires-for-build-wheel
     """
@@ -114,7 +116,7 @@ def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
     return os.path.basename(directory)
 
 
-def get_requires_for_build_editable(config_settings=None) -> Union[Dict[str, Dict[str, str]], Dict[str, str], List[Dict[str, str]], List[str], str]:
+def get_requires_for_build_editable(config_settings=None) -> dict[str, dict[str, str]] | dict[str, str] | list[dict[str, str]] | list[str] | str:
     """
     https://peps.python.org/pep-0660/#get-requires-for-build-editable
     """

--- a/backend/src/hatchling/plugin/manager.py
+++ b/backend/src/hatchling/plugin/manager.py
@@ -2,17 +2,17 @@ import pluggy
 
 
 class PluginManager:
-    def __init__(self):
+    def __init__(self) -> None:
         self.manager = pluggy.PluginManager('hatch')
         self.third_party_plugins = ThirdPartyPlugins(self.manager)
         self.initialized = False
 
-    def initialize(self):
+    def initialize(self) -> None:
         from hatchling.plugin import specs
 
         self.manager.add_hookspecs(specs)
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> "ClassRegister":
         if not self.initialized:
             self.initialize()
             self.initialized = True
@@ -24,39 +24,39 @@ class PluginManager:
         setattr(self, name, register)
         return register
 
-    def hatch_register_version_source(self):
+    def hatch_register_version_source(self) -> None:
         from hatchling.version.source.plugin import hooks
 
         self.manager.register(hooks)
 
-    def hatch_register_version_scheme(self):
+    def hatch_register_version_scheme(self) -> None:
         from hatchling.version.scheme.plugin import hooks
 
         self.manager.register(hooks)
 
-    def hatch_register_builder(self):
+    def hatch_register_builder(self) -> None:
         from hatchling.builders.plugin import hooks
 
         self.manager.register(hooks)
 
-    def hatch_register_build_hook(self):
+    def hatch_register_build_hook(self) -> None:
         from hatchling.builders.hooks.plugin import hooks
 
         self.manager.register(hooks)
 
-    def hatch_register_metadata_hook(self):
+    def hatch_register_metadata_hook(self) -> None:
         from hatchling.metadata.plugin import hooks
 
         self.manager.register(hooks)
 
 
 class ClassRegister:
-    def __init__(self, registration_method, identifier, third_party_plugins):
+    def __init__(self, registration_method, identifier, third_party_plugins) -> None:
         self.registration_method = registration_method
         self.identifier = identifier
         self.third_party_plugins = third_party_plugins
 
-    def collect(self, include_third_party=True):
+    def collect(self, include_third_party: bool=True):
         if include_third_party and not self.third_party_plugins.loaded:
             self.third_party_plugins.load()
 
@@ -90,10 +90,10 @@ class ClassRegister:
 
 
 class ThirdPartyPlugins:
-    def __init__(self, manager):
+    def __init__(self, manager) -> None:
         self.manager = manager
         self.loaded = False
 
-    def load(self):
+    def load(self) -> None:
         self.manager.load_setuptools_entrypoints('hatch')
         self.loaded = True

--- a/backend/src/hatchling/plugin/manager.py
+++ b/backend/src/hatchling/plugin/manager.py
@@ -56,7 +56,7 @@ class ClassRegister:
         self.identifier = identifier
         self.third_party_plugins = third_party_plugins
 
-    def collect(self, include_third_party: bool=True):
+    def collect(self, include_third_party: bool = True):
         if include_third_party and not self.third_party_plugins.loaded:
             self.third_party_plugins.load()
 

--- a/backend/src/hatchling/plugin/manager.py
+++ b/backend/src/hatchling/plugin/manager.py
@@ -12,7 +12,7 @@ class PluginManager:
 
         self.manager.add_hookspecs(specs)
 
-    def __getattr__(self, name: str) -> "ClassRegister":
+    def __getattr__(self, name: str) -> 'ClassRegister':
         if not self.initialized:
             self.initialize()
             self.initialized = True

--- a/backend/src/hatchling/plugin/manager.py
+++ b/backend/src/hatchling/plugin/manager.py
@@ -18,7 +18,7 @@ class PluginManager:
             self.initialized = True
 
         hook_name = f'hatch_register_{name}'
-        getattr(self, hook_name, None)()
+        getattr(self, hook_name, None)()  # BUG: fallback to `None` cannot be called
 
         register = ClassRegister(getattr(self.manager.hook, hook_name), 'PLUGIN_NAME', self.third_party_plugins)
         setattr(self, name, register)

--- a/backend/src/hatchling/plugin/specs.py
+++ b/backend/src/hatchling/plugin/specs.py
@@ -4,20 +4,20 @@ hookspec = pluggy.HookspecMarker('hatch')
 
 
 @hookspec
-def hatch_register_version_source():
+def hatch_register_version_source() -> None:
     """Register new classes that adhere to the version source interface."""
 
 
 @hookspec
-def hatch_register_builder():
+def hatch_register_builder() -> None:
     """Register new classes that adhere to the builder interface."""
 
 
 @hookspec
-def hatch_register_build_hook():
+def hatch_register_build_hook() -> None:
     """Register new classes that adhere to the build hook interface."""
 
 
 @hookspec
-def hatch_register_metadata_hook():
+def hatch_register_metadata_hook() -> None:
     """Register new classes that adhere to the metadata hook interface."""

--- a/backend/src/hatchling/plugin/utils.py
+++ b/backend/src/hatchling/plugin/utils.py
@@ -1,5 +1,13 @@
-def load_plugin_from_script(path, script_name, plugin_class, plugin_id):
-    import importlib
+from typing import Type
+
+
+def load_plugin_from_script(
+    path: str,
+    script_name: str,
+    plugin_class: Type,
+    plugin_id: str,
+):
+    import importlib.util
 
     spec = importlib.util.spec_from_file_location(script_name, path)
     module = importlib.util.module_from_spec(spec)

--- a/backend/src/hatchling/plugin/utils.py
+++ b/backend/src/hatchling/plugin/utils.py
@@ -1,10 +1,10 @@
-from typing import Type
+from __future__ import annotations
 
 
 def load_plugin_from_script(
     path: str,
     script_name: str,
-    plugin_class: Type,
+    plugin_class: type,
     plugin_id: str,
 ):
     import importlib.util

--- a/backend/src/hatchling/plugin/utils.py
+++ b/backend/src/hatchling/plugin/utils.py
@@ -10,8 +10,10 @@ def load_plugin_from_script(
     import importlib.util
 
     spec = importlib.util.spec_from_file_location(script_name, path)
+    if spec is None:
+        raise ImportError(f'Could not load plugin from {path}')
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    spec.loader.exec_module(module)  # type: ignore
 
     plugin_finder = f'get_{plugin_id}'
     names = dir(module)

--- a/backend/src/hatchling/utils/context.py
+++ b/backend/src/hatchling/utils/context.py
@@ -131,9 +131,7 @@ class ContextStringFormatter(Formatter):
         self.check_unused_args(used_args, args, kwargs)
         return result
 
-    def get_value(
-        self, key: str | int, args: tuple[str] | tuple[()], kwargs: dict[str, str | None]
-    ) -> str | None:
+    def get_value(self, key: str | int, args: tuple[str] | tuple[()], kwargs: dict[str, str | None]) -> str | None:
         if key in self.__formatters:
             # Avoid hard look-up and rely on `None` to indicate that the field is undefined
             return kwargs.get(key)

--- a/backend/src/hatchling/utils/context.py
+++ b/backend/src/hatchling/utils/context.py
@@ -82,7 +82,7 @@ class DefaultContextFormatter(ContextFormatter):
 
 
 class Context:
-    def __init__(self, root: Union[str, "Path"]) -> None:
+    def __init__(self, root: Union[str, 'Path']) -> None:
         self.__root = str(root)
 
         # Allow callers to define their own formatters with precedence
@@ -103,7 +103,7 @@ class Context:
         self.__configured_contexts.add(context.CONTEXT_NAME)
 
     @contextmanager
-    def apply_context(self, context: "EnvironmentContextFormatter") -> Iterator[None]:
+    def apply_context(self, context: 'EnvironmentContextFormatter') -> Iterator[None]:
         self.__add_formatters(context.get_formatters())
         try:
             yield
@@ -124,7 +124,7 @@ class ContextStringFormatter(Formatter):
 
     def vformat(
         self, format_string: str, args: tuple[str] | tuple[()], kwargs: dict[str, str | None]
-    ) -> "LiteralString":
+    ) -> 'LiteralString':
         # We override to increase the recursion limit from 2 to 10
         used_args = set()
         result, _ = self._vformat(format_string, args, kwargs, used_args, 10)

--- a/backend/src/hatchling/utils/context.py
+++ b/backend/src/hatchling/utils/context.py
@@ -9,13 +9,12 @@ from contextlib import contextmanager
 from string import Formatter
 from typing import TYPE_CHECKING, Union
 
-from typing_extensions import LiteralString
-
 from hatchling.utils.fs import path_to_uri
 
 if TYPE_CHECKING:
     from hatch.env.context import EnvironmentContextFormatter
     from hatch.utils.fs import Path
+    from typing_extensions import LiteralString
 
 class ContextFormatter(ABC):
     @abstractmethod
@@ -121,7 +120,7 @@ class ContextStringFormatter(Formatter):
     def __init__(self, formatters: ChainMap) -> None:
         self.__formatters = formatters
 
-    def vformat(self, format_string: str, args: tuple[str] | tuple[()], kwargs: dict[str, str | None]) -> LiteralString:
+    def vformat(self, format_string: str, args: tuple[str] | tuple[()], kwargs: dict[str, str | None]) -> "LiteralString":
         # We override to increase the recursion limit from 2 to 10
         used_args = set()
         result, _ = self._vformat(format_string, args, kwargs, used_args, 10)

--- a/backend/src/hatchling/utils/context.py
+++ b/backend/src/hatchling/utils/context.py
@@ -12,9 +12,11 @@ from typing import TYPE_CHECKING, Union
 from hatchling.utils.fs import path_to_uri
 
 if TYPE_CHECKING:
+    from typing_extensions import LiteralString
+
     from hatch.env.context import EnvironmentContextFormatter
     from hatch.utils.fs import Path
-    from typing_extensions import LiteralString
+
 
 class ContextFormatter(ABC):
     @abstractmethod
@@ -120,7 +122,9 @@ class ContextStringFormatter(Formatter):
     def __init__(self, formatters: ChainMap) -> None:
         self.__formatters = formatters
 
-    def vformat(self, format_string: str, args: tuple[str] | tuple[()], kwargs: dict[str, str | None]) -> "LiteralString":
+    def vformat(
+        self, format_string: str, args: tuple[str] | tuple[()], kwargs: dict[str, str | None]
+    ) -> "LiteralString":
         # We override to increase the recursion limit from 2 to 10
         used_args = set()
         result, _ = self._vformat(format_string, args, kwargs, used_args, 10)

--- a/backend/src/hatchling/utils/context.py
+++ b/backend/src/hatchling/utils/context.py
@@ -143,7 +143,7 @@ class ContextStringFormatter(Formatter):
         else:
             return super().format_field(value, format_spec)
 
-    def parse(self, format_string: str) -> Iterator[Union[Tuple[str, None, None, None], Tuple[str, str, str, None]]]:
+    def parse(self, format_string: str) -> Iterator[Tuple[str, Optional[str], Optional[str], Optional[str]]]:
         for literal_text, field_name, format_spec, conversion in super().parse(format_string):
             if field_name in self.__formatters:
                 yield literal_text, field_name, f'{field_name}:{format_spec}', conversion

--- a/backend/src/hatchling/utils/fs.py
+++ b/backend/src/hatchling/utils/fs.py
@@ -1,11 +1,13 @@
+from __future__ import annotations
+
 import os
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     from hatch.utils.fs import Path
 
 
-def locate_file(root: str, file_name: str) -> Optional[str]:
+def locate_file(root: str, file_name: str) -> str | None:
     while True:
         file_path = os.path.join(root, file_name)
         if os.path.isfile(file_path):

--- a/backend/src/hatchling/utils/fs.py
+++ b/backend/src/hatchling/utils/fs.py
@@ -1,7 +1,11 @@
 import os
+from typing import TYPE_CHECKING, Optional, Union
+
+if TYPE_CHECKING:
+    from hatch.utils.fs import Path
 
 
-def locate_file(root, file_name):
+def locate_file(root: str, file_name: str) -> Optional[str]:
     while True:
         file_path = os.path.join(root, file_name)
         if os.path.isfile(file_path):
@@ -14,7 +18,7 @@ def locate_file(root, file_name):
         root = new_root
 
 
-def path_to_uri(path):
+def path_to_uri(path: Union[str, "Path"]) -> str:
     if os.sep == '/':
         return f'file://{os.path.abspath(path)}'
     else:

--- a/backend/src/hatchling/utils/fs.py
+++ b/backend/src/hatchling/utils/fs.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from hatch.utils.fs import Path
@@ -20,7 +20,7 @@ def locate_file(root: str, file_name: str) -> str | None:
         root = new_root
 
 
-def path_to_uri(path: Union[str, "Path"]) -> str:
+def path_to_uri(path: str | 'Path') -> str:
     if os.sep == '/':
         return f'file://{os.path.abspath(path)}'
     else:

--- a/backend/src/hatchling/version/core.py
+++ b/backend/src/hatchling/version/core.py
@@ -14,7 +14,7 @@ __version__ = VERSION = {version!r}
 
 
 class VersionFile:
-    def __init__(self, root: str, relative_path: str):
+    def __init__(self, root: str, relative_path: str) -> None:
         self.__relative_path = relative_path
         self.__path = os.path.normpath(os.path.join(root, relative_path))
         self.__cached_read_data: tuple | None = None
@@ -40,12 +40,12 @@ class VersionFile:
         self.__cached_read_data = groups['version'], contents, match.span('version')
         return self.__cached_read_data[0]
 
-    def set_version(self, version: str):
+    def set_version(self, version: str) -> None:
         old_version, file_contents, (start, end) = self.__cached_read_data  # type: ignore
         with open(self.__path, 'w', encoding='utf-8') as f:
             f.write(f'{file_contents[:start]}{version}{file_contents[end:]}')
 
-    def write(self, version: str, template: str = DEFAULT_TEMPLATE):
+    def write(self, version: str, template: str = DEFAULT_TEMPLATE) -> None:
         template = template or DEFAULT_TEMPLATE
 
         parent_dir = os.path.dirname(self.__path)

--- a/backend/src/hatchling/version/scheme/plugin/interface.py
+++ b/backend/src/hatchling/version/scheme/plugin/interface.py
@@ -35,7 +35,7 @@ class VersionSchemeInterface(ABC):  # no cov
     PLUGIN_NAME = ''
     """The name used for selection."""
 
-    def __init__(self, root, config):
+    def __init__(self, root, config) -> None:
         self.__root = root
         self.__config = config
 

--- a/backend/src/hatchling/version/scheme/standard.py
+++ b/backend/src/hatchling/version/scheme/standard.py
@@ -1,4 +1,11 @@
+from typing import TYPE_CHECKING, Dict, List, Tuple, Union
+
 from hatchling.version.scheme.plugin.interface import VersionSchemeInterface
+
+if TYPE_CHECKING:
+    from packaging.version import Version
+
+    from hatchling.version.core import VersionFile
 
 
 class StandardScheme(VersionSchemeInterface):
@@ -8,7 +15,9 @@ class StandardScheme(VersionSchemeInterface):
 
     PLUGIN_NAME = 'standard'
 
-    def update(self, desired_version, original_version, version_data):
+    def update(
+        self, desired_version: str, original_version: str, version_data: Dict[str, Union[str, "VersionFile"]]
+    ) -> str:
         from packaging.version import Version, _parse_letter_version
 
         original = Version(original_version)
@@ -54,7 +63,7 @@ class StandardScheme(VersionSchemeInterface):
         return str(original)
 
 
-def reset_version_parts(version, **kwargs):
+def reset_version_parts(version: "Version", **kwargs) -> None:
     # https://github.com/pypa/packaging/blob/20.9/packaging/version.py#L301-L310
     internal_version = version._version
     parts = {'epoch': 0}
@@ -73,7 +82,7 @@ def reset_version_parts(version, **kwargs):
     version._version = type(internal_version)(**parts)
 
 
-def update_release(original_version, new_release_parts):
+def update_release(original_version: "Version", new_release_parts: List[int]) -> Tuple[int, int, int]:
     # Retain release length
     for _ in range(len(original_version.release) - len(new_release_parts)):
         new_release_parts.append(0)

--- a/backend/src/hatchling/version/scheme/standard.py
+++ b/backend/src/hatchling/version/scheme/standard.py
@@ -1,4 +1,6 @@
-from typing import TYPE_CHECKING, Dict, List, Tuple, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Union
 
 from hatchling.version.scheme.plugin.interface import VersionSchemeInterface
 
@@ -16,7 +18,7 @@ class StandardScheme(VersionSchemeInterface):
     PLUGIN_NAME = 'standard'
 
     def update(
-        self, desired_version: str, original_version: str, version_data: Dict[str, Union[str, "VersionFile"]]
+        self, desired_version: str, original_version: str, version_data: dict[str, Union[str, "VersionFile"]]
     ) -> str:
         from packaging.version import Version, _parse_letter_version
 
@@ -82,7 +84,7 @@ def reset_version_parts(version: "Version", **kwargs) -> None:
     version._version = type(internal_version)(**parts)
 
 
-def update_release(original_version: "Version", new_release_parts: List[int]) -> Tuple[int, int, int]:
+def update_release(original_version: "Version", new_release_parts: list[int]) -> tuple[int, int, int]:
     # Retain release length
     for _ in range(len(original_version.release) - len(new_release_parts)):
         new_release_parts.append(0)

--- a/backend/src/hatchling/version/scheme/standard.py
+++ b/backend/src/hatchling/version/scheme/standard.py
@@ -18,7 +18,7 @@ class StandardScheme(VersionSchemeInterface):
     PLUGIN_NAME = 'standard'
 
     def update(
-        self, desired_version: str, original_version: str, version_data: dict[str, Union[str, "VersionFile"]]
+        self, desired_version: str, original_version: str, version_data: dict[str, Union[str, 'VersionFile']]
     ) -> str:
         from packaging.version import Version, _parse_letter_version
 
@@ -65,7 +65,7 @@ class StandardScheme(VersionSchemeInterface):
         return str(original)
 
 
-def reset_version_parts(version: "Version", **kwargs) -> None:
+def reset_version_parts(version: 'Version', **kwargs) -> None:
     # https://github.com/pypa/packaging/blob/20.9/packaging/version.py#L301-L310
     internal_version = version._version
     parts = {'epoch': 0}
@@ -84,7 +84,7 @@ def reset_version_parts(version: "Version", **kwargs) -> None:
     version._version = type(internal_version)(**parts)
 
 
-def update_release(original_version: "Version", new_release_parts: list[int]) -> tuple[int, int, int]:
+def update_release(original_version: 'Version', new_release_parts: list[int]) -> tuple[int, int, int]:
     # Retain release length
     for _ in range(len(original_version.release) - len(new_release_parts)):
         new_release_parts.append(0)

--- a/backend/src/hatchling/version/source/code.py
+++ b/backend/src/hatchling/version/source/code.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import os
-from typing import Dict
 
 from hatchling.version.source.plugin.interface import VersionSourceInterface
 
@@ -7,7 +8,7 @@ from hatchling.version.source.plugin.interface import VersionSourceInterface
 class CodeSource(VersionSourceInterface):
     PLUGIN_NAME = 'code'
 
-    def get_version_data(self) -> Dict[str, str]:
+    def get_version_data(self) -> dict[str, str]:
         import importlib.util
         import sys
 

--- a/backend/src/hatchling/version/source/code.py
+++ b/backend/src/hatchling/version/source/code.py
@@ -1,4 +1,5 @@
 import os
+from typing import Dict
 
 from hatchling.version.source.plugin.interface import VersionSourceInterface
 
@@ -6,8 +7,8 @@ from hatchling.version.source.plugin.interface import VersionSourceInterface
 class CodeSource(VersionSourceInterface):
     PLUGIN_NAME = 'code'
 
-    def get_version_data(self):
-        import importlib
+    def get_version_data(self) -> Dict[str, str]:
+        import importlib.util
         import sys
 
         relative_path = self.config.get('path')

--- a/backend/src/hatchling/version/source/plugin/hooks.py
+++ b/backend/src/hatchling/version/source/plugin/hooks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from hatchling.plugin import hookimpl
 from hatchling.version.source.code import CodeSource
 from hatchling.version.source.env import EnvSource
@@ -5,5 +7,5 @@ from hatchling.version.source.regex import RegexSource
 
 
 @hookimpl
-def hatch_register_version_source():
+def hatch_register_version_source() -> list[type[CodeSource] | type[RegexSource]]:
     return [CodeSource, EnvSource, RegexSource]

--- a/backend/src/hatchling/version/source/plugin/hooks.py
+++ b/backend/src/hatchling/version/source/plugin/hooks.py
@@ -7,5 +7,5 @@ from hatchling.version.source.regex import RegexSource
 
 
 @hookimpl
-def hatch_register_version_source() -> list[type[CodeSource] | type[RegexSource]]:
+def hatch_register_version_source() -> list[type[CodeSource] | type[EnvSource] | type[RegexSource]]:
     return [CodeSource, EnvSource, RegexSource]

--- a/backend/src/hatchling/version/source/plugin/interface.py
+++ b/backend/src/hatchling/version/source/plugin/interface.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Dict, List, Union
+from typing import TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     from hatch.utils.fs import Path
@@ -39,7 +39,7 @@ class VersionSourceInterface(ABC):  # no cov
     PLUGIN_NAME = ''
     """The name used for selection."""
 
-    def __init__(self, root: Union[str, "Path"], config: Dict[str, Union[int, str, List[int], List[str]]]) -> None:
+    def __init__(self, root: Union[str, "Path"], config: dict[str, int | str | list[int] | list[str]]) -> None:
         self.__root = root
         self.__config = config
 
@@ -51,7 +51,7 @@ class VersionSourceInterface(ABC):  # no cov
         return str(self.__root)
 
     @property
-    def config(self) -> Dict[str, Union[int, str, List[int], List[str]]]:
+    def config(self) -> dict[str, int | str | list[int] | list[str]]:
         """
         === ":octicons-file-code-16: pyproject.toml"
 

--- a/backend/src/hatchling/version/source/plugin/interface.py
+++ b/backend/src/hatchling/version/source/plugin/interface.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Dict, List, Union
+
+if TYPE_CHECKING:
+    from hatch.utils.fs import Path
 
 
 class VersionSourceInterface(ABC):  # no cov
@@ -35,19 +39,19 @@ class VersionSourceInterface(ABC):  # no cov
     PLUGIN_NAME = ''
     """The name used for selection."""
 
-    def __init__(self, root, config):
+    def __init__(self, root: Union[str, "Path"], config: Dict[str, Union[int, str, List[int], List[str]]]) -> None:
         self.__root = root
         self.__config = config
 
     @property
-    def root(self):
+    def root(self) -> str:
         """
         The root of the project tree as a string.
         """
-        return self.__root
+        return str(self.__root)
 
     @property
-    def config(self):
+    def config(self) -> Dict[str, Union[int, str, List[int], List[str]]]:
         """
         === ":octicons-file-code-16: pyproject.toml"
 

--- a/backend/src/hatchling/version/source/plugin/interface.py
+++ b/backend/src/hatchling/version/source/plugin/interface.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from hatch.utils.fs import Path
@@ -39,7 +39,7 @@ class VersionSourceInterface(ABC):  # no cov
     PLUGIN_NAME = ''
     """The name used for selection."""
 
-    def __init__(self, root: Union[str, "Path"], config: dict[str, int | str | list[int] | list[str]]) -> None:
+    def __init__(self, root: str | 'Path', config: dict[str, int | str | list[int] | list[str]]) -> None:
         self.__root = root
         self.__config = config
 

--- a/backend/src/hatchling/version/source/regex.py
+++ b/backend/src/hatchling/version/source/regex.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union
+from __future__ import annotations
 
 from hatchling.version.core import VersionFile
 from hatchling.version.source.plugin.interface import VersionSourceInterface
@@ -7,7 +7,7 @@ from hatchling.version.source.plugin.interface import VersionSourceInterface
 class RegexSource(VersionSourceInterface):
     PLUGIN_NAME = 'regex'
 
-    def get_version_data(self) -> Dict[str, Union[str, VersionFile]]:
+    def get_version_data(self) -> dict[str, str | VersionFile]:
         relative_path = self.config.get('path', '')
         if not relative_path:
             raise ValueError('option `path` must be specified')
@@ -23,5 +23,5 @@ class RegexSource(VersionSourceInterface):
 
         return {'version': version, 'version_file': version_file}
 
-    def set_version(self, version: str, version_data: Dict[str, Union[str, VersionFile]]) -> None:
+    def set_version(self, version: str, version_data: dict[str, str | VersionFile]) -> None:
         version_data['version_file'].set_version(version)

--- a/backend/src/hatchling/version/source/regex.py
+++ b/backend/src/hatchling/version/source/regex.py
@@ -1,3 +1,5 @@
+from typing import Dict, Union
+
 from hatchling.version.core import VersionFile
 from hatchling.version.source.plugin.interface import VersionSourceInterface
 
@@ -5,7 +7,7 @@ from hatchling.version.source.plugin.interface import VersionSourceInterface
 class RegexSource(VersionSourceInterface):
     PLUGIN_NAME = 'regex'
 
-    def get_version_data(self):
+    def get_version_data(self) -> Dict[str, Union[str, VersionFile]]:
         relative_path = self.config.get('path', '')
         if not relative_path:
             raise ValueError('option `path` must be specified')
@@ -21,5 +23,5 @@ class RegexSource(VersionSourceInterface):
 
         return {'version': version, 'version_file': version_file}
 
-    def set_version(self, version, version_data):
+    def set_version(self, version: str, version_data: Dict[str, Union[str, VersionFile]]) -> None:
         version_data['version_file'].set_version(version)

--- a/backend/tests/downstream/integrate.py
+++ b/backend/tests/downstream/integrate.py
@@ -15,12 +15,13 @@ import tomli
 from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
 from virtualenv import cli_run
+from typing import Union
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-ON_WINDOWS = platform.system() == 'Windows'
+ON_WINDOWS: bool = platform.system() == 'Windows'
 
 
-def handle_remove_readonly(func, path, exc):  # no cov
+def handle_remove_readonly(func, path: Union[os.PathLike[bytes], os.PathLike[str], bytes, int, str], exc) -> None:  # no cov
     # PermissionError: [WinError 5] Access is denied: '...\\.git\\...'
     if func in (os.rmdir, os.remove, os.unlink) and exc[1].errno == errno.EACCES:
         os.chmod(path, stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)
@@ -30,7 +31,7 @@ def handle_remove_readonly(func, path, exc):  # no cov
 
 
 class EnvVars(dict):
-    def __init__(self, env_vars=None, ignore=None):
+    def __init__(self, env_vars=None, ignore=None) -> None:
         super().__init__(os.environ)
         self.old_env = dict(self)
 
@@ -41,16 +42,16 @@ class EnvVars(dict):
             for env_var in ignore:
                 self.pop(env_var, None)
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         os.environ.clear()
         os.environ.update(self)
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
         os.environ.clear()
         os.environ.update(self.old_env)
 
 
-def python_version_supported(project_config):
+def python_version_supported(project_config) -> bool:
     requires_python = project_config['project'].get('requires-python', '')
     if requires_python:
         python_constraint = SpecifierSet(requires_python)
@@ -60,7 +61,7 @@ def python_version_supported(project_config):
     return True
 
 
-def download_file(url, file_name):
+def download_file(url: Union[bytes, str], file_name) -> None:
     response = requests.get(url, stream=True)
     with open(file_name, 'wb') as f:
         for chunk in response.iter_content(16384):
@@ -100,7 +101,7 @@ def get_venv_exe_dir(venv_dir):
         raise OSError(f'Unable to locate executables directory within: {venv_dir}')
 
 
-def main():
+def main() -> None:
     original_backend_path = os.path.dirname(os.path.dirname(HERE))
     with temp_dir() as links_dir, temp_dir() as build_dir:
         print('<<<<< Copying backend >>>>>')

--- a/backend/tests/downstream/integrate.py
+++ b/backend/tests/downstream/integrate.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import errno
 import json
 import os
@@ -15,13 +17,14 @@ import tomli
 from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
 from virtualenv import cli_run
-from typing import Union
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 ON_WINDOWS: bool = platform.system() == 'Windows'
 
 
-def handle_remove_readonly(func, path: Union[os.PathLike[bytes], os.PathLike[str], bytes, int, str], exc) -> None:  # no cov
+def handle_remove_readonly(
+    func, path: os.PathLike[bytes] | os.PathLike[str] |bytes | int | str, exc
+) -> None:  # no cov
     # PermissionError: [WinError 5] Access is denied: '...\\.git\\...'
     if func in (os.rmdir, os.remove, os.unlink) and exc[1].errno == errno.EACCES:
         os.chmod(path, stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)

--- a/backend/tests/downstream/integrate.py
+++ b/backend/tests/downstream/integrate.py
@@ -23,7 +23,7 @@ ON_WINDOWS: bool = platform.system() == 'Windows'
 
 
 def handle_remove_readonly(
-    func, path: os.PathLike[bytes] | os.PathLike[str] |bytes | int | str, exc
+    func, path: os.PathLike[bytes] | os.PathLike[str] | bytes | int | str, exc
 ) -> None:  # no cov
     # PermissionError: [WinError 5] Access is denied: '...\\.git\\...'
     if func in (os.rmdir, os.remove, os.unlink) and exc[1].errno == errno.EACCES:
@@ -64,7 +64,7 @@ def python_version_supported(project_config) -> bool:
     return True
 
 
-def download_file(url: Union[bytes, str], file_name) -> None:
+def download_file(url: bytes | str, file_name) -> None:
     response = requests.get(url, stream=True)
     with open(file_name, 'wb') as f:
         for chunk in response.iter_content(16384):

--- a/src/hatch/cli/__init__.py
+++ b/src/hatch/cli/__init__.py
@@ -115,7 +115,7 @@ def hatch(
 
     app = Application(ctx.exit, verbose - quiet, color, interactive)
 
-    app.env_active = os.environ.get(AppEnvVars.ENV_ACTIVE)
+    app.env_active = os.environ.get(AppEnvVars.ENV_ACTIVE)  # type: ignore
     if app.env_active and ctx.get_parameter_source('env_name').name == 'DEFAULT':  # type: ignore
         app.env = app.env_active
     else:

--- a/src/hatch/cli/__init__.py
+++ b/src/hatch/cli/__init__.py
@@ -83,7 +83,18 @@ from hatch.utils.fs import Path
 )
 @click.version_option(version=__version__, prog_name='Hatch')
 @click.pass_context
-def hatch(ctx: click.Context, env_name, project, color, interactive, verbose, quiet, data_dir, cache_dir, config_file):
+def hatch(
+    ctx: click.Context,
+    env_name,
+    project,
+    color: bool,
+    interactive: bool,
+    verbose,
+    quiet,
+    data_dir,
+    cache_dir,
+    config_file,
+) -> None:
     """
     \b
      _   _       _       _

--- a/src/hatch/cli/application.py
+++ b/src/hatch/cli/application.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from hatch.env.virtual import VirtualEnvironment
     from hatch.plugin.manager import PluginManager
 
+
 class Application(Terminal):
     def __init__(self, exit_func: Callable, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)

--- a/src/hatch/cli/application.py
+++ b/src/hatch/cli/application.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from os.path import expanduser, expandvars, isabs
-from typing import TYPE_CHECKING, Callable, NoReturn, Optional, Union, cast
+from typing import TYPE_CHECKING, NoReturn, cast
 
 from hatch.cli.terminal import Terminal
 from hatch.config.user import ConfigFile, RootConfig
@@ -41,7 +42,7 @@ class Application(Terminal):
     def config(self) -> RootConfig:
         return self.config_file.model
 
-    def get_environment(self, env_name: Optional[str] = None) -> Union["VirtualEnvironment", "SystemEnvironment"]:
+    def get_environment(self, env_name: str | None = None) -> "VirtualEnvironment" | "SystemEnvironment":
         if env_name is None:
             env_name = self.env
 
@@ -72,7 +73,7 @@ class Application(Terminal):
 
     # Ensure that this method is clearly written since it is
     # used for documenting the life cycle of environments.
-    def prepare_environment(self, environment: Union["VirtualEnvironment", "SystemEnvironment"]) -> None:
+    def prepare_environment(self, environment: "VirtualEnvironment" | "SystemEnvironment") -> None:
         if not environment.exists():
             with self.status_waiting(f'Creating environment: {environment.name}'):
                 environment.create()
@@ -102,7 +103,7 @@ class Application(Terminal):
 
     def run_shell_commands(
         self,
-        environment: Union["VirtualEnvironment", "SystemEnvironment"],
+        environment: "VirtualEnvironment" | "SystemEnvironment",
         commands: list[str],
         source: str = 'cmd',
         force_continue: bool = False,

--- a/src/hatch/cli/application.py
+++ b/src/hatch/cli/application.py
@@ -36,14 +36,14 @@ class Application(Terminal):
         self.env_active = cast(str, None)
 
     @property
-    def plugins(self) -> "PluginManager":
+    def plugins(self) -> 'PluginManager':
         return self.project.plugin_manager
 
     @property
     def config(self) -> RootConfig:
         return self.config_file.model
 
-    def get_environment(self, env_name: str | None = None) -> "VirtualEnvironment" | "SystemEnvironment":
+    def get_environment(self, env_name: str | None = None) -> 'VirtualEnvironment' | 'SystemEnvironment':
         if env_name is None:
             env_name = self.env
 
@@ -74,7 +74,7 @@ class Application(Terminal):
 
     # Ensure that this method is clearly written since it is
     # used for documenting the life cycle of environments.
-    def prepare_environment(self, environment: "VirtualEnvironment" | "SystemEnvironment") -> None:
+    def prepare_environment(self, environment: 'VirtualEnvironment' | 'SystemEnvironment') -> None:
         if not environment.exists():
             with self.status_waiting(f'Creating environment: {environment.name}'):
                 environment.create()
@@ -104,7 +104,7 @@ class Application(Terminal):
 
     def run_shell_commands(
         self,
-        environment: "VirtualEnvironment" | "SystemEnvironment",
+        environment: 'VirtualEnvironment' | 'SystemEnvironment',
         commands: list[str],
         source: str = 'cmd',
         force_continue: bool = False,
@@ -140,7 +140,7 @@ class Application(Terminal):
             if first_error_code and force_continue:
                 self.abort(code=first_error_code)
 
-    def attach_builder(self, process: "Popen") -> None:
+    def attach_builder(self, process: 'Popen') -> None:
         import pickle
 
         with process:
@@ -159,7 +159,7 @@ class Application(Terminal):
         if process.returncode:
             self.abort(code=process.returncode)
 
-    def read_builder(self, process: "Popen") -> str:
+    def read_builder(self, process: 'Popen') -> str:
         import pickle
 
         lines = []

--- a/src/hatch/cli/application.py
+++ b/src/hatch/cli/application.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from os.path import expanduser, expandvars, isabs
-from typing import TYPE_CHECKING, Callable, Optional, Union, cast
+from typing import TYPE_CHECKING, Callable, NoReturn, Optional, Union, cast
 
 from hatch.cli.terminal import Terminal
 from hatch.config.user import ConfigFile, RootConfig
@@ -188,7 +188,7 @@ class Application(Terminal):
         else:
             return self.data_dir / 'env' / environment_type
 
-    def abort(self, text: str = '', code: int = 1, **kwargs) -> None:
+    def abort(self, text: str = '', code: int = 1, **kwargs) -> NoReturn:
         if text:
             self.display_error(text, **kwargs)
         self.__exit_func(code)

--- a/src/hatch/cli/build/__init__.py
+++ b/src/hatch/cli/build/__init__.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from __future__ import annotations
 
 import click
 
@@ -48,7 +48,7 @@ import click
 def build(
     app,
     location,
-    targets: Union[Tuple[str], Tuple[str, str]],
+    targets: tuple[str] | tuple[str, str],
     hooks_only: bool,
     no_hooks,
     ext,

--- a/src/hatch/cli/build/__init__.py
+++ b/src/hatch/cli/build/__init__.py
@@ -1,3 +1,5 @@
+from typing import Tuple, Union
+
 import click
 
 
@@ -43,7 +45,17 @@ import click
 )
 @click.option('--clean-only', is_flag=True, hidden=True)
 @click.pass_obj
-def build(app, location, targets, hooks_only, no_hooks, ext, clean, clean_hooks_after, clean_only):
+def build(
+    app,
+    location,
+    targets: Union[Tuple[str], Tuple[str, str]],
+    hooks_only: bool,
+    no_hooks,
+    ext,
+    clean,
+    clean_hooks_after,
+    clean_only,
+) -> None:
     """Build a project."""
     from hatch.utils.fs import Path
     from hatch.utils.structures import EnvVars

--- a/src/hatch/cli/build/__init__.py
+++ b/src/hatch/cli/build/__init__.py
@@ -45,11 +45,10 @@ import click
 @click.pass_obj
 def build(app, location, targets, hooks_only, no_hooks, ext, clean, clean_hooks_after, clean_only):
     """Build a project."""
-    from hatchling.builders.constants import BuildEnvVars
-    from hatchling.builders.plugin.interface import BuilderInterface
-
     from hatch.utils.fs import Path
     from hatch.utils.structures import EnvVars
+    from hatchling.builders.constants import BuildEnvVars
+    from hatchling.builders.plugin.interface import BuilderInterface
 
     if app.project.metadata.build.build_backend != 'hatchling.build':
         app.abort('Field `build-system.build-backend` must be set to `hatchling.build`')

--- a/src/hatch/cli/clean/__init__.py
+++ b/src/hatch/cli/clean/__init__.py
@@ -32,7 +32,7 @@ import click
     ),
 )
 @click.pass_context
-def clean(ctx, location, targets, hooks_only, no_hooks, ext):
+def clean(ctx, location, targets, hooks_only, no_hooks, ext) -> None:
     """Remove build artifacts."""
     from hatch.cli.build import build
 

--- a/src/hatch/cli/config/__init__.py
+++ b/src/hatch/cli/config/__init__.py
@@ -4,13 +4,13 @@ import click
 
 
 @click.group(short_help='Manage the config file')
-def config():
+def config() -> None:
     pass
 
 
 @config.command(short_help='Open the config location in your file manager')
 @click.pass_obj
-def explore(app):
+def explore(app) -> None:
     """Open the config location in your file manager."""
     click.launch(str(app.config_file.path), locate=True)
 
@@ -18,7 +18,7 @@ def explore(app):
 @config.command(short_help='Show the location of the config file')
 @click.option('--copy', '-c', is_flag=True, help='Copy the path to the config file to the clipboard')
 @click.pass_obj
-def find(app, copy):
+def find(app, copy) -> None:
     """Show the location of the config file."""
     config_path = str(app.config_file.path)
     if copy:
@@ -34,7 +34,7 @@ def find(app, copy):
 @config.command(short_help='Show the contents of the config file')
 @click.option('--all', '-a', 'all_keys', is_flag=True, help='Do not scrub secret fields')
 @click.pass_obj
-def show(app, all_keys):
+def show(app, all_keys) -> None:
     """Show the contents of the config file."""
     if not app.config_file.path.is_file():  # no cov
         app.display_info('No config file found! Please try `hatch config restore`.')
@@ -47,7 +47,7 @@ def show(app, all_keys):
 
 @config.command(short_help='Update the config file with any new fields')
 @click.pass_obj
-def update(app):  # no cov
+def update(app) -> None:  # no cov
     """Update the config file with any new fields."""
     app.config_file.update()
     app.display_success('Settings were successfully updated.')
@@ -55,7 +55,7 @@ def update(app):  # no cov
 
 @config.command(short_help='Restore the config file to default settings')
 @click.pass_obj
-def restore(app):
+def restore(app) -> None:
     """Restore the config file to default settings."""
     app.config_file.restore()
     app.display_success('Settings were successfully restored.')
@@ -65,7 +65,7 @@ def restore(app):
 @click.argument('key')
 @click.argument('value', required=False)
 @click.pass_obj
-def set_value(app, key, value):
+def set_value(app, key, value) -> None:
     """
     Assign values to config file entries. If the value is omitted,
     you will be prompted, with the input hidden if it is sensitive.

--- a/src/hatch/cli/dep/__init__.py
+++ b/src/hatch/cli/dep/__init__.py
@@ -2,7 +2,7 @@ import click
 
 
 @click.group(short_help='Manage environment dependencies')
-def dep():
+def dep() -> None:
     pass
 
 
@@ -10,7 +10,7 @@ def dep():
 @click.option('--project-only', '-p', is_flag=True, help='Whether or not to exclude environment dependencies')
 @click.option('--env-only', '-e', is_flag=True, help='Whether or not to exclude project dependencies')
 @click.pass_obj
-def hash_dependencies(app, project_only, env_only):
+def hash_dependencies(app, project_only, env_only) -> None:
     """Output a hash of the currently defined dependencies."""
     from hashlib import sha256
 
@@ -42,7 +42,7 @@ def hash_dependencies(app, project_only, env_only):
 
 
 @dep.group(short_help='Display dependencies in various formats')
-def show():
+def show() -> None:
     pass
 
 
@@ -52,7 +52,7 @@ def show():
 @click.option('--lines', '-l', 'show_lines', is_flag=True, help='Whether or not to show lines between table rows')
 @click.option('--ascii', 'force_ascii', is_flag=True, help='Whether or not to only use ASCII characters')
 @click.pass_obj
-def table(app, project_only, env_only, show_lines, force_ascii):
+def table(app, project_only, env_only, show_lines, force_ascii) -> None:
     """Enumerate dependencies in a tabular format."""
     from packaging.requirements import Requirement
 
@@ -119,7 +119,7 @@ def table(app, project_only, env_only, show_lines, force_ascii):
 )
 @click.option('--all', 'all_features', is_flag=True, help='Whether or not to include the dependencies of all features')
 @click.pass_obj
-def requirements(app, project_only, env_only, features, all_features):
+def requirements(app, project_only, env_only, features, all_features) -> None:
     """Enumerate dependencies as a list of requirements."""
     from hatch.utils.dep import get_normalized_dependencies, get_project_dependencies_complex
     from hatchling.metadata.utils import normalize_project_name

--- a/src/hatch/cli/env/__init__.py
+++ b/src/hatch/cli/env/__init__.py
@@ -9,7 +9,7 @@ from hatch.cli.env.show import show
 
 
 @click.group(short_help='Manage project environments')
-def env():
+def env() -> None:
     pass
 
 

--- a/src/hatch/cli/env/create.py
+++ b/src/hatch/cli/env/create.py
@@ -4,7 +4,7 @@ import click
 @click.command(short_help='Create environments')
 @click.argument('env_name', default='default')
 @click.pass_obj
-def create(app, env_name):
+def create(app, env_name) -> None:
     """Create environments."""
     root_env_name = env_name
     project_config = app.project.config

--- a/src/hatch/cli/env/find.py
+++ b/src/hatch/cli/env/find.py
@@ -4,7 +4,7 @@ import click
 @click.command(short_help='Locate environments')
 @click.argument('env_name', default='default')
 @click.pass_obj
-def find(app, env_name):
+def find(app, env_name) -> None:
     """Locate environments."""
     root_env_name = env_name
     project_config = app.project.config

--- a/src/hatch/cli/env/prune.py
+++ b/src/hatch/cli/env/prune.py
@@ -3,7 +3,7 @@ import click
 
 @click.command(short_help='Remove all environments')
 @click.pass_obj
-def prune(app):
+def prune(app) -> None:
     """Remove all environments."""
     environment_types = app.plugins.environment.collect()
 

--- a/src/hatch/cli/env/remove.py
+++ b/src/hatch/cli/env/remove.py
@@ -4,7 +4,7 @@ import click
 @click.command(short_help='Remove environments')
 @click.argument('env_name', default='default')
 @click.pass_context
-def remove(ctx, env_name):
+def remove(ctx, env_name) -> None:
     """Remove environments."""
     app = ctx.obj
     if ctx.get_parameter_source('env_name').name == 'DEFAULT':

--- a/src/hatch/cli/env/run.py
+++ b/src/hatch/cli/env/run.py
@@ -1,7 +1,9 @@
+from typing import Any, Dict, List, Set, Tuple, Union
+
 import click
 
 
-def parse_variable_spec(spec):
+def parse_variable_spec(spec: str) -> Union[Tuple[str, Set[str]], Tuple[str, Set[Any]]]:
     variable, _, values = spec.partition('=')
     if variable == 'py':
         variable = 'python'
@@ -10,7 +12,11 @@ def parse_variable_spec(spec):
     return variable, parsed_values
 
 
-def select_matrix_environments(environments, included_variables, excluded_variables):
+def select_matrix_environments(
+    environments: Dict[str, Dict[str, str]],
+    included_variables: Dict[str, Set[str]],
+    excluded_variables: Dict[str, Union[Set[str], Set[Any]]],
+) -> List[Union[str, Any]]:
     selected_environments = []
     for env_name, variables in environments.items():
         included = set(variables)
@@ -37,7 +43,9 @@ def select_matrix_environments(environments, included_variables, excluded_variab
     return selected_environments
 
 
-def filter_environments(environments, filter_data):
+def filter_environments(
+    environments: Dict[str, Dict[str, Union[bool, str]]], filter_data: Dict[str, bool]
+) -> List[str]:
     selected_environments = []
     for env_name, env_data in environments.items():
         for key, value in filter_data.items():

--- a/src/hatch/cli/env/run.py
+++ b/src/hatch/cli/env/run.py
@@ -1,9 +1,11 @@
-from typing import Any, Dict, List, Set, Tuple, Union
+from __future__ import annotations
+
+from typing import Any
 
 import click
 
 
-def parse_variable_spec(spec: str) -> Union[Tuple[str, Set[Any]], Tuple[str, Set[str]]]:
+def parse_variable_spec(spec: str) -> tuple[str, set[Any]] | tuple[str, set[str]]:
     variable, _, values = spec.partition('=')
     if variable == 'py':
         variable = 'python'
@@ -13,10 +15,10 @@ def parse_variable_spec(spec: str) -> Union[Tuple[str, Set[Any]], Tuple[str, Set
 
 
 def select_matrix_environments(
-    environments: Dict[str, Dict[str, str]],
-    included_variables: Dict[str, Set[str]],
-    excluded_variables: Dict[str, Union[Set[str], Set[Any]]],
-) -> List[Union[Any, str]]:
+    environments: dict[str, dict[str, str]],
+    included_variables: dict[str, set[str]],
+    excluded_variables: dict[str, set[str] | set[Any]],
+) -> list[Any | str]:
     selected_environments = []
     for env_name, variables in environments.items():
         included = set(variables)
@@ -44,8 +46,8 @@ def select_matrix_environments(
 
 
 def filter_environments(
-    environments: Dict[str, Dict[str, Union[bool, str]]], filter_data: Dict[str, bool]
-) -> List[str]:
+    environments: dict[str, dict[str, bool | str]], filter_data: dict[str, bool]
+) -> list[str]:
     selected_environments = []
     for env_name, env_data in environments.items():
         for key, value in filter_data.items():
@@ -74,7 +76,7 @@ def run(
     env_names,
     included_variable_specs,
     excluded_variable_specs,
-    filter_json: Union[bytes, str],
+    filter_json: bytes | str,
     force_continue,
     ignore_compat,
 ) -> None:

--- a/src/hatch/cli/env/run.py
+++ b/src/hatch/cli/env/run.py
@@ -45,9 +45,7 @@ def select_matrix_environments(
     return selected_environments
 
 
-def filter_environments(
-    environments: dict[str, dict[str, bool | str]], filter_data: dict[str, bool]
-) -> list[str]:
+def filter_environments(environments: dict[str, dict[str, bool | str]], filter_data: dict[str, bool]) -> list[str]:
     selected_environments = []
     for env_name, env_data in environments.items():
         for key, value in filter_data.items():

--- a/src/hatch/cli/env/run.py
+++ b/src/hatch/cli/env/run.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Set, Tuple, Union
 import click
 
 
-def parse_variable_spec(spec: str) -> Union[Tuple[str, Set[str]], Tuple[str, Set[Any]]]:
+def parse_variable_spec(spec: str) -> Union[Tuple[str, Set[Any]], Tuple[str, Set[str]]]:
     variable, _, values = spec.partition('=')
     if variable == 'py':
         variable = 'python'
@@ -16,7 +16,7 @@ def select_matrix_environments(
     environments: Dict[str, Dict[str, str]],
     included_variables: Dict[str, Set[str]],
     excluded_variables: Dict[str, Union[Set[str], Set[Any]]],
-) -> List[Union[str, Any]]:
+) -> List[Union[Any, str]]:
     selected_environments = []
     for env_name, variables in environments.items():
         included = set(variables)
@@ -74,10 +74,10 @@ def run(
     env_names,
     included_variable_specs,
     excluded_variable_specs,
-    filter_json,
+    filter_json: Union[bytes, str],
     force_continue,
     ignore_compat,
-):
+) -> None:
     """
     Run commands within project environments.
 

--- a/src/hatch/cli/env/show.py
+++ b/src/hatch/cli/env/show.py
@@ -6,7 +6,7 @@ import click
 @click.option('--ascii', 'force_ascii', is_flag=True, help='Whether or not to only use ASCII characters')
 @click.option('--json', 'as_json', is_flag=True, help='Whether or not to output in JSON format')
 @click.pass_obj
-def show(app, envs, force_ascii, as_json):
+def show(app, envs, force_ascii, as_json) -> None:
     """Show the available environments."""
     from hatch.config.constants import AppEnvVars
 

--- a/src/hatch/cli/new/__init__.py
+++ b/src/hatch/cli/new/__init__.py
@@ -9,7 +9,7 @@ import click
 @click.option('--init', 'initialize', is_flag=True, help='Initialize an existing project')
 @click.option('-so', 'setuptools_options', multiple=True, hidden=True)
 @click.pass_obj
-def new(app, name, location, interactive, feature_cli, initialize, setuptools_options):
+def new(app, name, location, interactive: bool, feature_cli, initialize, setuptools_options) -> None:
     """Create or initialize a project."""
     from copy import deepcopy
     from datetime import datetime, timezone

--- a/src/hatch/cli/new/migrate.py
+++ b/src/hatch/cli/new/migrate.py
@@ -1,12 +1,14 @@
 import os
 import sys
+from types import ModuleType
+from typing import Any, Dict, Union
 
 FILE = os.path.abspath(__file__)
 HERE = os.path.dirname(FILE)
 ENV_VAR_PREFIX = '_HATCHLING_PORT_ADD_'
 
 
-def _apply_env_vars(kwargs):
+def _apply_env_vars(kwargs) -> None:
     from ast import literal_eval
 
     for key, value in os.environ.items():
@@ -24,7 +26,7 @@ def _parse_dependencies(dependency_definition):
     return dependencies
 
 
-def _collapse_data(output, data):
+def _collapse_data(output, data: Dict[str, Any]):
     import tomli_w
 
     expected_output = new_output = tomli_w.dumps(data)
@@ -35,7 +37,7 @@ def _collapse_data(output, data):
     return output.replace(expected_output, new_output, 1)
 
 
-def _parse_setup_cfg(kwargs):
+def _parse_setup_cfg(kwargs) -> None:
     from configparser import ConfigParser
 
     setup_cfg_file = os.path.join(HERE, 'setup.cfg')
@@ -120,7 +122,7 @@ def _parse_setup_cfg(kwargs):
         }
 
 
-def setup(**kwargs):
+def setup(**kwargs) -> None:
     import itertools
     import re
 
@@ -315,8 +317,8 @@ def setup(**kwargs):
 
 
 if __name__ == 'setuptools':
-    __this_shim = sys.modules.pop('setuptools')
-    __current_directory = sys.path.pop(0)
+    __this_shim: ModuleType = sys.modules.pop('setuptools')
+    __current_directory: str = sys.path.pop(0)
 
     import setuptools as __real_setuptools
 
@@ -330,7 +332,7 @@ if __name__ == 'setuptools':
     del __current_directory
 
 
-def migrate(root, setuptools_options):
+def migrate(root: Union[os.PathLike[str], str], setuptools_options) -> None:
     import shutil
     import subprocess
     from tempfile import TemporaryDirectory

--- a/src/hatch/cli/new/migrate.py
+++ b/src/hatch/cli/new/migrate.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import os
 import sys
 from types import ModuleType
-from typing import Any, Dict, Union
+from typing import Any
 
 FILE = os.path.abspath(__file__)
 HERE = os.path.dirname(FILE)
@@ -26,7 +28,7 @@ def _parse_dependencies(dependency_definition):
     return dependencies
 
 
-def _collapse_data(output, data: Dict[str, Any]):
+def _collapse_data(output, data: dict[str, Any]):
     import tomli_w
 
     expected_output = new_output = tomli_w.dumps(data)
@@ -332,7 +334,7 @@ if __name__ == 'setuptools':
     del __current_directory
 
 
-def migrate(root: Union[os.PathLike[str], str], setuptools_options) -> None:
+def migrate(root: os.PathLike[str] | str, setuptools_options) -> None:
     import shutil
     import subprocess
     from tempfile import TemporaryDirectory

--- a/src/hatch/cli/project/__init__.py
+++ b/src/hatch/cli/project/__init__.py
@@ -4,7 +4,7 @@ from hatch.cli.project.metadata import metadata
 
 
 @click.group(short_help='View project information')
-def project():
+def project() -> None:
     pass
 
 

--- a/src/hatch/cli/project/metadata.py
+++ b/src/hatch/cli/project/metadata.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 import click
 
 
@@ -48,10 +50,11 @@ def metadata(app, field):
         if field not in project_metadata:
             app.abort(f'Unknown metadata field: {field}')
         elif field == 'readme':
-            if project_metadata[field]['content-type'] == 'text/markdown':  # no cov
-                app.display_markdown(project_metadata[field]['text'])
+            md_field = cast(dict, project_metadata[field])
+            if md_field['content-type'] == 'text/markdown':  # no cov
+                app.display_markdown(md_field['text'])
             else:
-                app.display_always(project_metadata[field]['text'])
+                app.display_always(md_field['text'])
         elif isinstance(project_metadata[field], str):
             app.display_always(project_metadata[field])
         else:

--- a/src/hatch/cli/publish/__init__.py
+++ b/src/hatch/cli/publish/__init__.py
@@ -74,7 +74,7 @@ def publish(
     publisher_name,
     options,
     yes,
-):
+) -> None:
     """Publish build artifacts."""
     option_map = {'no_prompt': no_prompt, 'initialize_auth': initialize_auth}
     if publisher_name == 'index':

--- a/src/hatch/cli/run/__init__.py
+++ b/src/hatch/cli/run/__init__.py
@@ -8,7 +8,7 @@ import click
 @click.argument('args', metavar='[ENV:]ARGS...', required=True, nargs=-1)
 @click.pass_obj
 @click.pass_context
-def run(ctx, app, args):
+def run(ctx, app, args) -> None:
     """
     Run commands within project environments.
     This is a convenience wrapper around the [`env run`](#hatch-env-run) command.

--- a/src/hatch/cli/shell/__init__.py
+++ b/src/hatch/cli/shell/__init__.py
@@ -6,7 +6,7 @@ import click
 @click.argument('shell_path', required=False)
 @click.argument('shell_args', required=False, nargs=-1)
 @click.pass_obj
-def shell(app, shell_name, shell_path, shell_args):  # no cov
+def shell(app, shell_name, shell_path, shell_args) -> None:  # no cov
     """Enter a shell within a project's environment."""
     if app.env == app.env_active:
         app.abort(f'Already in environment: {app.env}')

--- a/src/hatch/cli/status/__init__.py
+++ b/src/hatch/cli/status/__init__.py
@@ -3,7 +3,7 @@ import click
 
 @click.command(short_help='Show information about the current environment')
 @click.pass_obj
-def status(app):
+def status(app) -> None:
     """Show information about the current environment."""
 
     def display_pair(key, value, display_func=None, link=None):

--- a/src/hatch/cli/terminal.py
+++ b/src/hatch/cli/terminal.py
@@ -13,8 +13,7 @@ from rich.style import Style
 from rich.text import Text
 
 if TYPE_CHECKING:
-    from rich.syntax import Syntax
-    from rich.tree import Tree
+    from rich import Syntax, Table, Tree
 
     from hatch.utils.fs import Path
 

--- a/src/hatch/cli/terminal.py
+++ b/src/hatch/cli/terminal.py
@@ -3,17 +3,19 @@ from __future__ import annotations
 import os
 from contextlib import contextmanager
 from textwrap import indent as indent_text
-from typing import Any, Dict, Iterator, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Union
 
 import click
 from rich.console import Console
 from rich.errors import StyleSyntaxError
 from rich.style import Style
-from rich.syntax import Syntax
 from rich.text import Text
-from rich.tree import Tree
 
-from hatch.utils.fs import Path
+if TYPE_CHECKING:
+    from rich.syntax import Syntax
+    from rich.tree import Tree
+
+    from hatch.utils.fs import Path
 
 
 class Terminal:
@@ -64,129 +66,56 @@ class Terminal:
         return errors
 
     def display_error(
-        self,
-        text: str = '',
-        stderr: bool = True,
-        indent: Optional[int] = None,
-        link: None = None,
-        **kwargs,
+        self, text: str = '', stderr: bool = True, indent: None = None, link: None = None, **kwargs
     ) -> None:
         if self.verbosity < -2:
             return
 
-        self.display(
-            text,
-            self._style_level_error,
-            stderr=stderr,
-            indent=indent,
-            link=link,
-            **kwargs,
-        )
+        self.display(text, self._style_level_error, stderr=stderr, indent=indent, link=link, **kwargs)
 
     def display_warning(
-        self,
-        text: str = '',
-        stderr: bool = False,
-        indent: Optional[int] = None,
-        link: None = None,
-        **kwargs,
+        self, text: str = '', stderr: bool = False, indent: None = None, link: None = None, **kwargs
     ) -> None:
         if self.verbosity < -1:
             return
 
-        self.display(
-            text,
-            self._style_level_warning,
-            stderr=stderr,
-            indent=indent,
-            link=link,
-            **kwargs,
-        )
+        self.display(text, self._style_level_warning, stderr=stderr, indent=indent, link=link, **kwargs)
 
     def display_info(
-        self,
-        text: str = '',
-        stderr: bool = False,
-        indent: Optional[int] = None,
-        link: Optional[str] = None,
-        **kwargs,
+        self, text: str = '', stderr: bool = False, indent: None = None, link: Optional[str] = None, **kwargs
     ) -> None:
         if self.verbosity < 0:
             return
 
-        self.display(
-            text,
-            self._style_level_info,
-            stderr=stderr,
-            indent=indent,
-            link=link,
-            **kwargs,
-        )
+        self.display(text, self._style_level_info, stderr=stderr, indent=indent, link=link, **kwargs)
 
     def display_success(
-        self,
-        text: str = '',
-        stderr: bool = False,
-        indent: Optional[int] = None,
-        link: None = None,
-        **kwargs,
+        self, text: str = '', stderr: bool = False, indent: None = None, link: None = None, **kwargs
     ) -> None:
         if self.verbosity < 0:
             return
 
-        self.display(
-            text,
-            self._style_level_success,
-            stderr=stderr,
-            indent=indent,
-            link=link,
-            **kwargs,
-        )
+        self.display(text, self._style_level_success, stderr=stderr, indent=indent, link=link, **kwargs)
 
     def display_waiting(
-        self,
-        text: str = '',
-        stderr: bool = False,
-        indent: Optional[int] = None,
-        link: None = None,
-        **kwargs,
+        self, text: str = '', stderr: bool = False, indent: None = None, link: None = None, **kwargs
     ) -> None:
         if self.verbosity < 0:
             return
 
-        self.display(
-            text,
-            self._style_level_waiting,
-            stderr=stderr,
-            indent=indent,
-            link=link,
-            **kwargs,
-        )
+        self.display(text, self._style_level_waiting, stderr=stderr, indent=indent, link=link, **kwargs)
 
     def display_debug(
-        self,
-        text: str = '',
-        level: int = 1,
-        stderr: bool = False,
-        indent: Optional[int] = None,
-        link: None = None,
-        **kwargs,
+        self, text: str = '', level: int = 1, stderr: bool = False, indent: None = None, link: None = None, **kwargs
     ) -> None:
         if not 1 <= level <= 3:
             raise ValueError('Debug output can only have verbosity levels between 1 and 3 (inclusive)')
         elif self.verbosity < level:
             return
 
-        self.display(
-            text,
-            self._style_level_debug,
-            stderr=stderr,
-            indent=indent,
-            link=link,
-            **kwargs,
-        )
+        self.display(text, self._style_level_debug, stderr=stderr, indent=indent, link=link, **kwargs)
 
-    def display_mini_header(self, text: str, *, stderr=False, indent=None, link=None) -> None:
+    def display_mini_header(self, text: str, *, stderr: bool = False, indent=None, link=None) -> None:
         if self.verbosity < 0:
             return
 
@@ -194,10 +123,10 @@ class Terminal:
         self.display_success(text, stderr=stderr, link=link, end='')
         self.display_info(']', stderr=stderr)
 
-    def display_header(self, title: str = '', *, stderr=False) -> None:
+    def display_header(self, title: str = '', *, stderr: bool = False) -> None:
         self.console.rule(Text(title, self._style_level_success))
 
-    def display_markdown(self, text, **kwargs):  # no cov
+    def display_markdown(self, text, **kwargs) -> None:  # no cov
         from rich.markdown import Markdown
 
         self.display_raw(Markdown(text), **kwargs)
@@ -271,11 +200,11 @@ class Terminal:
 
     def display(
         self,
-        text: Union[str, Syntax, Table, Tree] = '',
-        style: Optional[Union[str, Style]] = None,
+        text: Union[str, "Table", "Tree", "Syntax"] = '',
+        style: Optional[Union[str, "Style"]] = None,
         *,
-        stderr=False,
-        indent=None,
+        stderr: bool = False,
+        indent: typing.Optional[str] = None,
         link=None,
         **kwargs,
     ) -> None:
@@ -298,25 +227,18 @@ class Terminal:
             finally:
                 self.console.stderr = False
 
-    def display_raw(self, text: str, **kwargs):
+    def display_raw(self, text, **kwargs) -> None:
         self.console.print(text, overflow='ignore', no_wrap=True, crop=False, **kwargs)
 
-    def display_always(self, text: Union[str, Path] = '', **kwargs) -> None:
-        self.console.print(
-            text,
-            style=self._style_level_info,
-            overflow='ignore',
-            no_wrap=True,
-            crop=False,
-            **kwargs,
-        )
+    def display_always(self, text: Union[str, "Path"] = '', **kwargs) -> None:
+        self.console.print(text, style=self._style_level_info, overflow='ignore', no_wrap=True, crop=False, **kwargs)
 
     @staticmethod
     def prompt(text: str, **kwargs) -> str:
         return click.prompt(text, **kwargs)
 
     @staticmethod
-    def confirm(text: str, **kwargs):
+    def confirm(text: str, **kwargs) -> bool:
         return click.confirm(text, **kwargs)
 
 
@@ -327,5 +249,5 @@ class MockStatus:
     def __enter__(self) -> "MockStatus":
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback) -> None:
+    def __exit__(self, exc_type: None, exc_value: None, traceback: None) -> None:
         pass

--- a/src/hatch/cli/terminal.py
+++ b/src/hatch/cli/terminal.py
@@ -200,7 +200,7 @@ class Terminal:
 
     def display(
         self,
-        text: str | "Table" | "Tree" | "Syntax" = '',
+        text: str | 'Table' | 'Tree' | 'Syntax' = '',
         style: str | Style | None = None,
         *,
         stderr: bool = False,
@@ -230,7 +230,7 @@ class Terminal:
     def display_raw(self, text, **kwargs) -> None:
         self.console.print(text, overflow='ignore', no_wrap=True, crop=False, **kwargs)
 
-    def display_always(self, text: str | "Path" = '', **kwargs) -> None:
+    def display_always(self, text: str | 'Path' = '', **kwargs) -> None:
         self.console.print(text, style=self._style_level_info, overflow='ignore', no_wrap=True, crop=False, **kwargs)
 
     @staticmethod
@@ -246,7 +246,7 @@ class MockStatus:
     def stop(self) -> None:
         pass
 
-    def __enter__(self) -> "MockStatus":
+    def __enter__(self) -> 'MockStatus':
         return self
 
     def __exit__(self, exc_type: None, exc_value: None, traceback: None) -> None:

--- a/src/hatch/cli/terminal.py
+++ b/src/hatch/cli/terminal.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Iterator
 from contextlib import contextmanager
 from textwrap import indent as indent_text
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 import click
 from rich.console import Console
@@ -44,7 +45,7 @@ class Terminal:
         # Chosen as the default since it's compatible everywhere and looks nice
         self._style_spinner = 'simpleDotsScrolling'
 
-    def initialize_styles(self, styles: dict) -> List[Any]:  # no cov
+    def initialize_styles(self, styles: dict) -> list[Any]:  # no cov
         # Lazily display errors so that they use the correct style
         errors = []
 
@@ -82,7 +83,7 @@ class Terminal:
         self.display(text, self._style_level_warning, stderr=stderr, indent=indent, link=link, **kwargs)
 
     def display_info(
-        self, text: str = '', stderr: bool = False, indent: None = None, link: Optional[str] = None, **kwargs
+        self, text: str = '', stderr: bool = False, indent: None = None, link: str | None = None, **kwargs
     ) -> None:
         if self.verbosity < 0:
             return
@@ -134,9 +135,9 @@ class Terminal:
     def display_table(
         self,
         title: str,
-        columns: Dict[str, Union[Dict[int, str], Dict[Any, Any]]],
+        columns: dict[str, dict[int, str] | dict[Any, Any]],
         show_lines: bool = False,
-        column_options: Optional[Dict[str, Dict[str, bool]]] = None,
+        column_options: dict[str, dict[str, bool]] | None = None,
         force_ascii: bool = False,
         num_rows: int = 0,
     ) -> None:
@@ -200,11 +201,11 @@ class Terminal:
 
     def display(
         self,
-        text: Union[str, "Table", "Tree", "Syntax"] = '',
-        style: Optional[Union[str, "Style"]] = None,
+        text: str | "Table" | "Tree" | "Syntax" = '',
+        style: str | Style | None = None,
         *,
         stderr: bool = False,
-        indent: typing.Optional[str] = None,
+        indent: str | None = None,
         link=None,
         **kwargs,
     ) -> None:
@@ -230,7 +231,7 @@ class Terminal:
     def display_raw(self, text, **kwargs) -> None:
         self.console.print(text, overflow='ignore', no_wrap=True, crop=False, **kwargs)
 
-    def display_always(self, text: Union[str, "Path"] = '', **kwargs) -> None:
+    def display_always(self, text: str | "Path" = '', **kwargs) -> None:
         self.console.print(text, style=self._style_level_info, overflow='ignore', no_wrap=True, crop=False, **kwargs)
 
     @staticmethod

--- a/src/hatch/cli/version/__init__.py
+++ b/src/hatch/cli/version/__init__.py
@@ -4,7 +4,7 @@ import click
 @click.command(short_help="View or set a project's version")
 @click.argument('desired_version', required=False)
 @click.pass_obj
-def version(app, desired_version):
+def version(app, desired_version: str) -> None:
     """View or set a project's version."""
     if 'version' in app.project.metadata.config.get('project', {}):
         if desired_version:

--- a/src/hatch/config/model.py
+++ b/src/hatch/config/model.py
@@ -1,18 +1,19 @@
 import os
+from typing import Any
 
 FIELD_TO_PARSE = object()
 
 
 class ConfigurationError(Exception):
-    def __init__(self, *args, location):
+    def __init__(self, *args, location) -> None:
         self.location = location
         super().__init__(*args)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f'Error parsing config:\n{self.location}\n  {super().__str__()}'
 
 
-def parse_config(obj):
+def parse_config(obj: Any) -> None:
     if isinstance(obj, LazilyParsedConfig):
         obj.parse_fields()
     elif isinstance(obj, list):
@@ -24,17 +25,17 @@ def parse_config(obj):
 
 
 class LazilyParsedConfig:
-    def __init__(self, config: dict, steps: tuple = ()):
+    def __init__(self, config: dict, steps: tuple = ()) -> None:
         self.raw_data = config
         self.steps = steps
 
-    def parse_fields(self):
+    def parse_fields(self) -> None:
         for attribute in self.__dict__:
             _, prefix, name = attribute.partition('_field_')
             if prefix:
                 parse_config(getattr(self, name))
 
-    def raise_error(self, message, *, extra_steps=()):
+    def raise_error(self, message: str, *, extra_steps:tuple =()):
         import inspect
 
         field = inspect.currentframe().f_back.f_code.co_name
@@ -42,7 +43,7 @@ class LazilyParsedConfig:
 
 
 class RootConfig(LazilyParsedConfig):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
         self._field_mode = FIELD_TO_PARSE
@@ -234,7 +235,7 @@ class RootConfig(LazilyParsedConfig):
 
 
 class ShellConfig(LazilyParsedConfig):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
         self._field_name = FIELD_TO_PARSE
@@ -304,7 +305,7 @@ class ShellConfig(LazilyParsedConfig):
 
 
 class DirsConfig(LazilyParsedConfig):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
         self._field_project = FIELD_TO_PARSE
@@ -422,7 +423,7 @@ class DirsConfig(LazilyParsedConfig):
 
 
 class ProjectConfig(LazilyParsedConfig):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
         self._field_location = FIELD_TO_PARSE
@@ -448,7 +449,7 @@ class ProjectConfig(LazilyParsedConfig):
 
 
 class TemplateConfig(LazilyParsedConfig):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
         self._field_name = FIELD_TO_PARSE
@@ -560,7 +561,7 @@ class TemplateConfig(LazilyParsedConfig):
 
 
 class LicensesConfig(LazilyParsedConfig):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
         self._field_headers = FIELD_TO_PARSE
@@ -610,7 +611,7 @@ class LicensesConfig(LazilyParsedConfig):
 
 
 class TerminalConfig(LazilyParsedConfig):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
         self._field_styles = FIELD_TO_PARSE
@@ -638,7 +639,7 @@ class TerminalConfig(LazilyParsedConfig):
 
 
 class StylesConfig(LazilyParsedConfig):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
         self._field_info = FIELD_TO_PARSE

--- a/src/hatch/config/model.py
+++ b/src/hatch/config/model.py
@@ -35,7 +35,7 @@ class LazilyParsedConfig:
             if prefix:
                 parse_config(getattr(self, name))
 
-    def raise_error(self, message: str, *, extra_steps:tuple =()):
+    def raise_error(self, message: str, *, extra_steps: tuple = ()):
         import inspect
 
         field = inspect.currentframe().f_back.f_code.co_name

--- a/src/hatch/config/user.py
+++ b/src/hatch/config/user.py
@@ -6,7 +6,7 @@ from hatch.utils.toml import load_toml_data
 
 
 class ConfigFile:
-    def __init__(self, path: Optional[Path] = None):
+    def __init__(self, path: Optional[Path] = None) -> None:
         self._path: Optional[Path] = path
         self.model = cast(RootConfig, None)
 
@@ -21,7 +21,7 @@ class ConfigFile:
     def path(self, value):
         self._path = value
 
-    def save(self, content=None):
+    def save(self, content: Optional[str]=None) -> None:
         import tomli_w
 
         if not content:
@@ -30,7 +30,7 @@ class ConfigFile:
         self.path.ensure_parent_dir_exists()
         self.path.write_atomic(content, 'w', encoding='utf-8')
 
-    def load(self):
+    def load(self) -> None:
         self.model = RootConfig(load_toml_data(self.read()))
 
     def read(self) -> str:
@@ -43,7 +43,7 @@ class ConfigFile:
         config.raw_data.pop('publish', None)
         return tomli_w.dumps(config.raw_data)
 
-    def restore(self):
+    def restore(self) -> None:
         import tomli_w
 
         config = RootConfig({})

--- a/src/hatch/config/user.py
+++ b/src/hatch/config/user.py
@@ -1,4 +1,6 @@
-from typing import Optional, cast
+from __future__ import annotations
+
+from typing import cast
 
 from hatch.config.model import RootConfig
 from hatch.utils.fs import Path
@@ -6,8 +8,8 @@ from hatch.utils.toml import load_toml_data
 
 
 class ConfigFile:
-    def __init__(self, path: Optional[Path] = None) -> None:
-        self._path: Optional[Path] = path
+    def __init__(self, path: Path | None = None) -> None:
+        self._path: Path | None = path
         self.model = cast(RootConfig, None)
 
     @property
@@ -21,7 +23,7 @@ class ConfigFile:
     def path(self, value):
         self._path = value
 
-    def save(self, content: Optional[str] = None) -> None:
+    def save(self, content: str | None = None) -> None:
         import tomli_w
 
         if not content:

--- a/src/hatch/config/user.py
+++ b/src/hatch/config/user.py
@@ -21,7 +21,7 @@ class ConfigFile:
     def path(self, value):
         self._path = value
 
-    def save(self, content: Optional[str]=None) -> None:
+    def save(self, content: Optional[str] = None) -> None:
         import tomli_w
 
         if not content:
@@ -54,7 +54,7 @@ class ConfigFile:
 
         self.model = config
 
-    def update(self):  # no cov
+    def update(self) -> None:  # no cov
         self.model.parse_fields()
         self.save()
 

--- a/src/hatch/config/utils.py
+++ b/src/hatch/config/utils.py
@@ -1,13 +1,15 @@
+from typing import Union
 import tomlkit
 from tomlkit.toml_document import TOMLDocument
+from tomlkit.items import InlineTable
 
 from hatch.utils.fs import Path
 
 
-def save_toml_document(document: TOMLDocument, path: Path):
+def save_toml_document(document: TOMLDocument, path: Path) -> None:
     path.ensure_parent_dir_exists()
     path.write_atomic(tomlkit.dumps(document), 'w', encoding='utf-8')
 
 
-def create_toml_document(config: dict) -> TOMLDocument:
+def create_toml_document(config: dict) -> Union[TOMLDocument, InlineTable]:
     return tomlkit.item(config)

--- a/src/hatch/config/utils.py
+++ b/src/hatch/config/utils.py
@@ -1,7 +1,8 @@
-from typing import Union
+from __future__ import annotations
+
 import tomlkit
-from tomlkit.toml_document import TOMLDocument
 from tomlkit.items import InlineTable
+from tomlkit.toml_document import TOMLDocument
 
 from hatch.utils.fs import Path
 
@@ -11,5 +12,5 @@ def save_toml_document(document: TOMLDocument, path: Path) -> None:
     path.write_atomic(tomlkit.dumps(document), 'w', encoding='utf-8')
 
 
-def create_toml_document(config: dict) -> Union[TOMLDocument, InlineTable]:
+def create_toml_document(config: dict) -> TOMLDocument | InlineTable:
     return tomlkit.item(config)

--- a/src/hatch/env/collectors/default.py
+++ b/src/hatch/env/collectors/default.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from hatch.env.collectors.plugin.interface import EnvironmentCollectorInterface
 from hatch.env.utils import ensure_valid_environment
 
@@ -5,7 +7,7 @@ from hatch.env.utils import ensure_valid_environment
 class DefaultEnvironmentCollector(EnvironmentCollectorInterface):
     PLUGIN_NAME = 'default'
 
-    def get_initial_config(self):
+    def get_initial_config(self) -> Dict[str, Dict[str, str]]:
         config = {}
         ensure_valid_environment(config)
 

--- a/src/hatch/env/collectors/default.py
+++ b/src/hatch/env/collectors/default.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from __future__ import annotations
 
 from hatch.env.collectors.plugin.interface import EnvironmentCollectorInterface
 from hatch.env.utils import ensure_valid_environment
@@ -7,7 +7,7 @@ from hatch.env.utils import ensure_valid_environment
 class DefaultEnvironmentCollector(EnvironmentCollectorInterface):
     PLUGIN_NAME = 'default'
 
-    def get_initial_config(self) -> Dict[str, Dict[str, str]]:
+    def get_initial_config(self) -> dict[str, dict[str, str]]:
         config = {}
         ensure_valid_environment(config)
 

--- a/src/hatch/env/collectors/plugin/hooks.py
+++ b/src/hatch/env/collectors/plugin/hooks.py
@@ -1,9 +1,9 @@
-from typing import Type
+from __future__ import annotations
 
 from hatch.env.collectors.default import DefaultEnvironmentCollector
 from hatchling.plugin import hookimpl
 
 
 @hookimpl
-def hatch_register_environment_collector() -> Type[DefaultEnvironmentCollector]:
+def hatch_register_environment_collector() -> type[DefaultEnvironmentCollector]:
     return DefaultEnvironmentCollector

--- a/src/hatch/env/collectors/plugin/hooks.py
+++ b/src/hatch/env/collectors/plugin/hooks.py
@@ -1,7 +1,9 @@
+from typing import Type
+
 from hatch.env.collectors.default import DefaultEnvironmentCollector
 from hatchling.plugin import hookimpl
 
 
 @hookimpl
-def hatch_register_environment_collector():
+def hatch_register_environment_collector() -> Type[DefaultEnvironmentCollector]:
     return DefaultEnvironmentCollector

--- a/src/hatch/env/collectors/plugin/interface.py
+++ b/src/hatch/env/collectors/plugin/interface.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from hatch.utils.fs import Path
@@ -38,7 +38,7 @@ class EnvironmentCollectorInterface:
     PLUGIN_NAME = ''
     """The name used for selection."""
 
-    def __init__(self, root: "Path", config: Dict[Any, Any]) -> None:
+    def __init__(self, root: "Path", config: dict[Any, Any]) -> None:
         self.__root = root
         self.__config = config
 

--- a/src/hatch/env/collectors/plugin/interface.py
+++ b/src/hatch/env/collectors/plugin/interface.py
@@ -38,7 +38,7 @@ class EnvironmentCollectorInterface:
     PLUGIN_NAME = ''
     """The name used for selection."""
 
-    def __init__(self, root: "Path", config: dict[Any, Any]) -> None:
+    def __init__(self, root: 'Path', config: dict[Any, Any]) -> None:
         self.__root = root
         self.__config = config
 

--- a/src/hatch/env/collectors/plugin/interface.py
+++ b/src/hatch/env/collectors/plugin/interface.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from typing import Any, Dict
+
+from hatch.utils.fs import Path
+
 
 class EnvironmentCollectorInterface:
     """
@@ -33,7 +37,7 @@ class EnvironmentCollectorInterface:
     PLUGIN_NAME = ''
     """The name used for selection."""
 
-    def __init__(self, root, config):
+    def __init__(self, root: Path, config: Dict[Any, Any]) -> None:
         self.__root = root
         self.__config = config
 
@@ -67,7 +71,7 @@ class EnvironmentCollectorInterface:
         """
         return {}
 
-    def finalize_config(self, config: dict[str, dict]):
+    def finalize_config(self, config: dict[str, dict]) -> None:
         """
         Finalizes configuration for environments keyed by the environment or matrix name. This will override
         any user-defined settings and any collectors that ran before this call.
@@ -75,7 +79,7 @@ class EnvironmentCollectorInterface:
         This is called before matrices are turned into concrete environments.
         """
 
-    def finalize_environments(self, config: dict[str, dict]):
+    def finalize_environments(self, config: dict[str, dict]) -> None:
         """
         Finalizes configuration for environments keyed by the environment name. This will override
         any user-defined settings and any collectors that ran before this call.

--- a/src/hatch/env/collectors/plugin/interface.py
+++ b/src/hatch/env/collectors/plugin/interface.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import TYPE_CHECKING, Any, Dict
 
-from hatch.utils.fs import Path
+if TYPE_CHECKING:
+    from hatch.utils.fs import Path
 
 
 class EnvironmentCollectorInterface:
@@ -37,7 +38,7 @@ class EnvironmentCollectorInterface:
     PLUGIN_NAME = ''
     """The name used for selection."""
 
-    def __init__(self, root: Path, config: Dict[Any, Any]) -> None:
+    def __init__(self, root: "Path", config: Dict[Any, Any]) -> None:
         self.__root = root
         self.__config = config
 

--- a/src/hatch/env/context.py
+++ b/src/hatch/env/context.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 from hatch.env.utils import get_verbosity_flag
 from hatchling.utils.context import ContextFormatter
@@ -19,7 +19,7 @@ class EnvironmentContextFormatterBase(ContextFormatter, ABC):
 
 
 class EnvironmentContextFormatter(EnvironmentContextFormatterBase):
-    def __init__(self, environment: Union["VirtualEnvironment", "SystemEnvironment"]) -> None:
+    def __init__(self, environment: 'VirtualEnvironment' | 'SystemEnvironment') -> None:
         self.environment = environment
         self.CONTEXT_NAME = f'environment_{environment.PLUGIN_NAME}'
 

--- a/src/hatch/env/context.py
+++ b/src/hatch/env/context.py
@@ -1,7 +1,12 @@
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, Callable, Dict, Union
 
 from hatch.env.utils import get_verbosity_flag
 from hatchling.utils.context import ContextFormatter
+
+if TYPE_CHECKING:
+    from hatch.env.system import SystemEnvironment
+    from hatch.env.virtual import VirtualEnvironment
 
 
 class EnvironmentContextFormatterBase(ContextFormatter, ABC):
@@ -11,11 +16,11 @@ class EnvironmentContextFormatterBase(ContextFormatter, ABC):
 
 
 class EnvironmentContextFormatter(EnvironmentContextFormatterBase):
-    def __init__(self, environment):
+    def __init__(self, environment: Union["VirtualEnvironment", "SystemEnvironment"]) -> None:
         self.environment = environment
         self.CONTEXT_NAME = f'environment_{environment.PLUGIN_NAME}'
 
-    def formatters(self):
+    def formatters(self) -> Dict[Any, Any]:
         """
         This returns a mapping of supported field names to their respective formatting functions. Each function
         accepts 2 arguments:
@@ -25,7 +30,7 @@ class EnvironmentContextFormatter(EnvironmentContextFormatterBase):
         """
         return {}
 
-    def get_formatters(self):
+    def get_formatters(self) -> Dict[str, Callable]:
         formatters = {
             'args': self.__format_args,
             'env_name': self.__format_env_name,

--- a/src/hatch/env/context.py
+++ b/src/hatch/env/context.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Callable, Dict, Union
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Union
 
 from hatch.env.utils import get_verbosity_flag
 from hatchling.utils.context import ContextFormatter
@@ -20,7 +23,7 @@ class EnvironmentContextFormatter(EnvironmentContextFormatterBase):
         self.environment = environment
         self.CONTEXT_NAME = f'environment_{environment.PLUGIN_NAME}'
 
-    def formatters(self) -> Dict[Any, Any]:
+    def formatters(self) -> dict[Any, Any]:
         """
         This returns a mapping of supported field names to their respective formatting functions. Each function
         accepts 2 arguments:
@@ -30,7 +33,7 @@ class EnvironmentContextFormatter(EnvironmentContextFormatterBase):
         """
         return {}
 
-    def get_formatters(self) -> Dict[str, Callable]:
+    def get_formatters(self) -> dict[str, Callable]:
         formatters = {
             'args': self.__format_args,
             'env_name': self.__format_env_name,

--- a/src/hatch/env/plugin/hooks.py
+++ b/src/hatch/env/plugin/hooks.py
@@ -1,4 +1,4 @@
-from typing import List, Type, Union
+from __future__ import annotations
 
 from hatch.env.system import SystemEnvironment
 from hatch.env.virtual import VirtualEnvironment
@@ -6,5 +6,5 @@ from hatchling.plugin import hookimpl
 
 
 @hookimpl
-def hatch_register_environment() -> List[Union[Type[SystemEnvironment], Type[VirtualEnvironment]]]:
+def hatch_register_environment() -> list[type[SystemEnvironment] | type[VirtualEnvironment]]:
     return [SystemEnvironment, VirtualEnvironment]

--- a/src/hatch/env/plugin/hooks.py
+++ b/src/hatch/env/plugin/hooks.py
@@ -1,8 +1,10 @@
+from typing import List, Type, Union
+
 from hatch.env.system import SystemEnvironment
 from hatch.env.virtual import VirtualEnvironment
 from hatchling.plugin import hookimpl
 
 
 @hookimpl
-def hatch_register_environment():
+def hatch_register_environment() -> List[Union[Type[SystemEnvironment], Type[VirtualEnvironment]]]:
     return [SystemEnvironment, VirtualEnvironment]

--- a/src/hatch/env/plugin/interface.py
+++ b/src/hatch/env/plugin/interface.py
@@ -66,10 +66,10 @@ class EnvironmentInterface(ABC):
         name: str,
         config: dict[str, Any],
         matrix_variables: dict[str, str],
-        data_directory: "Path",
-        platform: "Platform",
+        data_directory: 'Path',
+        platform: 'Platform',
         verbosity: int,
-        app: "SafeApplication" | None = None,
+        app: 'SafeApplication' | None = None,
     ) -> None:
         self.__root = root
         self.__metadata = metadata
@@ -104,7 +104,7 @@ class EnvironmentInterface(ABC):
         return self.__matrix_variables
 
     @property
-    def app(self) -> "SafeApplication":
+    def app(self) -> 'SafeApplication':
         """
         An instance of [Application](../utilities.md#hatchling.bridge.app.Application).
         """
@@ -116,7 +116,7 @@ class EnvironmentInterface(ABC):
         return self.__app
 
     @property
-    def context(self) -> "EnvironmentContextFormatter":
+    def context(self) -> 'EnvironmentContextFormatter':
         if self.__context is None:
             self.__context = self.get_context()
 
@@ -134,7 +134,7 @@ class EnvironmentInterface(ABC):
         return self.__root
 
     @property
-    def metadata(self) -> "ProjectMetadata":
+    def metadata(self) -> 'ProjectMetadata':
         return self.__metadata
 
     @property
@@ -145,14 +145,14 @@ class EnvironmentInterface(ABC):
         return self.__name
 
     @property
-    def platform(self) -> "Platform":
+    def platform(self) -> 'Platform':
         """
         An instance of [Platform](../utilities.md#hatch.utils.platform.Platform).
         """
         return self.__platform
 
     @property
-    def data_directory(self) -> "Path":
+    def data_directory(self) -> 'Path':
         """
         The [directory](../../config/hatch.md#environments) reserved exclusively for this plugin as a path-like object.
         """
@@ -295,7 +295,7 @@ class EnvironmentInterface(ABC):
         return self._env_exclude
 
     @property
-    def environment_dependencies_complex(self) -> list["Requirement" | Any]:
+    def environment_dependencies_complex(self) -> list['Requirement' | Any]:
         if self._environment_dependencies_complex is None:
             from packaging.requirements import InvalidRequirement, Requirement
 
@@ -334,7 +334,7 @@ class EnvironmentInterface(ABC):
         return self._environment_dependencies
 
     @property
-    def dependencies_complex(self) -> list["Requirement" | Any]:
+    def dependencies_complex(self) -> list['Requirement' | Any]:
         if self._dependencies_complex is None:
             all_dependencies_complex = list(self.environment_dependencies_complex)
 
@@ -706,7 +706,7 @@ class EnvironmentInterface(ABC):
         with self.get_env_vars():
             yield
 
-    def get_build_process(self, build_environment: "MagicMock" | None, **kwargs) -> "MagicMock" | "Popen":
+    def get_build_process(self, build_environment: 'MagicMock' | None, **kwargs) -> 'MagicMock' | 'Popen':
         """
         This will be called when the
         [build environment](reference.md#hatch.env.plugin.interface.EnvironmentInterface.build_environment)
@@ -745,7 +745,7 @@ class EnvironmentInterface(ABC):
         with self.command_context():
             self.platform.exit_with_command([path, *args])
 
-    def run_shell_command(self, command: str, **kwargs) -> "CompletedProcess":
+    def run_shell_command(self, command: str, **kwargs) -> 'CompletedProcess':
         """
         This should return the standard library's
         [subprocess.CompletedProcess](https://docs.python.org/3/library/subprocess.html#subprocess.CompletedProcess)
@@ -888,7 +888,7 @@ class EnvironmentInterface(ABC):
         """
         return os.environ.get(f'{AppEnvVars.ENV_OPTION_PREFIX}{self.PLUGIN_NAME}_{option}'.upper(), '')
 
-    def get_context(self) -> "EnvironmentContextFormatter":
+    def get_context(self) -> 'EnvironmentContextFormatter':
         """
         Returns a subclass of
         [EnvironmentContextFormatter](../utilities.md#hatch.env.context.EnvironmentContextFormatter).
@@ -910,7 +910,7 @@ class EnvironmentInterface(ABC):
         with self.get_env_vars(), self.metadata.context.apply_context(self.context):
             yield
 
-    def __enter__(self) -> "VirtualEnvironment":
+    def __enter__(self) -> 'VirtualEnvironment':
         self.activate()
         return self
 

--- a/src/hatch/env/plugin/interface.py
+++ b/src/hatch/env/plugin/interface.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import os
 import sys
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
 from contextlib import contextmanager
 from os.path import isabs
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 from hatch.config.constants import AppEnvVars
 from hatch.env.utils import add_verbosity_flag
@@ -59,15 +60,15 @@ class EnvironmentInterface(ABC):
 
     def __init__(
         self,
-        root: "Path",
+        root: Path,
         metadata: ProjectMetadata,
         name: str,
-        config: Dict[str, Any],
-        matrix_variables: Dict[str, str],
+        config: dict[str, Any],
+        matrix_variables: dict[str, str],
         data_directory: "Path",
         platform: "Platform",
         verbosity: int,
-        app: Optional["SafeApplication"] = None,
+        app: "SafeApplication" | None = None,
     ) -> None:
         self.__root = root
         self.__metadata = metadata
@@ -98,7 +99,7 @@ class EnvironmentInterface(ABC):
         self._post_install_commands = None
 
     @property
-    def matrix_variables(self) -> Dict[str, str]:
+    def matrix_variables(self) -> dict[str, str]:
         return self.__matrix_variables
 
     @property
@@ -293,7 +294,7 @@ class EnvironmentInterface(ABC):
         return self._env_exclude
 
     @property
-    def environment_dependencies_complex(self) -> List[Union["Requirement", Any]]:
+    def environment_dependencies_complex(self) -> list["Requirement" | Any]:
         if self._environment_dependencies_complex is None:
             from packaging.requirements import InvalidRequirement, Requirement
 
@@ -332,7 +333,7 @@ class EnvironmentInterface(ABC):
         return self._environment_dependencies
 
     @property
-    def dependencies_complex(self) -> List[Union["Requirement", Any]]:
+    def dependencies_complex(self) -> list["Requirement" | Any]:
         if self._dependencies_complex is None:
             all_dependencies_complex = list(self.environment_dependencies_complex)
 
@@ -456,7 +457,7 @@ class EnvironmentInterface(ABC):
         return self._dev_mode
 
     @property
-    def features(self) -> List[Union[Any, str]]:
+    def features(self) -> list[Any | str]:
         if self._features is None:
             from hatchling.metadata.utils import normalize_project_name
 
@@ -515,7 +516,7 @@ class EnvironmentInterface(ABC):
         return self._description
 
     @property
-    def scripts(self) -> Dict[str, List[str]]:
+    def scripts(self) -> dict[str, list[str]]:
         if self._scripts is None:
             script_config = self.config.get('scripts', {})
             if not isinstance(script_config, dict):
@@ -558,7 +559,7 @@ class EnvironmentInterface(ABC):
         return self._scripts
 
     @property
-    def pre_install_commands(self) -> List[Union[Any, str]]:
+    def pre_install_commands(self) -> list[Any | str]:
         if self._pre_install_commands is None:
             pre_install_commands = self.config.get('pre-install-commands', [])
             if not isinstance(pre_install_commands, list):
@@ -575,7 +576,7 @@ class EnvironmentInterface(ABC):
         return self._pre_install_commands
 
     @property
-    def post_install_commands(self) -> List[Union[Any, str]]:
+    def post_install_commands(self) -> list[Any | str]:
         if self._post_install_commands is None:
             post_install_commands = self.config.get('post-install-commands', [])
             if not isinstance(post_install_commands, list):
@@ -704,7 +705,7 @@ class EnvironmentInterface(ABC):
         with self.get_env_vars():
             yield
 
-    def get_build_process(self, build_environment: Optional["MagicMock"], **kwargs) -> Union["MagicMock", "Popen"]:
+    def get_build_process(self, build_environment: "MagicMock" | None, **kwargs) -> "MagicMock" | "Popen":
         """
         This will be called when the
         [build environment](reference.md#hatch.env.plugin.interface.EnvironmentInterface.build_environment)
@@ -799,7 +800,7 @@ class EnvironmentInterface(ABC):
         clean=False,
         clean_hooks_after=False,
         clean_only=False,
-    ) -> List[str]:
+    ) -> list[str]:
         """
         This is the canonical way [`build`](../../cli/reference.md#hatch-build) command options are translated to
         a subprocess command issued to [builders](../builder/reference.md).
@@ -830,7 +831,7 @@ class EnvironmentInterface(ABC):
 
         return command
 
-    def construct_pip_install_command(self, args: list[str]) -> List[str]:
+    def construct_pip_install_command(self, args: list[str]) -> list[str]:
         """
         A convenience method for constructing a [`pip install`](https://pip.pypa.io/en/stable/cli/pip_install/)
         command with the given verbosity. The default verbosity is set to one less than Hatch's verbosity.
@@ -919,11 +920,11 @@ class EnvironmentInterface(ABC):
 def expand_script_commands(
     env_name: str,
     script_name: str,
-    commands: List[str],
-    config: Dict[str, List[str]],
-    seen: Dict[str, List[str]],
-    active: List[Union[Any, str]],
-) -> List[str]:
+    commands: list[str],
+    config: dict[str, list[str]],
+    seen: dict[str, list[str]],
+    active: list[Any | str],
+) -> list[str]:
     if script_name in seen:
         return seen[script_name]
     elif script_name in active:

--- a/src/hatch/env/plugin/interface.py
+++ b/src/hatch/env/plugin/interface.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from packaging.requirements import Requirement
 
     from hatch.cli.application import SafeApplication
+    from hatch.env.context import EnvironmentContextFormatter
     from hatch.env.virtual import VirtualEnvironment
     from hatch.utils.fs import Path
     from hatch.utils.platform import Platform

--- a/src/hatch/env/system.py
+++ b/src/hatch/env/system.py
@@ -7,7 +7,7 @@ from hatch.utils.env import PythonInfo
 class SystemEnvironment(EnvironmentInterface):
     PLUGIN_NAME = 'system'
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
         self.python_info = PythonInfo(self.platform)
@@ -33,7 +33,7 @@ class SystemEnvironment(EnvironmentInterface):
             self.construct_pip_install_command(['--editable', self.apply_features(str(self.root))])
         )
 
-    def dependencies_in_sync(self):
+    def dependencies_in_sync(self) -> bool:
         if not self.dependencies:
             return True
 

--- a/src/hatch/env/system.py
+++ b/src/hatch/env/system.py
@@ -16,19 +16,19 @@ class SystemEnvironment(EnvironmentInterface):
     def find(self):
         return os.path.dirname(os.path.dirname(self.system_python))
 
-    def create(self):
+    def create(self) -> None:
         self.install_indicator.touch()
 
-    def remove(self):
+    def remove(self) -> None:
         self.install_indicator.remove()
 
     def exists(self):
         return self.install_indicator.is_file()
 
-    def install_project(self):
+    def install_project(self) -> None:
         self.platform.check_command(self.construct_pip_install_command([self.apply_features(str(self.root))]))
 
-    def install_project_dev_mode(self):
+    def install_project_dev_mode(self) -> None:
         self.platform.check_command(
             self.construct_pip_install_command(['--editable', self.apply_features(str(self.root))])
         )
@@ -43,5 +43,5 @@ class SystemEnvironment(EnvironmentInterface):
             self.dependencies_complex, sys_path=self.python_info.sys_path, environment=self.python_info.environment
         )
 
-    def sync_dependencies(self):
+    def sync_dependencies(self) -> None:
         self.platform.check_command(self.construct_pip_install_command(self.dependencies))

--- a/src/hatch/env/utils.py
+++ b/src/hatch/env/utils.py
@@ -5,7 +5,7 @@ def ensure_valid_environment(env_config: dict) -> None:
     env_config.setdefault('type', 'virtual')
 
 
-def get_verbosity_flag(verbosity: int, *, adjustment: int=0) -> str:
+def get_verbosity_flag(verbosity: int, *, adjustment: int = 0) -> str:
     verbosity += adjustment
     if not verbosity:
         return ''
@@ -15,7 +15,7 @@ def get_verbosity_flag(verbosity: int, *, adjustment: int=0) -> str:
         return f'-{"q" * abs(max(verbosity, -3))}'
 
 
-def add_verbosity_flag(command: list[str], verbosity: int, *, adjustment: int=0) -> None:
+def add_verbosity_flag(command: list[str], verbosity: int, *, adjustment: int = 0) -> None:
     flag = get_verbosity_flag(verbosity, adjustment=adjustment)
     if flag:
         command.append(flag)

--- a/src/hatch/env/utils.py
+++ b/src/hatch/env/utils.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 
-def ensure_valid_environment(env_config: dict):
+def ensure_valid_environment(env_config: dict) -> None:
     env_config.setdefault('type', 'virtual')
 
 
-def get_verbosity_flag(verbosity: int, *, adjustment=0) -> str:
+def get_verbosity_flag(verbosity: int, *, adjustment: int=0) -> str:
     verbosity += adjustment
     if not verbosity:
         return ''
@@ -15,7 +15,7 @@ def get_verbosity_flag(verbosity: int, *, adjustment=0) -> str:
         return f'-{"q" * abs(max(verbosity, -3))}'
 
 
-def add_verbosity_flag(command: list[str], verbosity: int, *, adjustment=0):
+def add_verbosity_flag(command: list[str], verbosity: int, *, adjustment: int=0) -> None:
     flag = get_verbosity_flag(verbosity, adjustment=adjustment)
     if flag:
         command.append(flag)

--- a/src/hatch/env/virtual.py
+++ b/src/hatch/env/virtual.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 from base64 import urlsafe_b64encode
+from collections.abc import Iterator
 from contextlib import contextmanager
 from hashlib import sha256
 from os.path import isabs
-from typing import Iterator, List
 
 from hatch.env.plugin.interface import EnvironmentInterface
 from hatch.utils.fs import Path
@@ -117,7 +119,7 @@ class VirtualEnvironment(EnvironmentInterface):
             self.platform.check_command(self.construct_pip_install_command(self.dependencies))
 
     @contextmanager
-    def build_environment(self, dependencies: List[str]) -> Iterator[None]:
+    def build_environment(self, dependencies: list[str]) -> Iterator[None]:
         from packaging.requirements import Requirement
 
         from hatchling.dep.core import dependencies_in_sync

--- a/src/hatch/index/core.py
+++ b/src/hatch/index/core.py
@@ -35,7 +35,7 @@ class PackageIndex:
         *,
         user: str = '',
         auth: str = '',
-        ca_cert: "VerifyTypes" | None = None,
+        ca_cert: 'VerifyTypes' | None = None,
         client_cert: None
         | str
         | tuple[str, str | None]

--- a/src/hatch/index/core.py
+++ b/src/hatch/index/core.py
@@ -36,7 +36,10 @@ class PackageIndex:
         user: str = '',
         auth: str = '',
         ca_cert: "VerifyTypes" | None = None,
-        client_cert: None | str | tuple[str, str | None] | tuple[str, str | None, str | None] = None,  # TODO: simplify complex type hints
+        client_cert: None
+        | str
+        | tuple[str, str | None]
+        | tuple[str, str | None, str | None] = None,  # TODO: simplify complex type hints
         client_key: str | None = None,
     ) -> None:
         self.urls = IndexURLs(repo)

--- a/src/hatch/index/core.py
+++ b/src/hatch/index/core.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Tuple, Union
+from typing import TYPE_CHECKING
 
 import httpx
 import hyperlink
@@ -35,16 +35,16 @@ class PackageIndex:
         *,
         user: str = '',
         auth: str = '',
-        ca_cert: Optional["VerifyTypes"] = None,
-        client_cert: Union[None, str, Tuple[str, Optional[str]], Tuple[str, Optional[str], Optional[str]]] = None,
-        client_key: Optional[str] = None,
+        ca_cert: "VerifyTypes" | None = None,
+        client_cert: None | str | tuple[str, str | None] | tuple[str, str | None, str | None] = None,  # TODO: simplify complex type hints
+        client_key: str | None = None,
     ) -> None:
         self.urls = IndexURLs(repo)
         self.repo = str(self.urls.repo)
         self.user = user
         self.auth = auth
 
-        cert: Union[str, Tuple[str, Optional[str]], None] = None
+        cert: str | tuple[str, str | None] | None = None
         if client_cert:
             cert = client_cert
             if client_key:

--- a/src/hatch/index/core.py
+++ b/src/hatch/index/core.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
+from typing import Optional, Tuple, Union
 
 import httpx
 import hyperlink
 
 from hatch.utils.fs import Path
 
+from httpx._types import VerifyTypes, CertTypes
+
 
 class IndexURLs:
-    def __init__(self, repo: str):
+    def __init__(self, repo: str) -> None:
         self.repo = hyperlink.parse(repo).normalize()
 
         # PyPI
@@ -24,13 +27,22 @@ class IndexURLs:
 
 
 class PackageIndex:
-    def __init__(self, repo: str, *, user='', auth='', ca_cert=None, client_cert=None, client_key=None):
+    def __init__(
+        self,
+        repo: str,
+        *,
+        user: str = '',
+        auth: str = '',
+        ca_cert: Optional[VerifyTypes] = None,
+        client_cert: Optional[str] = None,
+        client_key: Optional[str] = None,
+    ) -> None:
         self.urls = IndexURLs(repo)
         self.repo = str(self.urls.repo)
         self.user = user
         self.auth = auth
 
-        cert = None
+        cert: Union[str, Tuple[str, Optional[str]], None] = None
         if client_cert:
             cert = client_cert
             if client_key:

--- a/src/hatch/index/core.py
+++ b/src/hatch/index/core.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
-from typing import Optional, Tuple, Union
+
+from typing import TYPE_CHECKING, Optional, Tuple, Union
 
 import httpx
 import hyperlink
 
 from hatch.utils.fs import Path
 
-from httpx._types import VerifyTypes, CertTypes
+if TYPE_CHECKING:
+    from httpx._types import VerifyTypes
 
 
 class IndexURLs:
@@ -33,8 +35,8 @@ class PackageIndex:
         *,
         user: str = '',
         auth: str = '',
-        ca_cert: Optional[VerifyTypes] = None,
-        client_cert: Optional[str] = None,
+        ca_cert: Optional["VerifyTypes"] = None,
+        client_cert: Union[None, str, Tuple[str, Optional[str]], Tuple[str, Optional[str], Optional[str]]] = None,
         client_key: Optional[str] = None,
     ) -> None:
         self.urls = IndexURLs(repo)
@@ -50,7 +52,7 @@ class PackageIndex:
 
         self.tls_context = httpx.create_ssl_context(verify=ca_cert or True, cert=cert)
 
-    def upload_artifact(self, artifact: Path, data: dict):
+    def upload_artifact(self, artifact: Path, data: dict) -> None:
         import hashlib
         import io
 

--- a/src/hatch/index/publish.py
+++ b/src/hatch/index/publish.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from hatch.index.errors import ArtifactMetadataError
 
 MULTIPLE_USE_METADATA_FIELDS = {
@@ -80,7 +82,7 @@ def get_sdist_form_data(artifact):
     return data
 
 
-def parse_headers(metadata_file_contents):
+def parse_headers(metadata_file_contents: str) -> Dict[str, Any]:
     import email
 
     message = email.message_from_string(metadata_file_contents)

--- a/src/hatch/index/publish.py
+++ b/src/hatch/index/publish.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict
+from __future__ import annotations
+
+from typing import Any
 
 from hatch.index.errors import ArtifactMetadataError
 
@@ -82,7 +84,7 @@ def get_sdist_form_data(artifact):
     return data
 
 
-def parse_headers(metadata_file_contents: str) -> Dict[str, Any]:
+def parse_headers(metadata_file_contents: str) -> dict[str, Any]:
     import email
 
     message = email.message_from_string(metadata_file_contents)

--- a/src/hatch/plugin/manager.py
+++ b/src/hatch/plugin/manager.py
@@ -19,7 +19,7 @@ class PluginManager(_PluginManager):
 
         self.manager.register(hooks)
 
-    def hatch_register_publisher(self):
+    def hatch_register_publisher(self) -> None:
         from hatch.publish.plugin import hooks
 
         self.manager.register(hooks)

--- a/src/hatch/plugin/manager.py
+++ b/src/hatch/plugin/manager.py
@@ -2,19 +2,19 @@ from hatchling.plugin.manager import PluginManager as _PluginManager
 
 
 class PluginManager(_PluginManager):
-    def initialize(self):
+    def initialize(self) -> None:
         super().initialize()
 
         from hatch.plugin import specs
 
         self.manager.add_hookspecs(specs)
 
-    def hatch_register_environment(self):
+    def hatch_register_environment(self) -> None:
         from hatch.env.plugin import hooks
 
         self.manager.register(hooks)
 
-    def hatch_register_environment_collector(self):
+    def hatch_register_environment_collector(self) -> None:
         from hatch.env.collectors.plugin import hooks
 
         self.manager.register(hooks)
@@ -24,7 +24,7 @@ class PluginManager(_PluginManager):
 
         self.manager.register(hooks)
 
-    def hatch_register_template(self):
+    def hatch_register_template(self) -> None:
         from hatch.template.plugin import hooks
 
         self.manager.register(hooks)

--- a/src/hatch/plugin/specs.py
+++ b/src/hatch/plugin/specs.py
@@ -2,25 +2,25 @@ from hatchling.plugin.specs import hookspec
 
 
 @hookspec
-def hatch_register_environment():
+def hatch_register_environment() -> None:
     """Register new classes that adhere to the environment interface."""
 
 
 @hookspec
-def hatch_register_environment_collector():
+def hatch_register_environment_collector() -> None:
     """Register new classes that adhere to the environment collector interface."""
 
 
 @hookspec
-def hatch_register_version_scheme():
+def hatch_register_version_scheme() -> None:
     """Register new classes that adhere to the version scheme interface."""
 
 
 @hookspec
-def hatch_register_publisher():
+def hatch_register_publisher() -> None:
     """Register new classes that adhere to the publisher interface."""
 
 
 @hookspec
-def hatch_register_template():
+def hatch_register_template() -> None:
     """Register new classes that adhere to the template interface."""

--- a/src/hatch/project/config.py
+++ b/src/hatch/project/config.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 
 class ProjectConfig:
-    def __init__(self, root: "Path", config: dict[str, Any], plugin_manager: "PluginManager" | None = None) -> None:
+    def __init__(self, root: 'Path', config: dict[str, Any], plugin_manager: 'PluginManager' | None = None) -> None:
         self.root = root
         self.config = config
         self.plugin_manager = plugin_manager

--- a/src/hatch/project/config.py
+++ b/src/hatch/project/config.py
@@ -4,7 +4,7 @@ import re
 from copy import deepcopy
 from itertools import product
 from os import environ
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from hatch.env.utils import ensure_valid_environment
 from hatch.project.env import apply_overrides

--- a/src/hatch/project/config.py
+++ b/src/hatch/project/config.py
@@ -439,7 +439,11 @@ def expand_script_commands(
 
 
 def _populate_default_env_values(
-    env_name: str, data: dict[str, Any], config: dict[str, Any], seen: set[str], active: list[Any | str],
+    env_name: str,
+    data: dict[str, Any],
+    config: dict[str, Any],
+    seen: set[str],
+    active: list[Any | str],
 ) -> None:
     if env_name in seen:
         return

--- a/src/hatch/project/config.py
+++ b/src/hatch/project/config.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import re
 from copy import deepcopy
 from itertools import product
 from os import environ
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Type, Union
+from typing import TYPE_CHECKING, Any, Optional
 
 from hatch.env.utils import ensure_valid_environment
 from hatch.project.env import apply_overrides
@@ -14,7 +16,7 @@ if TYPE_CHECKING:
 
 
 class ProjectConfig:
-    def __init__(self, root: "Path", config: Dict[str, Any], plugin_manager: Optional["PluginManager"] = None) -> None:
+    def __init__(self, root: "Path", config: dict[str, Any], plugin_manager: "PluginManager" | None = None) -> None:
         self.root = root
         self.config = config
         self.plugin_manager = plugin_manager
@@ -31,7 +33,7 @@ class ProjectConfig:
     @property
     def env(
         self,
-    ) -> Dict[str, Union[int, Dict[str, Dict[Any, Any]], Dict[str, int], Dict[str, Dict[str, Dict[str, int]]]]]:
+    ) -> dict[str, int | dict[str, dict[Any, Any]] | dict[str, int] | dict[str, dict[str, dict[str, int]]]]:
         if self._env is None:
             config = self.config.get('env', {})
             if not isinstance(config, dict):
@@ -42,7 +44,7 @@ class ProjectConfig:
         return self._env
 
     @property
-    def env_collectors(self) -> Dict[str, Union[Dict[Any, Any], Dict[str, Dict[str, int]]]]:
+    def env_collectors(self) -> dict[str, dict[Any, Any] | dict[str, dict[str, int]]]:
         if self._env_collectors is None:
             collectors = self.env.get('collectors', {})
             if not isinstance(collectors, dict):
@@ -60,21 +62,21 @@ class ProjectConfig:
         return self._env_collectors
 
     @property
-    def matrices(self) -> Dict[str, Any]:
+    def matrices(self) -> dict[str, Any]:
         if self._matrices is None:
             _ = self.envs
 
         return self._matrices
 
     @property
-    def matrix_variables(self) -> Dict[str, Dict[str, str]]:
+    def matrix_variables(self) -> dict[str, dict[str, str]]:
         if self._matrix_variables is None:
             _ = self.envs
 
         return self._matrix_variables
 
     @property
-    def envs(self) -> Dict[str, Any]:
+    def envs(self) -> dict[str, Any]:
         from hatch.utils.platform import get_platform_name
 
         if self._envs is None:
@@ -334,7 +336,7 @@ class ProjectConfig:
         return self._envs
 
     @property
-    def publish(self) -> Dict[str, Dict[str, str]]:
+    def publish(self) -> dict[str, dict[str, str]]:
         if self._publish is None:
             config = self.config.get('publish', {})
             if not isinstance(config, dict):
@@ -349,7 +351,7 @@ class ProjectConfig:
         return self._publish
 
     @property
-    def scripts(self) -> Dict[str, List[str]]:
+    def scripts(self) -> dict[str, list[str]]:
         if self._scripts is None:
             script_config = self.config.get('scripts', {})
             if not isinstance(script_config, dict):
@@ -385,7 +387,7 @@ class ProjectConfig:
 
         return self._scripts
 
-    def finalize_env_overrides(self, option_types: Dict[str, Union[Type[bool], Type[str], Type[dict]]]) -> None:
+    def finalize_env_overrides(self, option_types: dict[str, type[bool] | type[str] | type[dict]]) -> None:
         # We lazily apply overrides because we need type information potentially defined by
         # environment plugins for their options
         if not self._cached_env_overrides:
@@ -401,11 +403,11 @@ class ProjectConfig:
 
 def expand_script_commands(
     script_name: str,
-    commands: List[str],
-    config: Dict[str, List[str]],
-    seen: Dict[str, List[str]],
-    active: List[Union[Any, str]],
-) -> List[str]:
+    commands: list[str],
+    config: dict[str, list[str]],
+    seen: dict[str, list[str]],
+    active: list[Any | str],
+) -> list[str]:
     if script_name in seen:
         return seen[script_name]
     elif script_name in active:
@@ -437,7 +439,7 @@ def expand_script_commands(
 
 
 def _populate_default_env_values(
-    env_name: str, data: Dict[str, Any], config: Dict[str, Any], seen: Set[str], active: List[Union[Any, str]],
+    env_name: str, data: dict[str, Any], config: dict[str, Any], seen: set[str], active: list[Any | str],
 ) -> None:
     if env_name in seen:
         return

--- a/src/hatch/project/config.py
+++ b/src/hatch/project/config.py
@@ -2,22 +2,19 @@ import re
 from copy import deepcopy
 from itertools import product
 from os import environ
-from typing import Any, Dict, List, Optional, Set, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Type, Union
 
 from hatch.env.utils import ensure_valid_environment
-from hatch.plugin.manager import PluginManager
 from hatch.project.env import apply_overrides
 from hatch.project.utils import format_script_commands, parse_script_command
-from hatch.utils.fs import Path
+
+if TYPE_CHECKING:
+    from hatch.plugin.manager import PluginManager
+    from hatch.utils.fs import Path
 
 
 class ProjectConfig:
-    def __init__(
-        self,
-        root: Path,
-        config: Dict[str, Any],
-        plugin_manager: Optional[PluginManager] = None,
-    ) -> None:
+    def __init__(self, root: "Path", config: Dict[str, Any], plugin_manager: Optional["PluginManager"] = None) -> None:
         self.root = root
         self.config = config
         self.plugin_manager = plugin_manager
@@ -34,7 +31,7 @@ class ProjectConfig:
     @property
     def env(
         self,
-    ) -> Dict[str, Union[Dict[str, Dict[Any, Any]], Dict[str, int], Dict[str, Dict[str, Dict[str, int]]], int]]:
+    ) -> Dict[str, Union[int, Dict[str, Dict[Any, Any]], Dict[str, int], Dict[str, Dict[str, Dict[str, int]]]]]:
         if self._env is None:
             config = self.config.get('env', {})
             if not isinstance(config, dict):
@@ -440,11 +437,7 @@ def expand_script_commands(
 
 
 def _populate_default_env_values(
-    env_name: str,
-    data: Dict[str, Any],
-    config: Dict[str, Any],
-    seen: Set[str],
-    active: List[Union[Any, str]],
+    env_name: str, data: Dict[str, Any], config: Dict[str, Any], seen: Set[str], active: List[Union[Any, str]],
 ) -> None:
     if env_name in seen:
         return

--- a/src/hatch/project/core.py
+++ b/src/hatch/project/core.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import re
+from typing import Optional
 
 from hatch.config.model import RootConfig
 from hatch.utils.fs import Path
 
 
 class Project:
-    def __init__(self, path: Path, *, name: str = None, config=None):
+    def __init__(self, path: Path, *, name: Optional[str] = None, config=None) -> None:
         self._path = path
 
         # From app config
@@ -90,7 +91,7 @@ class Project:
             path = new_path
 
     @staticmethod
-    def canonicalize_name(name: str, strict=True) -> str:
+    def canonicalize_name(name: str, strict: bool = True) -> str:
         if strict:
             return re.sub(r'[-_.]+', '-', name).lower()
         else:
@@ -119,14 +120,14 @@ class Project:
 
         return self._raw_config
 
-    def save_config(self, config):
+    def save_config(self, config) -> None:
         import tomlkit
 
         with open(str(self._project_file_path), 'w', encoding='utf-8') as f:
             f.write(tomlkit.dumps(config))
 
     @staticmethod
-    def initialize(project_file_path, template_config):
+    def initialize(project_file_path, template_config) -> None:
         import tomlkit
 
         with open(str(project_file_path), encoding='utf-8') as f:

--- a/src/hatch/project/core.py
+++ b/src/hatch/project/core.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import re
-from typing import Optional
 
 from hatch.config.model import RootConfig
 from hatch.utils.fs import Path
 
 
 class Project:
-    def __init__(self, path: Path, *, name: Optional[str] = None, config=None) -> None:
+    def __init__(self, path: Path, *, name: str | None = None, config=None) -> None:
         self._path = path
 
         # From app config

--- a/src/hatch/project/env.py
+++ b/src/hatch/project/env.py
@@ -1,4 +1,5 @@
 from os import environ
+from typing import Any, Dict, List, Optional, Type, Union
 
 from hatch.utils.platform import get_platform_name
 
@@ -21,7 +22,15 @@ RESERVED_OPTIONS = {
 }
 
 
-def apply_overrides(env_name, source, condition, condition_value, options, new_config, option_types=None):
+def apply_overrides(
+    env_name: str,
+    source: str,
+    condition: str,
+    condition_value: str,
+    options: Dict[str, Any],
+    new_config: Dict,
+    option_types: Optional[Dict[str, Type]] = None,
+) -> None:
     if option_types is None:
         option_types = RESERVED_OPTIONS
 
@@ -48,7 +57,16 @@ def apply_overrides(env_name, source, condition, condition_value, options, new_c
             )
 
 
-def _apply_override_to_mapping(env_name, option, data, source, condition, condition_value, new_config, overwrite):
+def _apply_override_to_mapping(
+    env_name: str,
+    option: str,
+    data: Any,
+    source: str,
+    condition: str,
+    condition_value: str,
+    new_config: Dict[str, Union[str, bool, Dict[str, str]]],
+    overwrite: bool,
+) -> None:
     new_mapping = {}
     if isinstance(data, str):
         key, separator, value = data.partition('=')
@@ -105,7 +123,16 @@ def _apply_override_to_mapping(env_name, option, data, source, condition, condit
         new_config[option] = new_mapping
 
 
-def _apply_override_to_array(env_name, option, data, source, condition, condition_value, new_config, overwrite):
+def _apply_override_to_array(
+    env_name: str,
+    option: str,
+    data: Any,
+    source: str,
+    condition: str,
+    condition_value: str,
+    new_config: Dict[str, Union[bool, List[str], str]],
+    overwrite: bool,
+) -> None:
     if not isinstance(data, list):
         raise TypeError(f'Field `tool.hatch.envs.{env_name}.overrides.{source}.{condition}.{option}` must be an array')
 
@@ -146,7 +173,16 @@ def _apply_override_to_array(env_name, option, data, source, condition, conditio
         new_config[option] = new_array
 
 
-def _apply_override_to_string(env_name, option, data, source, condition, condition_value, new_config, overwrite):
+def _apply_override_to_string(
+    env_name: str,
+    option: str,
+    data: Any,
+    source: str,
+    condition: str,
+    condition_value: str,
+    new_config: Dict[str, Union[str, bool]],
+    overwrite: bool,
+) -> None:
     if isinstance(data, str):
         new_config[option] = data
     elif isinstance(data, dict):
@@ -195,7 +231,16 @@ def _apply_override_to_string(env_name, option, data, source, condition, conditi
         )
 
 
-def _apply_override_to_boolean(env_name, option, data, source, condition, condition_value, new_config, overwrite):
+def _apply_override_to_boolean(
+    env_name: str,
+    option: str,
+    data: Any,
+    source: str,
+    condition: str,
+    condition_value: str,
+    new_config: Dict[str, Union[bool, List[Dict[str, List[str]]], str]],
+    overwrite: bool,
+) -> None:
     if isinstance(data, bool):
         new_config[option] = data
     elif isinstance(data, dict):
@@ -244,7 +289,15 @@ def _apply_override_to_boolean(env_name, option, data, source, condition, condit
         )
 
 
-def _resolve_condition(env_name, option, source, condition, condition_value, condition_config, condition_index=None):
+def _resolve_condition(
+    env_name: str,
+    option: str,
+    source: str,
+    condition: str,
+    condition_value: str,
+    condition_config: Dict[str, Union[bool, List[str], str, int, List[int]]],
+    condition_index: Optional[int] = None,
+) -> bool:
     location = 'field' if condition_index is None else f'entry #{condition_index} in field'
 
     if 'if' in condition_config:

--- a/src/hatch/project/env.py
+++ b/src/hatch/project/env.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 from os import environ
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any
 
 from hatch.utils.platform import get_platform_name
 
-RESERVED_OPTIONS: Dict[str, Type[Union[bool, dict, list, str]]] = {
+RESERVED_OPTIONS: dict[str, type[bool | dict | list | str]] = {
     'dependencies': list,
     'extra-dependencies': list,
     'dev-mode': bool,
@@ -27,9 +29,9 @@ def apply_overrides(
     source: str,
     condition: str,
     condition_value: str,
-    options: Dict[str, Any],
-    new_config: Dict[str, Union[bool, List[Dict[str, List[str]]], str, List[str], Dict[str, str]]],
-    option_types: Optional[Union[Dict[str, Union[Type[bool], Type[str], Type[dict]]], Dict[str, Type[bool]]]] = None,
+    options: dict[str, Any],
+    new_config: dict[str, bool | list[dict[str, list[str]]] | str | list[str] | dict[str, str]],
+    option_types: dict[str, type[bool] | type[str] | type[dict]] | dict[str, type[bool]] | None = None,
 ) -> None:
     if option_types is None:
         option_types = RESERVED_OPTIONS
@@ -64,7 +66,7 @@ def _apply_override_to_mapping(
     source: str,
     condition: str,
     condition_value: str,
-    new_config: Dict[str, Union[str, bool, Dict[str, str]]],
+    new_config: dict[str, str | bool | dict[str, str]],
     overwrite: bool,
 ) -> None:
     new_mapping = {}
@@ -130,7 +132,7 @@ def _apply_override_to_array(
     source: str,
     condition: str,
     condition_value: str,
-    new_config: Dict[str, Union[bool, List[str], str]],
+    new_config: dict[str, bool | list[str] | str],
     overwrite: bool,
 ) -> None:
     if not isinstance(data, list):
@@ -180,7 +182,7 @@ def _apply_override_to_string(
     source: str,
     condition: str,
     condition_value: str,
-    new_config: Dict[str, Union[bool, str]],
+    new_config: dict[str, bool | str],
     overwrite: bool,
 ) -> None:
     if isinstance(data, str):
@@ -238,7 +240,7 @@ def _apply_override_to_boolean(
     source: str,
     condition: str,
     condition_value: str,
-    new_config: Dict[str, Union[bool, List[Dict[str, List[str]]], str]],
+    new_config: dict[str, bool | list[dict[str, list[str]]] | str],
     overwrite: bool,
 ) -> None:
     if isinstance(data, bool):
@@ -295,8 +297,8 @@ def _resolve_condition(
     source: str,
     condition: str,
     condition_value: str,
-    condition_config: Dict[str, Union[str, int, bool, List[str], List[int]]],
-    condition_index: Optional[int] = None,
+    condition_config: dict[str, str | int | bool | list[str] | list[int]],
+    condition_index: int | None = None,
 ) -> bool:
     location = 'field' if condition_index is None else f'entry #{condition_index} in field'
 

--- a/src/hatch/project/env.py
+++ b/src/hatch/project/env.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Type, Union
 
 from hatch.utils.platform import get_platform_name
 
-RESERVED_OPTIONS = {
+RESERVED_OPTIONS: Dict[str, Type[Union[bool, dict, list, str]]] = {
     'dependencies': list,
     'extra-dependencies': list,
     'dev-mode': bool,
@@ -28,8 +28,8 @@ def apply_overrides(
     condition: str,
     condition_value: str,
     options: Dict[str, Any],
-    new_config: Dict,
-    option_types: Optional[Dict[str, Type]] = None,
+    new_config: Dict[str, Union[bool, List[Dict[str, List[str]]], str, List[str], Dict[str, str]]],
+    option_types: Optional[Union[Dict[str, Union[Type[bool], Type[str], Type[dict]]], Dict[str, Type[bool]]]] = None,
 ) -> None:
     if option_types is None:
         option_types = RESERVED_OPTIONS
@@ -180,7 +180,7 @@ def _apply_override_to_string(
     source: str,
     condition: str,
     condition_value: str,
-    new_config: Dict[str, Union[str, bool]],
+    new_config: Dict[str, Union[bool, str]],
     overwrite: bool,
 ) -> None:
     if isinstance(data, str):
@@ -295,7 +295,7 @@ def _resolve_condition(
     source: str,
     condition: str,
     condition_value: str,
-    condition_config: Dict[str, Union[bool, List[str], str, int, List[int]]],
+    condition_config: Dict[str, Union[str, int, bool, List[str], List[int]]],
     condition_index: Optional[int] = None,
 ) -> bool:
     location = 'field' if condition_index is None else f'entry #{condition_index} in field'

--- a/src/hatch/project/utils.py
+++ b/src/hatch/project/utils.py
@@ -1,4 +1,7 @@
-def parse_script_command(command):
+from typing import Iterator, List, Tuple
+
+
+def parse_script_command(command: str) -> Tuple[str, str, bool]:
     possible_script, _, args = command.partition(' ')
     if possible_script == '-':
         ignore_exit_code = True
@@ -9,7 +12,7 @@ def parse_script_command(command):
     return possible_script, args, ignore_exit_code
 
 
-def format_script_commands(commands, args, ignore_exit_code):
+def format_script_commands(commands: List[str], args: str, ignore_exit_code: bool) -> Iterator[str]:
     for command in commands:
         if args:
             command = f'{command} {args}'

--- a/src/hatch/project/utils.py
+++ b/src/hatch/project/utils.py
@@ -1,7 +1,9 @@
-from typing import Iterator, List, Tuple
+from __future__ import annotations
+
+from collections.abc import Iterator
 
 
-def parse_script_command(command: str) -> Tuple[str, str, bool]:
+def parse_script_command(command: str) -> tuple[str, str, bool]:
     possible_script, _, args = command.partition(' ')
     if possible_script == '-':
         ignore_exit_code = True
@@ -12,7 +14,7 @@ def parse_script_command(command: str) -> Tuple[str, str, bool]:
     return possible_script, args, ignore_exit_code
 
 
-def format_script_commands(commands: List[str], args: str, ignore_exit_code: bool) -> Iterator[str]:
+def format_script_commands(commands: list[str], args: str, ignore_exit_code: bool) -> Iterator[str]:
     for command in commands:
         if args:
             command = f'{command} {args}'

--- a/src/hatch/publish/index.py
+++ b/src/hatch/publish/index.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import Generator
+from collections.abc import Generator
 
 from hatch.publish.plugin.interface import PublisherInterface
 from hatch.utils.fs import Path

--- a/src/hatch/publish/index.py
+++ b/src/hatch/publish/index.py
@@ -39,7 +39,7 @@ class IndexPublisher(PublisherInterface):
 
         return repos
 
-    def publish(self, artifacts: list, options: dict):
+    def publish(self, artifacts: list, options: dict) -> None:
         """
         https://warehouse.readthedocs.io/api-reference/legacy.html#upload-api
         """
@@ -194,7 +194,7 @@ def parse_artifacts(artifact_payload):
 
 
 class CachedUserFile:
-    def __init__(self, cache_dir: Path):
+    def __init__(self, cache_dir: Path) -> None:
         self.path = cache_dir / 'previous_working_users.json'
 
         self._data = None
@@ -202,7 +202,7 @@ class CachedUserFile:
     def get_user(self, repo: str):
         return self.data.get(repo)
 
-    def set_user(self, repo: str, user: str):
+    def set_user(self, repo: str, user: str) -> None:
         import json
 
         self.data[repo] = user

--- a/src/hatch/publish/plugin/interface.py
+++ b/src/hatch/publish/plugin/interface.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import Dict, Optional, Union
+
+from hatch.utils.fs import Path
 
 
 class PublisherInterface(ABC):
@@ -35,14 +38,21 @@ class PublisherInterface(ABC):
     PLUGIN_NAME = ''
     """The name used for selection."""
 
-    def __init__(self, app, root, cache_dir, project_config, plugin_config):
+    def __init__(
+        self,
+        app: None,
+        root: Path,
+        cache_dir: None,
+        project_config: Dict[str, Union[int, bool]],
+        plugin_config: Dict[str, Union[int, bool]],
+    ) -> None:
         self.__app = app
         self.__root = root
         self.__cache_dir = cache_dir
         self.__project_config = project_config
         self.__plugin_config = plugin_config
 
-        self.__disable = None
+        self.__disable: Optional[bool] = None
 
     @property
     def app(self):
@@ -96,7 +106,7 @@ class PublisherInterface(ABC):
         return self.__plugin_config
 
     @property
-    def disable(self):
+    def disable(self) -> bool:
         """
         Whether this plugin is disabled, thus requiring confirmation when publishing. Local
         [project configuration](reference.md#hatch.publish.plugin.interface.PublisherInterface.project_config)

--- a/src/hatch/publish/plugin/interface.py
+++ b/src/hatch/publish/plugin/interface.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Dict, Optional, Union
+from typing import TYPE_CHECKING, Dict, Optional, Union
 
-from hatch.utils.fs import Path
+if TYPE_CHECKING:
+    from hatch.utils.fs import Path
 
 
 class PublisherInterface(ABC):
@@ -41,7 +42,7 @@ class PublisherInterface(ABC):
     def __init__(
         self,
         app: None,
-        root: Path,
+        root: "Path",
         cache_dir: None,
         project_config: Dict[str, Union[int, bool]],
         plugin_config: Dict[str, Union[int, bool]],
@@ -55,7 +56,7 @@ class PublisherInterface(ABC):
         self.__disable: Optional[bool] = None
 
     @property
-    def app(self):
+    def app(self) -> None:
         """
         An instance of [Application](../utilities.md#hatchling.bridge.app.Application).
         """
@@ -69,7 +70,7 @@ class PublisherInterface(ABC):
         return self.__root
 
     @property
-    def cache_dir(self):
+    def cache_dir(self) -> None:
         """
         The directory reserved exclusively for this plugin as a path-like object.
         """

--- a/src/hatch/publish/plugin/interface.py
+++ b/src/hatch/publish/plugin/interface.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Dict, Optional, Union
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from hatch.utils.fs import Path
@@ -44,8 +44,8 @@ class PublisherInterface(ABC):
         app: None,
         root: "Path",
         cache_dir: None,
-        project_config: Dict[str, Union[int, bool]],
-        plugin_config: Dict[str, Union[int, bool]],
+        project_config: dict[str, int | bool],
+        plugin_config: dict[str, int | bool],
     ) -> None:
         self.__app = app
         self.__root = root
@@ -53,7 +53,7 @@ class PublisherInterface(ABC):
         self.__project_config = project_config
         self.__plugin_config = plugin_config
 
-        self.__disable: Optional[bool] = None
+        self.__disable: bool | None = None
 
     @property
     def app(self) -> None:

--- a/src/hatch/publish/plugin/interface.py
+++ b/src/hatch/publish/plugin/interface.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from hatch.utils.fs import Path
@@ -44,8 +44,8 @@ class PublisherInterface(ABC):
         app: None,
         root: "Path",
         cache_dir: None,
-        project_config: dict[str, int | bool],
-        plugin_config: dict[str, int | bool],
+        project_config: dict[str, Any],
+        plugin_config: dict[str, Any],
     ) -> None:
         self.__app = app
         self.__root = root

--- a/src/hatch/publish/plugin/interface.py
+++ b/src/hatch/publish/plugin/interface.py
@@ -42,7 +42,7 @@ class PublisherInterface(ABC):
     def __init__(
         self,
         app: None,
-        root: "Path",
+        root: 'Path',
         cache_dir: None,
         project_config: dict[str, Any],
         plugin_config: dict[str, Any],

--- a/src/hatch/template/__init__.py
+++ b/src/hatch/template/__init__.py
@@ -1,16 +1,16 @@
 from contextlib import suppress
-from typing import Optional
+from typing import Generator, Optional
 
 from hatch.utils.fs import Path
 
 
 class File:
-    def __init__(self, path: Optional[Path], contents: str = ''):
+    def __init__(self, path: Optional[Path], contents: str = '') -> None:
         self.path = path
         self.contents = contents
         self.feature = None
 
-    def write(self, root):
+    def write(self, root: Path) -> None:
         if self.path is None:  # no cov
             return
 
@@ -19,12 +19,12 @@ class File:
         path.write_text(self.contents, encoding='utf-8')
 
 
-def find_template_files(module):
+def find_template_files(module) -> Generator[File, None, None]:
     for name in dir(module):
         obj = getattr(module, name)
-        if obj is File:
+        if type(obj) is File:
             continue
 
         with suppress(TypeError):
-            if issubclass(obj, File):
+            if issubclass(type(obj), File):
                 yield obj

--- a/src/hatch/template/__init__.py
+++ b/src/hatch/template/__init__.py
@@ -1,11 +1,13 @@
+from __future__ import annotations
+
+from collections.abc import Generator
 from contextlib import suppress
-from typing import Generator, Optional
 
 from hatch.utils.fs import Path
 
 
 class File:
-    def __init__(self, path: Optional[Path], contents: str = '') -> None:
+    def __init__(self, path: Path | None, contents: str = '') -> None:
         self.path = path
         self.contents = contents
         self.feature = None

--- a/src/hatch/template/__init__.py
+++ b/src/hatch/template/__init__.py
@@ -22,9 +22,9 @@ class File:
 def find_template_files(module) -> Generator[File, None, None]:
     for name in dir(module):
         obj = getattr(module, name)
-        if type(obj) is File:
+        if obj is File:
             continue
 
         with suppress(TypeError):
-            if issubclass(type(obj), File):
+            if issubclass(obj, File):
                 yield obj

--- a/src/hatch/template/default.py
+++ b/src/hatch/template/default.py
@@ -1,4 +1,7 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Set, Union
+# TODO: simplify complex type hints
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from hatch.template import File, files_default, find_template_files
 from hatch.template.plugin.interface import TemplateInterface
@@ -20,7 +23,7 @@ class DefaultTemplate(TemplateInterface):
         self.plugin_config.setdefault('tests', True)
 
     def initialize_config(
-        self, config: Dict[str, Union[str, Dict[str, Union[bool, List[str]]], Dict[str, bool]]]
+        self, config: dict[str, str | dict[str, bool | list[str]] | dict[str, bool]]
     ) -> None:
         # Default values
         config['readme_file_path'] = 'README.md'
@@ -82,8 +85,8 @@ class DefaultTemplate(TemplateInterface):
 
     def get_files(
         self,
-        config: Dict[str, Union[str, Dict[str, Union[bool, List[str]]], Set[str], Dict[str, bool], Dict[str, str]]],
-    ) -> List[Any]:
+        config: dict[str, str | dict[str, bool | list[str]] | set[str] | dict[str, bool] | dict[str, str]],
+    ) -> list[Any]:
         files = list(find_template_files(files_default))
 
         # Add any licenses
@@ -118,8 +121,8 @@ class DefaultTemplate(TemplateInterface):
 
     def finalize_files(
         self,
-        config: Dict[str, Union[str, Dict[str, Union[bool, List[str]]], Set[str], Dict[str, bool], Dict[str, str]]],
-        files: List[File],
+        config: dict[str, str | dict[str, bool | list[str]] | set[str] | dict[str, bool] | dict[str, str]],
+        files: list[File],
     ) -> None:
         if config['licenses']['headers'] and config['license_data']:
             for template_file in files:
@@ -133,7 +136,7 @@ class DefaultTemplate(TemplateInterface):
 
 
 def get_license_text(
-    config: Dict[str, Union[str, Dict[str, Union[bool, List[str]]], Set[str], Dict[str, bool], Dict[str, str]]],
+    config: dict[str, str | dict[str, bool | list[str]] | set[str] | dict[str, bool] | dict[str, str]],
     license_id: str,
     license_text: str,
     creation_time: "datetime",

--- a/src/hatch/template/default.py
+++ b/src/hatch/template/default.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+from typing import Any, Dict, List, Set, Union
+
 from hatch.template import File, files_default, find_template_files
 from hatch.template.plugin.interface import TemplateInterface
 from hatch.utils.fs import Path
@@ -7,14 +10,14 @@ from hatch.utils.network import download_file
 class DefaultTemplate(TemplateInterface):
     PLUGIN_NAME = 'default'
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
         self.plugin_config.setdefault('ci', False)
         self.plugin_config.setdefault('src-layout', False)
         self.plugin_config.setdefault('tests', True)
 
-    def initialize_config(self, config):
+    def initialize_config(self, config: Dict) -> None:
         # Default values
         config['readme_file_path'] = 'README.md'
         config['package_metadata_file_path'] = f'{config["package_name"]}/__about__.py'
@@ -73,7 +76,7 @@ class DefaultTemplate(TemplateInterface):
         if self.plugin_config['src-layout']:
             config['package_metadata_file_path'] = f'src/{config["package_metadata_file_path"]}'
 
-    def get_files(self, config):
+    def get_files(self, config: Dict) -> List[Any]:
         files = list(find_template_files(files_default))
 
         # Add any licenses
@@ -106,19 +109,24 @@ class DefaultTemplate(TemplateInterface):
 
         return files
 
-    def finalize_files(self, config, files):
+    def finalize_files(self, config: Dict, files: List[File]) -> None:
         if config['licenses']['headers'] and config['license_data']:
             for template_file in files:
-                if template_file.path.name.endswith('.py'):
+                if template_file.path and template_file.path.name.endswith('.py'):
                     template_file.contents = config['license_header'] + template_file.contents
 
         if self.plugin_config['src-layout']:
             for template_file in files:
-                if template_file.path.parts[0] == config['package_name']:
+                if template_file.path and template_file.path.parts[0] == config['package_name']:
                     template_file.path = Path('src', template_file.path)
 
 
-def get_license_text(config, license_id, license_text, creation_time):
+def get_license_text(
+    config: Dict,
+    license_id: str,
+    license_text: str,
+    creation_time: datetime,
+) -> str:
     if license_id == 'MIT':
         license_text = license_text.replace('<year>', f'{creation_time.year}-present', 1)
         license_text = license_text.replace('<copyright holders>', f'{config["name"]} <{config["email"]}>', 1)

--- a/src/hatch/template/default.py
+++ b/src/hatch/template/default.py
@@ -137,7 +137,7 @@ def get_license_text(
     config: dict[str, str | dict[str, bool | list[str]] | set[str] | dict[str, bool] | dict[str, str]],
     license_id: str,
     license_text: str,
-    creation_time: "datetime",
+    creation_time: 'datetime',
 ) -> str:
     if license_id == 'MIT':
         license_text = license_text.replace('<year>', f'{creation_time.year}-present', 1)

--- a/src/hatch/template/default.py
+++ b/src/hatch/template/default.py
@@ -1,7 +1,7 @@
 # TODO: simplify complex type hints
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from hatch.template import File, files_default, find_template_files
 from hatch.template.plugin.interface import TemplateInterface
@@ -22,9 +22,7 @@ class DefaultTemplate(TemplateInterface):
         self.plugin_config.setdefault('src-layout', False)
         self.plugin_config.setdefault('tests', True)
 
-    def initialize_config(
-        self, config: dict[str, str | dict[str, bool | list[str]] | dict[str, bool]]
-    ) -> None:
+    def initialize_config(self, config: dict[str, str | dict[str, bool | list[str]] | dict[str, bool]]) -> None:
         # Default values
         config['readme_file_path'] = 'README.md'
         config['package_metadata_file_path'] = f'{config["package_name"]}/__about__.py'

--- a/src/hatch/template/files_default.py
+++ b/src/hatch/template/files_default.py
@@ -3,12 +3,12 @@ from hatch.utils.fs import Path
 
 
 class PackageRoot(File):
-    def __init__(self, template_config: dict, plugin_config: dict):
+    def __init__(self, template_config: dict, plugin_config: dict) -> None:
         super().__init__(Path(template_config['package_name'], '__init__.py'), '')
 
 
 class MetadataFile(File):
-    def __init__(self, template_config: dict, plugin_config: dict):
+    def __init__(self, template_config: dict, plugin_config: dict) -> None:
         super().__init__(Path(template_config['package_name'], '__about__.py'), "__version__ = '0.0.1'\n")
 
 
@@ -32,7 +32,7 @@ pip install {project_name_normalized}
 ```{license_info}
 """  # noqa: E501
 
-    def __init__(self, template_config: dict, plugin_config: dict):
+    def __init__(self, template_config: dict, plugin_config: dict) -> None:
         extra_badges = ''
         extra_toc = ''
 
@@ -96,7 +96,7 @@ dynamic = ["version"]
 path = "{package_metadata_file_path}"{tests_section}
 """
 
-    def __init__(self, template_config: dict, plugin_config: dict):
+    def __init__(self, template_config: dict, plugin_config: dict) -> None:
         template_config = dict(template_config)
         template_config['name'] = repr(template_config['name'])[1:-1]
 

--- a/src/hatch/template/files_feature_ci.py
+++ b/src/hatch/template/files_feature_ci.py
@@ -45,5 +45,5 @@ jobs:
       run: hatch run cov
 """  # noqa: E501
 
-    def __init__(self, template_config: dict, plugin_config: dict):
+    def __init__(self, template_config: dict, plugin_config: dict) -> None:
         super().__init__(Path('.github', 'workflows', 'test.yml'), self.TEMPLATE)

--- a/src/hatch/template/files_feature_cli.py
+++ b/src/hatch/template/files_feature_cli.py
@@ -12,7 +12,7 @@ if __name__ == '__main__':
     sys.exit({package_name}())
 """
 
-    def __init__(self, template_config: dict, plugin_config: dict):
+    def __init__(self, template_config: dict, plugin_config: dict) -> None:
         super().__init__(Path(template_config['package_name'], '__main__.py'), self.TEMPLATE.format(**template_config))
 
 
@@ -30,7 +30,7 @@ def {package_name}(ctx: click.Context):
     click.echo('Hello world!')
 """
 
-    def __init__(self, template_config: dict, plugin_config: dict):
+    def __init__(self, template_config: dict, plugin_config: dict) -> None:
         super().__init__(
             Path(template_config['package_name'], 'cli', '__init__.py'), self.TEMPLATE.format(**template_config)
         )

--- a/src/hatch/template/files_feature_tests.py
+++ b/src/hatch/template/files_feature_tests.py
@@ -3,5 +3,5 @@ from hatch.utils.fs import Path
 
 
 class TestsPackageRoot(File):
-    def __init__(self, template_config: dict, plugin_config: dict):
+    def __init__(self, template_config: dict, plugin_config: dict) -> None:
         super().__init__(Path('tests', '__init__.py'))

--- a/src/hatch/template/plugin/hooks.py
+++ b/src/hatch/template/plugin/hooks.py
@@ -1,9 +1,9 @@
-from typing import Type
+from __future__ import annotations
 
 from hatch.template.default import DefaultTemplate
 from hatchling.plugin import hookimpl
 
 
 @hookimpl
-def hatch_register_template() -> Type[DefaultTemplate]:
+def hatch_register_template() -> type[DefaultTemplate]:
     return DefaultTemplate

--- a/src/hatch/template/plugin/hooks.py
+++ b/src/hatch/template/plugin/hooks.py
@@ -1,7 +1,9 @@
+from typing import Type
+
 from hatch.template.default import DefaultTemplate
 from hatchling.plugin import hookimpl
 
 
 @hookimpl
-def hatch_register_template():
+def hatch_register_template() -> Type[DefaultTemplate]:
     return DefaultTemplate

--- a/src/hatch/template/plugin/interface.py
+++ b/src/hatch/template/plugin/interface.py
@@ -1,18 +1,21 @@
-from datetime import datetime
+from typing import TYPE_CHECKING, Dict
 
-from hatch.utils.fs import Path
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from hatch.utils.fs import Path
 
 
 class TemplateInterface:
     PLUGIN_NAME = ''
     PRIORITY = 100
 
-    def __init__(self, plugin_config: dict, cache_dir: Path, creation_time: datetime) -> None:
+    def __init__(self, plugin_config: Dict, cache_dir: "Path", creation_time: "datetime") -> None:
         self.plugin_config = plugin_config
         self.cache_dir = cache_dir
         self.creation_time = creation_time
 
-    def initialize_config(self, config):
+    def initialize_config(self, config) -> None:
         """
         Allow modification of the configuration passed to every file for new projects
         before the list of files are determined.
@@ -22,6 +25,6 @@ class TemplateInterface:
         """Add to the list of files for new projects that are written to the file system."""
         return []
 
-    def finalize_files(self, config, files):
+    def finalize_files(self, config, files) -> None:
         """Allow modification of files for new projects before they are written to the file system."""
         pass

--- a/src/hatch/template/plugin/interface.py
+++ b/src/hatch/template/plugin/interface.py
@@ -1,8 +1,13 @@
+from datetime import datetime
+
+from hatch.utils.fs import Path
+
+
 class TemplateInterface:
     PLUGIN_NAME = ''
     PRIORITY = 100
 
-    def __init__(self, plugin_config: dict, cache_dir, creation_time):
+    def __init__(self, plugin_config: dict, cache_dir: Path, creation_time: datetime) -> None:
         self.plugin_config = plugin_config
         self.cache_dir = cache_dir
         self.creation_time = creation_time

--- a/src/hatch/template/plugin/interface.py
+++ b/src/hatch/template/plugin/interface.py
@@ -1,4 +1,6 @@
-from typing import TYPE_CHECKING, Dict
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -10,7 +12,7 @@ class TemplateInterface:
     PLUGIN_NAME = ''
     PRIORITY = 100
 
-    def __init__(self, plugin_config: Dict, cache_dir: "Path", creation_time: "datetime") -> None:
+    def __init__(self, plugin_config: dict, cache_dir: "Path", creation_time: "datetime") -> None:
         self.plugin_config = plugin_config
         self.cache_dir = cache_dir
         self.creation_time = creation_time

--- a/src/hatch/template/plugin/interface.py
+++ b/src/hatch/template/plugin/interface.py
@@ -12,7 +12,7 @@ class TemplateInterface:
     PLUGIN_NAME = ''
     PRIORITY = 100
 
-    def __init__(self, plugin_config: dict, cache_dir: "Path", creation_time: "datetime") -> None:
+    def __init__(self, plugin_config: dict, cache_dir: 'Path', creation_time: 'datetime') -> None:
         self.plugin_config = plugin_config
         self.cache_dir = cache_dir
         self.creation_time = creation_time

--- a/src/hatch/utils/ci.py
+++ b/src/hatch/utils/ci.py
@@ -1,7 +1,7 @@
 import os
 
 
-def running_in_ci():
+def running_in_ci() -> bool:
     for env_var in ('CI', 'GITHUB_ACTIONS'):
         if os.environ.get(env_var) in ('true', '1'):
             return True

--- a/src/hatch/utils/dep.py
+++ b/src/hatch/utils/dep.py
@@ -17,17 +17,17 @@ def normalize_marker_quoting(text: str) -> str:
     return text.replace('"', "'")
 
 
-def get_normalized_dependencies(requirements: list["Requirement"]) -> list[str]:
+def get_normalized_dependencies(requirements: list['Requirement']) -> list[str]:
     normalized_dependencies = {get_normalized_dependency(requirement) for requirement in requirements}
     return sorted(normalized_dependencies)
 
 
 def get_project_dependencies_complex(
-    environment: "VirtualEnvironment" | "MockEnvironment",
+    environment: 'VirtualEnvironment' | 'MockEnvironment',
 ) -> (
-    tuple[dict[str, "Requirement"], dict[str, dict[str, "Requirement"]]]
-    | tuple[dict[str, "Requirement"], dict[Any, Any]]
-    | tuple[dict[Any, Any], dict[str, dict[str, "Requirement"]]]
+    tuple[dict[str, 'Requirement'], dict[str, dict[str, 'Requirement']]]
+    | tuple[dict[str, 'Requirement'], dict[Any, Any]]
+    | tuple[dict[Any, Any], dict[str, dict[str, 'Requirement']]]
     | tuple[dict[Any, Any], dict[str, dict[Any, Any]]]
     | tuple[dict[Any, Any], dict[Any, Any]]
 ):

--- a/src/hatch/utils/dep.py
+++ b/src/hatch/utils/dep.py
@@ -1,17 +1,33 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union
+
 from hatchling.metadata.utils import get_normalized_dependency
 
+if TYPE_CHECKING:
+    from packaging.requirements import Requirement
 
-def normalize_marker_quoting(text):
+    from hatch.env.virtual import VirtualEnvironment
+    from tests.env.plugin.test_interface import MockEnvironment
+
+
+def normalize_marker_quoting(text: str) -> str:
     # All TOML writers use double quotes, so allow copy/pasting to avoid escaping
     return text.replace('"', "'")
 
 
-def get_normalized_dependencies(requirements):
+def get_normalized_dependencies(requirements: List["Requirement"]) -> List[str]:
     normalized_dependencies = {get_normalized_dependency(requirement) for requirement in requirements}
     return sorted(normalized_dependencies)
 
 
-def get_project_dependencies_complex(environment):
+def get_project_dependencies_complex(
+    environment: Union["VirtualEnvironment", "MockEnvironment"]
+) -> Union[
+    Tuple[Dict[str, "Requirement"], Dict[str, Dict[str, "Requirement"]]],
+    Tuple[Dict[str, "Requirement"], Dict[Any, Any]],
+    Tuple[Dict[Any, Any], Dict[str, Dict[str, "Requirement"]]],
+    Tuple[Dict[Any, Any], Dict[str, Dict[Any, Any]]],
+    Tuple[Dict[Any, Any], Dict[Any, Any]],
+]:
     from hatchling.dep.core import dependencies_in_sync
 
     dependencies_complex = {}

--- a/src/hatch/utils/dep.py
+++ b/src/hatch/utils/dep.py
@@ -25,11 +25,11 @@ def get_normalized_dependencies(requirements: list["Requirement"]) -> list[str]:
 def get_project_dependencies_complex(
     environment: Union["VirtualEnvironment", "MockEnvironment"]
 ) -> (
-    tuple[dict[str, "Requirement"], dict[str, dict[str, "Requirement"]]] |
-    tuple[dict[str, "Requirement"], dict[Any, Any]] |
-    tuple[dict[Any, Any], dict[str, dict[str, "Requirement"]]] |
-    tuple[dict[Any, Any], dict[str, dict[Any, Any]]] |
-    tuple[dict[Any, Any], dict[Any, Any]]
+    tuple[dict[str, "Requirement"], dict[str, dict[str, "Requirement"]]]
+    | tuple[dict[str, "Requirement"], dict[Any, Any]]
+    | tuple[dict[Any, Any], dict[str, dict[str, "Requirement"]]]
+    | tuple[dict[Any, Any], dict[str, dict[Any, Any]]]
+    | tuple[dict[Any, Any], dict[Any, Any]]
 ):
     from hatchling.dep.core import dependencies_in_sync
 

--- a/src/hatch/utils/dep.py
+++ b/src/hatch/utils/dep.py
@@ -23,7 +23,7 @@ def get_normalized_dependencies(requirements: list["Requirement"]) -> list[str]:
 
 
 def get_project_dependencies_complex(
-    environment: Union["VirtualEnvironment", "MockEnvironment"]
+    environment: "VirtualEnvironment" | "MockEnvironment",
 ) -> (
     tuple[dict[str, "Requirement"], dict[str, dict[str, "Requirement"]]]
     | tuple[dict[str, "Requirement"], dict[Any, Any]]

--- a/src/hatch/utils/dep.py
+++ b/src/hatch/utils/dep.py
@@ -1,4 +1,7 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union
+# TODO: simplify complex type hints
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from hatchling.metadata.utils import get_normalized_dependency
 
@@ -14,20 +17,20 @@ def normalize_marker_quoting(text: str) -> str:
     return text.replace('"', "'")
 
 
-def get_normalized_dependencies(requirements: List["Requirement"]) -> List[str]:
+def get_normalized_dependencies(requirements: list["Requirement"]) -> list[str]:
     normalized_dependencies = {get_normalized_dependency(requirement) for requirement in requirements}
     return sorted(normalized_dependencies)
 
 
 def get_project_dependencies_complex(
     environment: Union["VirtualEnvironment", "MockEnvironment"]
-) -> Union[
-    Tuple[Dict[str, "Requirement"], Dict[str, Dict[str, "Requirement"]]],
-    Tuple[Dict[str, "Requirement"], Dict[Any, Any]],
-    Tuple[Dict[Any, Any], Dict[str, Dict[str, "Requirement"]]],
-    Tuple[Dict[Any, Any], Dict[str, Dict[Any, Any]]],
-    Tuple[Dict[Any, Any], Dict[Any, Any]],
-]:
+) -> (
+    tuple[dict[str, "Requirement"], dict[str, dict[str, "Requirement"]]] |
+    tuple[dict[str, "Requirement"], dict[Any, Any]] |
+    tuple[dict[Any, Any], dict[str, dict[str, "Requirement"]]] |
+    tuple[dict[Any, Any], dict[str, dict[Any, Any]]] |
+    tuple[dict[Any, Any], dict[Any, Any]]
+):
     from hatchling.dep.core import dependencies_in_sync
 
     dependencies_complex = {}

--- a/src/hatch/utils/env.py
+++ b/src/hatch/utils/env.py
@@ -1,11 +1,12 @@
 from ast import literal_eval
-from typing import Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
-from hatch.utils.platform import Platform
+if TYPE_CHECKING:
+    from hatch.utils.platform import Platform
 
 
 class PythonInfo:
-    def __init__(self, platform: Platform, executable: str = 'python') -> None:
+    def __init__(self, platform: "Platform", executable: str = 'python') -> None:
         self.platform = platform
         self.executable = executable
 
@@ -14,7 +15,7 @@ class PythonInfo:
         self.__sys_path: Optional[List[str]] = None
 
     @property
-    def dep_check_data(self) -> Dict:
+    def dep_check_data(self) -> Dict[str, Union[Dict[str, str], List[str]]]:
         if self.__dep_check_data is None:
             process = self.platform.check_command(
                 [self.executable, '-W', 'ignore', '-'], capture_output=True, input=DEP_CHECK_DATA_SCRIPT

--- a/src/hatch/utils/env.py
+++ b/src/hatch/utils/env.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from ast import literal_eval
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from hatch.utils.platform import Platform
@@ -10,12 +12,12 @@ class PythonInfo:
         self.platform = platform
         self.executable = executable
 
-        self.__dep_check_data: Optional[Dict] = None
-        self.__environment: Optional[Dict] = None
-        self.__sys_path: Optional[List[str]] = None
+        self.__dep_check_data: dict | None = None
+        self.__environment: dict | None = None
+        self.__sys_path: list[str] | None = None
 
     @property
-    def dep_check_data(self) -> Dict[str, Union[Dict[str, str], List[str]]]:
+    def dep_check_data(self) -> dict[str, dict[str, str] | list[str]]:
         if self.__dep_check_data is None:
             process = self.platform.check_command(
                 [self.executable, '-W', 'ignore', '-'], capture_output=True, input=DEP_CHECK_DATA_SCRIPT
@@ -26,14 +28,14 @@ class PythonInfo:
         return self.__dep_check_data
 
     @property
-    def environment(self) -> Dict[str, str]:
+    def environment(self) -> dict[str, str]:
         if self.__environment is None:
             self.__environment = self.dep_check_data['environment']
 
         return self.__environment
 
     @property
-    def sys_path(self) -> List[str]:
+    def sys_path(self) -> list[str]:
         if self.__sys_path is None:
             self.__sys_path = self.dep_check_data['sys_path']
 

--- a/src/hatch/utils/env.py
+++ b/src/hatch/utils/env.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 
 class PythonInfo:
-    def __init__(self, platform: "Platform", executable: str = 'python') -> None:
+    def __init__(self, platform: 'Platform', executable: str = 'python') -> None:
         self.platform = platform
         self.executable = executable
 

--- a/src/hatch/utils/env.py
+++ b/src/hatch/utils/env.py
@@ -1,17 +1,20 @@
 from ast import literal_eval
+from typing import Dict, List, Optional
+
+from hatch.utils.platform import Platform
 
 
 class PythonInfo:
-    def __init__(self, platform, executable='python'):
+    def __init__(self, platform: Platform, executable: str = 'python') -> None:
         self.platform = platform
         self.executable = executable
 
-        self.__dep_check_data = None
-        self.__environment = None
-        self.__sys_path = None
+        self.__dep_check_data: Optional[Dict] = None
+        self.__environment: Optional[Dict] = None
+        self.__sys_path: Optional[List[str]] = None
 
     @property
-    def dep_check_data(self):
+    def dep_check_data(self) -> Dict:
         if self.__dep_check_data is None:
             process = self.platform.check_command(
                 [self.executable, '-W', 'ignore', '-'], capture_output=True, input=DEP_CHECK_DATA_SCRIPT
@@ -22,14 +25,14 @@ class PythonInfo:
         return self.__dep_check_data
 
     @property
-    def environment(self):
+    def environment(self) -> Dict[str, str]:
         if self.__environment is None:
             self.__environment = self.dep_check_data['environment']
 
         return self.__environment
 
     @property
-    def sys_path(self):
+    def sys_path(self) -> List[str]:
         if self.__sys_path is None:
             self.__sys_path = self.dep_check_data['sys_path']
 

--- a/src/hatch/utils/fs.py
+++ b/src/hatch/utils/fs.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import os
 import pathlib
 import sys
+from collections.abc import Generator
 from contextlib import contextmanager
-from typing import Generator
 
 from hatch.utils.structures import EnvVars
 

--- a/src/hatch/utils/fs.py
+++ b/src/hatch/utils/fs.py
@@ -52,7 +52,7 @@ class Path(_PathBase):  # type: ignore
         fd, path = mkstemp(dir=self.parent)
         with os.fdopen(fd, *args, **kwargs) as f:
             if type(data) is bytes:
-                data = data.decode("utf-8")
+                data = data.decode('utf-8')
 
             f.write(data)
             f.flush()

--- a/src/hatch/utils/fs.py
+++ b/src/hatch/utils/fs.py
@@ -27,7 +27,7 @@ if sys.platform == 'darwin':
             fcntl.fcntl(fd, fcntl.F_FULLFSYNC)
 
 
-class Path(_PathBase):
+class Path(_PathBase):  # type: ignore
     def ensure_dir_exists(self):
         self.mkdir(parents=True, exist_ok=True)
 
@@ -51,6 +51,9 @@ class Path(_PathBase):
 
         fd, path = mkstemp(dir=self.parent)
         with os.fdopen(fd, *args, **kwargs) as f:
+            if type(data) is bytes:
+                data = data.decode("utf-8")
+
             f.write(data)
             f.flush()
             disk_sync(fd)

--- a/src/hatch/utils/network.py
+++ b/src/hatch/utils/network.py
@@ -1,7 +1,9 @@
 import httpx
 
+from hatch.utils.fs import Path
 
-def download_file(path, *args, **kwargs):
+
+def download_file(path: Path, *args, **kwargs) -> None:
     with path.open(mode='wb', buffering=0) as f:
         with httpx.stream('GET', *args, **kwargs) as response:
             for chunk in response.iter_bytes(16384):

--- a/src/hatch/utils/network.py
+++ b/src/hatch/utils/network.py
@@ -1,9 +1,12 @@
+from typing import TYPE_CHECKING
+
 import httpx
 
-from hatch.utils.fs import Path
+if TYPE_CHECKING:
+    from hatch.utils.fs import Path
 
 
-def download_file(path: Path, *args, **kwargs) -> None:
+def download_file(path: "Path", *args, **kwargs) -> None:
     with path.open(mode='wb', buffering=0) as f:
         with httpx.stream('GET', *args, **kwargs) as response:
             for chunk in response.iter_bytes(16384):

--- a/src/hatch/utils/network.py
+++ b/src/hatch/utils/network.py
@@ -6,7 +6,7 @@ if TYPE_CHECKING:
     from hatch.utils.fs import Path
 
 
-def download_file(path: "Path", *args, **kwargs) -> None:
+def download_file(path: 'Path', *args, **kwargs) -> None:
     with path.open(mode='wb', buffering=0) as f:
         with httpx.stream('GET', *args, **kwargs) as response:
             for chunk in response.iter_bytes(16384):

--- a/src/hatch/utils/platform.py
+++ b/src/hatch/utils/platform.py
@@ -5,7 +5,7 @@ import sys
 from functools import lru_cache
 from importlib import import_module
 from types import ModuleType
-from typing import NoReturn, Optional
+from typing import NoReturn
 
 
 @lru_cache(maxsize=None)
@@ -200,7 +200,7 @@ class Platform:
         """
         return not (self.windows or self.macos)
 
-    def exit_with_command(self, command: list[str]) -> Optional[NoReturn]:
+    def exit_with_command(self, command: list[str]) -> NoReturn | None:
         """
         Run the given command and exit with its exit code. On non-Windows systems, this uses the standard library's
         [os.execvp](https://docs.python.org/3/library/os.html#os.execvp).

--- a/src/hatch/utils/platform.py
+++ b/src/hatch/utils/platform.py
@@ -37,7 +37,7 @@ class Platform:
         self.__modules = LazilyLoadedModules()
 
     @property
-    def modules(self) -> "LazilyLoadedModules":
+    def modules(self) -> 'LazilyLoadedModules':
         """
         Accessor for lazily loading modules that either take multiple milliseconds to import
         (like `shutil` and `subprocess`) or are not used on all platforms (like `shlex`).

--- a/src/hatch/utils/shells.py
+++ b/src/hatch/utils/shells.py
@@ -5,7 +5,7 @@ if TYPE_CHECKING:
 
 
 class ShellManager:
-    def __init__(self, environment: "VirtualEnvironment") -> None:
+    def __init__(self, environment: 'VirtualEnvironment') -> None:
         self.environment = environment
 
     def enter_cmd(self, path, args, exe_dir) -> None:

--- a/src/hatch/utils/shells.py
+++ b/src/hatch/utils/shells.py
@@ -1,11 +1,17 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from hatch.env.virtual import VirtualEnvironment
+
+
 class ShellManager:
-    def __init__(self, environment):
+    def __init__(self, environment: "VirtualEnvironment") -> None:
         self.environment = environment
 
-    def enter_cmd(self, path, args, exe_dir):
+    def enter_cmd(self, path, args, exe_dir) -> None:
         self.environment.platform.exit_with_command([path or 'cmd', '/k', str(exe_dir / 'activate.bat')])
 
-    def enter_powershell(self, path, args, exe_dir):
+    def enter_powershell(self, path, args, exe_dir) -> None:
         self.environment.platform.exit_with_command(
             [
                 path or 'powershell',
@@ -18,10 +24,10 @@ class ShellManager:
             ]
         )
 
-    def enter_pwsh(self, path, args, exe_dir):
+    def enter_pwsh(self, path, args, exe_dir) -> None:
         self.enter_powershell(path or 'pwsh', args, exe_dir)
 
-    def enter_xonsh(self, path, args, exe_dir):
+    def enter_xonsh(self, path, args, exe_dir) -> None:
         if self.environment.platform.windows:
             with self.environment:
                 self.environment.platform.exit_with_command(
@@ -35,7 +41,7 @@ class ShellManager:
                 callback=lambda terminal: terminal.sendline(f'$PATH.insert(0, {str(exe_dir)!r})'),
             )
 
-    def enter_bash(self, path, args, exe_dir):
+    def enter_bash(self, path, args, exe_dir) -> None:
         if self.environment.platform.windows:
             self.environment.platform.exit_with_command(
                 [path or 'bash', '--init-file', exe_dir / 'activate', *(args or ['-i'])]
@@ -43,16 +49,16 @@ class ShellManager:
         else:
             self.spawn_linux_shell(path or 'bash', args or ['-i'], script=exe_dir / 'activate')
 
-    def enter_fish(self, path, args, exe_dir):
+    def enter_fish(self, path, args, exe_dir) -> None:
         self.spawn_linux_shell(path or 'fish', args or ['-i'], script=exe_dir / 'activate.fish')
 
-    def enter_zsh(self, path, args, exe_dir):
+    def enter_zsh(self, path, args, exe_dir) -> None:
         self.spawn_linux_shell(path or 'zsh', args or ['-i'], script=exe_dir / 'activate')
 
-    def enter_ash(self, path, args, exe_dir):
+    def enter_ash(self, path, args, exe_dir) -> None:
         self.spawn_linux_shell(path or 'ash', args or ['-i'], script=exe_dir / 'activate')
 
-    def enter_nu(self, path, args, exe_dir):
+    def enter_nu(self, path, args, exe_dir) -> None:
         executable = path or 'nu'
         activation_script = exe_dir / 'activate.nu'
         if self.environment.platform.windows:
@@ -62,13 +68,13 @@ class ShellManager:
         else:
             self.spawn_linux_shell(executable, args or None, script=activation_script)
 
-    def enter_tcsh(self, path, args, exe_dir):
+    def enter_tcsh(self, path, args, exe_dir) -> None:
         self.spawn_linux_shell(path or 'tcsh', args or ['-i'], script=exe_dir / 'activate.csh')
 
-    def enter_csh(self, path, args, exe_dir):
+    def enter_csh(self, path, args, exe_dir) -> None:
         self.spawn_linux_shell(path or 'csh', args or ['-i'], script=exe_dir / 'activate.csh')
 
-    def spawn_linux_shell(self, path, args, *, script=None, callback=None):
+    def spawn_linux_shell(self, path, args, *, script=None, callback=None) -> None:
         import shutil
         import signal
 

--- a/src/hatch/utils/shells.py
+++ b/src/hatch/utils/shells.py
@@ -95,7 +95,7 @@ class ShellManager:
         if callback is not None:
             callback(terminal)
 
-        terminal.interact(escape_character=None)
+        terminal.interact(escape_character=None)  # BUG: escape character should not be None
         terminal.close()
 
         self.environment.platform.exit_with_code(terminal.exitstatus)

--- a/src/hatch/utils/structures.py
+++ b/src/hatch/utils/structures.py
@@ -1,9 +1,15 @@
 import os
 from fnmatch import fnmatch
+from typing import Dict, Iterable, Optional
 
 
 class EnvVars(dict):
-    def __init__(self, env_vars=None, include=None, exclude=None):
+    def __init__(
+        self,
+        env_vars: Optional[Dict[str, str]] = None,
+        include: Optional[Iterable[str]] = None,
+        exclude: Optional[Iterable[str]] = None,
+    ) -> None:
         super().__init__(os.environ)
         self.old_env = dict(self)
 
@@ -25,10 +31,10 @@ class EnvVars(dict):
         if env_vars:
             self.update(env_vars)
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         os.environ.clear()
         os.environ.update(self)
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
         os.environ.clear()
         os.environ.update(self.old_env)

--- a/src/hatch/utils/structures.py
+++ b/src/hatch/utils/structures.py
@@ -1,14 +1,16 @@
+from __future__ import annotations
+
 import os
+from collections.abc import Iterable
 from fnmatch import fnmatch
-from typing import Dict, Iterable, Optional
 
 
 class EnvVars(dict):
     def __init__(
         self,
-        env_vars: Optional[Dict[str, str]] = None,
-        include: Optional[Iterable[str]] = None,
-        exclude: Optional[Iterable[str]] = None,
+        env_vars: dict[str, str] | None = None,
+        include: Iterable[str] | None = None,
+        exclude: Iterable[str] | None = None,
     ) -> None:
         super().__init__(os.environ)
         self.old_env = dict(self)

--- a/src/hatch/utils/toml.py
+++ b/src/hatch/utils/toml.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import sys
-from typing import Any, Dict
+from typing import Any
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -7,10 +9,10 @@ else:
     import tomli as tomllib
 
 
-def load_toml_data(data: str) -> Dict[str, Any]:
+def load_toml_data(data: str) -> dict[str, Any]:
     return tomllib.loads(data)
 
 
-def load_toml_file(path: str) -> Dict[str, Any]:
+def load_toml_file(path: str) -> dict[str, Any]:
     with open(path, encoding='utf-8') as f:
         return tomllib.loads(f.read())

--- a/src/hatch/utils/toml.py
+++ b/src/hatch/utils/toml.py
@@ -1,4 +1,5 @@
 import sys
+from typing import Any, Dict
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -6,10 +7,10 @@ else:
     import tomli as tomllib
 
 
-def load_toml_data(data):
+def load_toml_data(data: str) -> Dict[str, Any]:
     return tomllib.loads(data)
 
 
-def load_toml_file(path):
+def load_toml_file(path: str) -> Dict[str, Any]:
     with open(path, encoding='utf-8') as f:
         return tomllib.loads(f.read())

--- a/src/hatch/venv/core.py
+++ b/src/hatch/venv/core.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from hatch.env.utils import add_verbosity_flag
 from hatch.utils.env import PythonInfo
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 class VirtualEnv:
     IGNORED_ENV_VARS = ('__PYVENV_LAUNCHER__', 'PYTHONHOME')
 
-    def __init__(self, directory: Path, platform: "Platform", verbosity: int = 0) -> None:
+    def __init__(self, directory: Path, platform: 'Platform', verbosity: int = 0) -> None:
         self.directory = directory
         self.platform = platform
         self.verbosity = verbosity
@@ -103,7 +103,7 @@ class VirtualEnv:
     def sys_path(self) -> list[str]:
         return self.python_info.sys_path
 
-    def __enter__(self) -> Union["TempVirtualEnv", "VirtualEnv"]:
+    def __enter__(self) -> 'TempVirtualEnv' | 'VirtualEnv':
         self.activate()
         return self
 
@@ -112,7 +112,7 @@ class VirtualEnv:
 
 
 class TempVirtualEnv(VirtualEnv):
-    def __init__(self, parent_python: str, platform: "Platform", verbosity: int = 0) -> None:
+    def __init__(self, parent_python: str, platform: 'Platform', verbosity: int = 0) -> None:
         self.parent_python = parent_python
         self.parent_dir = TemporaryDirectory()
         directory = Path(self.parent_dir.name).resolve() / get_random_venv_name()
@@ -123,7 +123,7 @@ class TempVirtualEnv(VirtualEnv):
         super().remove()
         self.parent_dir.cleanup()
 
-    def __enter__(self) -> "TempVirtualEnv":
+    def __enter__(self) -> 'TempVirtualEnv':
         self.create(self.parent_python)
         return super().__enter__()  # type: ignore
 

--- a/src/hatch/venv/core.py
+++ b/src/hatch/venv/core.py
@@ -123,7 +123,7 @@ class TempVirtualEnv(VirtualEnv):
 
     def __enter__(self) -> "TempVirtualEnv":
         self.create(self.parent_python)
-        return super().__enter__()
+        return super().__enter__()  # type: ignore
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:
         super().__exit__(exc_type, exc_value, traceback)

--- a/src/hatch/venv/core.py
+++ b/src/hatch/venv/core.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import os
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Union
 
 from hatch.env.utils import add_verbosity_flag
 from hatch.utils.env import PythonInfo
@@ -20,8 +22,8 @@ class VirtualEnv:
         self.verbosity = verbosity
         self.python_info = PythonInfo(platform)
 
-        self._env_vars_to_restore: Dict[str, Optional[str]] = {}
-        self._executables_directory: Optional[Path] = None
+        self._env_vars_to_restore: dict[str, str | None] = {}
+        self._executables_directory: Path | None = None
 
     def activate(self) -> None:
         self._env_vars_to_restore['VIRTUAL_ENV'] = os.environ.pop('VIRTUAL_ENV', None)
@@ -94,11 +96,11 @@ class VirtualEnv:
         return self._executables_directory
 
     @property
-    def environment(self) -> Dict[str, str]:
+    def environment(self) -> dict[str, str]:
         return self.python_info.environment
 
     @property
-    def sys_path(self) -> List[str]:
+    def sys_path(self) -> list[str]:
         return self.python_info.sys_path
 
     def __enter__(self) -> Union["TempVirtualEnv", "VirtualEnv"]:

--- a/src/hatch/venv/core.py
+++ b/src/hatch/venv/core.py
@@ -1,18 +1,20 @@
 import os
 from tempfile import TemporaryDirectory
-from typing import Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 from hatch.env.utils import add_verbosity_flag
 from hatch.utils.env import PythonInfo
 from hatch.utils.fs import Path
-from hatch.utils.platform import Platform
 from hatch.venv.utils import get_random_venv_name
+
+if TYPE_CHECKING:
+    from hatch.utils.platform import Platform
 
 
 class VirtualEnv:
     IGNORED_ENV_VARS = ('__PYVENV_LAUNCHER__', 'PYTHONHOME')
 
-    def __init__(self, directory: Path, platform: Platform, verbosity: int=0) -> None:
+    def __init__(self, directory: Path, platform: "Platform", verbosity: int = 0) -> None:
         self.directory = directory
         self.platform = platform
         self.verbosity = verbosity
@@ -44,7 +46,7 @@ class VirtualEnv:
 
         self._env_vars_to_restore.clear()
 
-    def create(self, python: str, allow_system_packages: bool=False) -> None:
+    def create(self, python: str, allow_system_packages: bool = False) -> None:
         # WARNING: extremely slow import
         from virtualenv import cli_run
 
@@ -99,7 +101,7 @@ class VirtualEnv:
     def sys_path(self) -> List[str]:
         return self.python_info.sys_path
 
-    def __enter__(self) -> Union["VirtualEnv", "TempVirtualEnv"]:
+    def __enter__(self) -> Union["TempVirtualEnv", "VirtualEnv"]:
         self.activate()
         return self
 
@@ -108,7 +110,7 @@ class VirtualEnv:
 
 
 class TempVirtualEnv(VirtualEnv):
-    def __init__(self, parent_python: str, platform: Platform, verbosity: int=0) -> None:
+    def __init__(self, parent_python: str, platform: "Platform", verbosity: int = 0) -> None:
         self.parent_python = parent_python
         self.parent_dir = TemporaryDirectory()
         directory = Path(self.parent_dir.name).resolve() / get_random_venv_name()
@@ -119,7 +121,7 @@ class TempVirtualEnv(VirtualEnv):
         super().remove()
         self.parent_dir.cleanup()
 
-    def __enter__(self) -> "VirtualEnv":
+    def __enter__(self) -> "TempVirtualEnv":
         self.create(self.parent_python)
         return super().__enter__()
 

--- a/src/hatch/venv/utils.py
+++ b/src/hatch/venv/utils.py
@@ -2,6 +2,6 @@ from base64 import urlsafe_b64encode
 from os import urandom
 
 
-def get_random_venv_name():
+def get_random_venv_name() -> str:
     # Will be length 4
     return urlsafe_b64encode(urandom(3)).decode('ascii')


### PR DESCRIPTION
PR adds type hints to a larger percent of the codebase.

Still WIP since there are a few areas I haven't covered or checked yet, so no need for review, just adding the PR so I can keep some todo's here.

Todo:

- [ ] Finish adding type hints
- [ ] Verify with mypy/pyre/other code analysis tools
- [ ] Should mypy/type-based analysis be included as stages during the CI?
- [ ] Check code functionality changes are correct:
  - [ ] `src/hatch/template/__init__.py::find_template_files` - comparisons changed from `if obj is File`/`if issubclass(obj, File)` to `if type(obj) is File)`/`if issubclass(type(obj), File)` as the call at `src/hatch/template/default.py::get_files` created a list of instantiated file objects, whereas the comparison and returned values from in `find_template_files` were uninstantiated classes. Adding in type hints showed this as a warning since the list is not of consistent types, but it's not clear to me if my 'fix' is actually a fix or breaks expected functionality