### PR TITLE
Mypy check build.py and ouroboros.py

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,7 @@ jobs:
       run: hatch run coverage:write-summary-report
 
     - name: Update coverage pull request comment
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
       uses: marocchino/sticky-pull-request-comment@v2
       with:
         path: coverage-report.md

--- a/backend/src/hatchling/build.py
+++ b/backend/src/hatchling/build.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import os
+from typing import Any
 
 
-def get_requires_for_build_sdist(config_settings=None):
+def get_requires_for_build_sdist(config_settings: dict[str, Any] | None = None) -> list[str]:
     """
     https://peps.python.org/pep-0517/#get-requires-for-build-sdist
     """
@@ -11,7 +14,7 @@ def get_requires_for_build_sdist(config_settings=None):
     return builder.config.dependencies
 
 
-def build_sdist(sdist_directory, config_settings=None):
+def build_sdist(sdist_directory: str, config_settings: dict[str, Any] | None = None) -> str:
     """
     https://peps.python.org/pep-0517/#build-sdist
     """
@@ -21,7 +24,7 @@ def build_sdist(sdist_directory, config_settings=None):
     return os.path.basename(next(builder.build(sdist_directory, ['standard'])))
 
 
-def get_requires_for_build_wheel(config_settings=None):
+def get_requires_for_build_wheel(config_settings: dict[str, Any] | None = None) -> list[str]:
     """
     https://peps.python.org/pep-0517/#get-requires-for-build-wheel
     """
@@ -31,7 +34,9 @@ def get_requires_for_build_wheel(config_settings=None):
     return builder.config.dependencies
 
 
-def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
+def build_wheel(
+    wheel_directory: str, config_settings: dict[str, Any] | None = None, metadata_directory: str | None = None
+) -> str:
     """
     https://peps.python.org/pep-0517/#build-wheel
     """
@@ -41,7 +46,7 @@ def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
     return os.path.basename(next(builder.build(wheel_directory, ['standard'])))
 
 
-def get_requires_for_build_editable(config_settings=None):
+def get_requires_for_build_editable(config_settings: dict[str, Any] | None) -> list[str]:
     """
     https://peps.python.org/pep-0660/#get-requires-for-build-editable
     """
@@ -51,7 +56,9 @@ def get_requires_for_build_editable(config_settings=None):
     return builder.config.dependencies
 
 
-def build_editable(wheel_directory, config_settings=None, metadata_directory=None):
+def build_editable(
+    wheel_directory: str, config_settings: dict[str, Any] | None, metadata_directory: str | None = None
+) -> str:
     """
     https://peps.python.org/pep-0660/#build-editable
     """
