### PR TITLE
Update link to "editable installs" in build docs

### DIFF
--- a/docs/config/build.md
+++ b/docs/config/build.md
@@ -334,7 +334,7 @@ When the output directory is not provided to the [`build`](../cli/reference.md#h
 
 ## Dev mode
 
-By default for [dev mode](environment/overview.md#dev-mode) environment installations or [editable installs](https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs), the `wheel` target will determine which directories should be added to Python's search path based on the [selected files](#file-selection).
+By default for [dev mode](environment/overview.md#dev-mode) environment installations or [editable installs](https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs), the `wheel` target will determine which directories should be added to Python's search path based on the [selected files](#file-selection).
 
 If you want to override this detection or perhaps instruct other build targets as well, you can use the `dev-mode-dirs` option:
 


### PR DESCRIPTION
The "editable installs" section was moved to a different page in the pip docs.