### PR TITLE
Add `validate-bump` option to the `standard` version scheme

### DIFF
--- a/backend/src/hatchling/version/scheme/standard.py
+++ b/backend/src/hatchling/version/scheme/standard.py
@@ -44,7 +44,7 @@ class StandardScheme(VersionSchemeInterface):
                     raise ValueError('Cannot specify multiple update operations with an explicit version')
 
                 next_version = Version(version)
-                if next_version <= original:
+                if self.config.get('validate-bump', True) and next_version <= original:
                     raise ValueError(
                         f'Version `{version}` is not higher than the original version `{original_version}`'
                     )

--- a/docs/history.md
+++ b/docs/history.md
@@ -189,6 +189,7 @@ This is the first stable release of Hatch v1, a complete rewrite. Enjoy!
 ***Added:***
 
 - Add `env` version source to retrieve the version from an environment variable
+- Add `validate-bump` option to the `standard` version scheme
 
 ***Fixed:***
 

--- a/docs/plugins/version-scheme/standard.md
+++ b/docs/plugins/version-scheme/standard.md
@@ -4,7 +4,7 @@
 
 See the documentation for [versioning](../../version.md#updating).
 
-#### Configuration
+## Configuration
 
 The version scheme plugin name is `standard`.
 
@@ -24,4 +24,6 @@ The version scheme plugin name is `standard`.
 
 ## Options
 
-There are no options available currently.
+| Option | Description |
+| --- | --- |
+| `validate-bump` | When setting a specific version, this determines whether to check that the new version is higher than the original. The default is `true`. |

--- a/tests/backend/version/scheme/test_standard.py
+++ b/tests/backend/version/scheme/test_standard.py
@@ -17,6 +17,12 @@ def test_specific(isolation):
     assert scheme.update('9000.0.0-rc.1', '1.0', {}) == '9000.0.0rc1'
 
 
+def test_specific_not_higher_allowed(isolation):
+    scheme = StandardScheme(str(isolation), {'validate-bump': False})
+
+    assert scheme.update('0.24.4', '1.0.0.dev0', {}) == '0.24.4'
+
+
 def test_release(isolation):
     scheme = StandardScheme(str(isolation), {})
 


### PR DESCRIPTION
resolves #515 