### PR TITLE
Fix default file selection behavior of the `wheel` target when there is a single top-level module

### DIFF
--- a/backend/src/hatchling/builders/config.py
+++ b/backend/src/hatchling/builders/config.py
@@ -699,7 +699,7 @@ class BuilderConfig:
                 only_include_config = self.build_config
                 only_include_location = 'tool.hatch.build.only-include'
 
-            only_include = only_include_config.get('only-include', []) or self.packages
+            only_include = only_include_config.get('only-include', self.default_only_include()) or self.packages
             if not isinstance(only_include, list):
                 raise TypeError(f'Field `{only_include_location}` must be an array')
 
@@ -784,6 +784,9 @@ class BuilderConfig:
         return []
 
     def default_packages(self):
+        return []
+
+    def default_only_include(self):
         return []
 
     def default_global_exclude(self):

--- a/backend/src/hatchling/builders/wheel.py
+++ b/backend/src/hatchling/builders/wheel.py
@@ -147,6 +147,7 @@ class WheelBuilderConfig(BuilderConfig):
         self.__include = []
         self.__exclude = []
         self.__packages = []
+        self.__only_include = []
 
         self.__core_metadata_constructor = None
         self.__shared_data = None
@@ -154,7 +155,7 @@ class WheelBuilderConfig(BuilderConfig):
         self.__strict_naming = None
 
     def set_default_file_selection(self):
-        if self.__include or self.__exclude or self.__packages:
+        if self.__include or self.__exclude or self.__packages or self.__only_include:
             return
 
         for project_name in (
@@ -168,7 +169,7 @@ class WheelBuilderConfig(BuilderConfig):
                 self.__packages.append(f'src/{project_name}')
                 break
             elif os.path.isfile(os.path.join(self.root, f'{project_name}.py')):
-                self.__packages.append(f'{project_name}.py')
+                self.__only_include.append(f'{project_name}.py')
                 break
             else:
                 from glob import glob
@@ -200,6 +201,12 @@ class WheelBuilderConfig(BuilderConfig):
             self.set_default_file_selection()
 
         return self.__packages
+
+    def default_only_include(self):
+        if not self.__include_defined:
+            self.set_default_file_selection()
+
+        return self.__only_include
 
     @property
     def core_metadata_constructor(self):

--- a/docs/history.md
+++ b/docs/history.md
@@ -194,6 +194,10 @@ This is the first stable release of Hatch v1, a complete rewrite. Enjoy!
 
 ### Unreleased
 
+***Fixed:***
+
+- Fix default file selection behavior of the `wheel` target when there is a single top-level module
+
 ### [1.11.0](https://github.com/pypa/hatch/releases/tag/hatchling-v1.11.0) - 2022-10-08 ### {: #hatchling-v1.11.0 }
 
 ***Added:***

--- a/docs/plugins/utilities.md
+++ b/docs/plugins/utilities.md
@@ -19,6 +19,7 @@
       - default_include
       - default_exclude
       - default_packages
+      - default_only_include
 
 ::: hatchling.bridge.app.Application
     options:

--- a/tests/backend/builders/test_config.py
+++ b/tests/backend/builders/test_config.py
@@ -947,7 +947,7 @@ class TestForceInclude:
         }
 
 
-class TestIncludeOnly:
+class TestOnlyInclude:
     def test_default(self, isolation):
         builder = MockBuilder(str(isolation))
 
@@ -1600,6 +1600,11 @@ class TestFileSelectionDefaults:
         builder = MockBuilder(str(isolation))
 
         assert builder.config.default_packages() == []
+
+    def test_only_include(self, isolation):
+        builder = MockBuilder(str(isolation))
+
+        assert builder.config.default_only_include() == []
 
     def test_global_exclude(self, isolation):
         builder = MockBuilder(str(isolation))

--- a/tests/backend/builders/test_wheel.py
+++ b/tests/backend/builders/test_wheel.py
@@ -56,6 +56,7 @@ class TestDefaultFileSelection:
         assert builder.config.default_include() == []
         assert builder.config.default_exclude() == []
         assert builder.config.default_packages() == ['my_app']
+        assert builder.config.default_only_include() == []
 
     def test_src_layout(self, temp_dir):
         config = {'project': {'name': 'my-app', 'version': '0.0.1'}}
@@ -75,6 +76,7 @@ class TestDefaultFileSelection:
         assert builder.config.default_include() == []
         assert builder.config.default_exclude() == []
         assert builder.config.default_packages() == ['src/my_app']
+        assert builder.config.default_only_include() == []
 
     def test_single_module(self, temp_dir):
         config = {'project': {'name': 'my-app', 'version': '0.0.1'}}
@@ -89,7 +91,8 @@ class TestDefaultFileSelection:
 
         assert builder.config.default_include() == []
         assert builder.config.default_exclude() == []
-        assert builder.config.default_packages() == ['my_app.py']
+        assert builder.config.default_packages() == []
+        assert builder.config.default_only_include() == ['my_app.py']
 
     def test_namespace(self, temp_dir):
         config = {'project': {'name': 'my-app', 'version': '0.0.1'}}
@@ -102,6 +105,7 @@ class TestDefaultFileSelection:
         assert builder.config.default_include() == []
         assert builder.config.default_exclude() == []
         assert builder.config.default_packages() == ['ns']
+        assert builder.config.default_only_include() == []
 
     def test_default(self, temp_dir):
         config = {'project': {'name': 'my-app', 'version': '0.0.1'}}
@@ -115,6 +119,7 @@ class TestDefaultFileSelection:
         assert builder.config.default_include() == ['*.py']
         assert builder.config.default_exclude() == ['test*']
         assert builder.config.default_packages() == []
+        assert builder.config.default_only_include() == []
 
     def test_raw_name_not_normalized(self, temp_dir):
         config = {'project': {'name': 'MyApp', 'version': '0.0.1'}}


### PR DESCRIPTION
resolves #557 