@@ -75,7 +82,7 @@ def build_editable(wheel_directory, config_settings=None, metadata_directory=Non
 # Example use case: https://github.com/pypa/hatch/issues/532
 if 'PIP_BUILD_TRACKER' not in os.environ:
 
-    def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
+    def prepare_metadata_for_build_wheel(metadata_directory: str, config_settings: dict[str, Any] | None) -> str:
         """
         https://peps.python.org/pep-0517/#prepare-metadata-for-build-wheel
         """
@@ -92,7 +99,7 @@ if 'PIP_BUILD_TRACKER' not in os.environ:
 
         return os.path.basename(directory)
 
-    def prepare_metadata_for_build_editable(metadata_directory, config_settings=None):
+    def prepare_metadata_for_build_editable(metadata_directory: str, config_settings: dict[str, Any] | None) -> str:
         """
         https://peps.python.org/pep-0660/#prepare-metadata-for-build-editable
         """

--- a/backend/src/hatchling/ouroboros.py
+++ b/backend/src/hatchling/ouroboros.py
@@ -1,6 +1,9 @@
-import os
+from __future__ import annotations
 
-CONFIG = {
+import os
+from typing import Any
+
+CONFIG: dict[str, Any] = {
     'project': {
         'name': 'hatchling',
         'description': 'Modern, extensible Python build backend',
@@ -51,7 +54,7 @@ CONFIG = {
 }
 
 
-def build_sdist(sdist_directory, config_settings=None):
+def build_sdist(sdist_directory: str, config_settings: dict[str, Any] | None = None) -> str:
     """
     https://peps.python.org/pep-0517/#build-sdist
     """
@@ -61,7 +64,9 @@ def build_sdist(sdist_directory, config_settings=None):
     return os.path.basename(next(builder.build(sdist_directory, ['standard'])))
 
 
-def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
+def build_wheel(
+    wheel_directory: str, config_settings: dict[str, Any] | None = None, metadata_directory: str | None = None
+) -> str:
     """
     https://peps.python.org/pep-0517/#build-wheel
     """
@@ -71,7 +76,9 @@ def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
     return os.path.basename(next(builder.build(wheel_directory, ['standard'])))
 
 
-def build_editable(wheel_directory, config_settings=None, metadata_directory=None):
+def build_editable(
+    wheel_directory: str, config_settings: dict[str, Any] | None = None, metadata_directory: str | None = None
+) -> str:
     """
     https://peps.python.org/pep-0660/#build-editable
     """
@@ -81,21 +88,21 @@ def build_editable(wheel_directory, config_settings=None, metadata_directory=Non
     return os.path.basename(next(builder.build(wheel_directory, ['editable'])))
 
 
-def get_requires_for_build_sdist(config_settings=None):
+def get_requires_for_build_sdist(config_settings: dict[str, Any] | None = None) -> list[str]:
     """
     https://peps.python.org/pep-0517/#get-requires-for-build-sdist
     """
     return CONFIG['project']['dependencies']
 
 
-def get_requires_for_build_wheel(config_settings=None):
+def get_requires_for_build_wheel(config_settings: dict[str, Any] | None = None) -> list[str]:
     """
     https://peps.python.org/pep-0517/#get-requires-for-build-wheel
     """
     return CONFIG['project']['dependencies']
 
 
-def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
+def prepare_metadata_for_build_wheel(metadata_directory: str, config_settings: dict[str, Any] | None = None) -> str:
     """
     https://peps.python.org/pep-0517/#prepare-metadata-for-build-wheel
     """
@@ -113,14 +120,14 @@ def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
     return os.path.basename(directory)
 
 
-def get_requires_for_build_editable(config_settings=None):
+def get_requires_for_build_editable(config_settings: dict[str, Any] | None = None) -> list[str]:
     """
     https://peps.python.org/pep-0660/#get-requires-for-build-editable
     """
     return CONFIG['project']['dependencies']
 
 
-def prepare_metadata_for_build_editable(metadata_directory, config_settings=None):
+def prepare_metadata_for_build_editable(metadata_directory: str, config_settings: dict[str, Any] | None = None) -> str:
     """
     https://peps.python.org/pep-0660/#prepare-metadata-for-build-editable
     """

--- a/docs/meta/authors.md
+++ b/docs/meta/authors.md
@@ -10,6 +10,7 @@
 
 - Amjith Ramanujam [:material-twitter:](https://twitter.com/amjithr)
 - Arnaud Crowther [:material-github:](https://github.com/areknow)
+- Chaojie [:material-web:](https://chaojie.fun) [:material-github:](https://github.com/ischaojie)
 - Chris Warrick [:material-twitter:](https://twitter.com/Kwpolska)
 - Lumír 'Frenzy' Balhar [:material-email:](mailto:frenzy.madness@gmail.com) [:material-twitter:](https://twitter.com/lumirbalhar)
 - Ofek Lev [:material-web:](https://ofek.dev) [:material-github:](https://github.com/ofek) [:material-twitter:](https://twitter.com/Ofekmeister)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,12 +80,27 @@ exclude = [
 
 [tool.mypy]
 disallow_untyped_defs = false
+disallow_incomplete_defs = false
 follow_imports = "normal"
 ignore_missing_imports = true
 pretty = true
 show_column_numbers = true
+show_error_codes = true
 warn_no_return = false
 warn_unused_ignores = true
+
+# make sure mypy finding file path
+explicit_package_bases = true
+namespace_packages = true
+
+[[tool.mypy.overrides]]
+module = [
+    "*.hatchling.build",
+    "*.hatchling.ouroboros"
+]
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+warn_no_return = true
 
 [tool.bandit]
 recursive = true


### PR DESCRIPTION
As https://github.com/pypa/hatch/issues/564, I start to add type hints in the `backend/hatchling` part, first `build.py` and `ouroboros.py`.

Use `mypy` overrides config to add module check until all files are checked, then we can remove this.

```toml
[[tool.mypy.overrides]]
module = [
    "backend.src.hatchling.build",
    "backend.src.hatchling.ouroboros"
]
disallow_untyped_defs = true
disallow_incomplete_defs = true
warn_no_return = true
```