### PR TITLE
Update best practices part 1

### DIFF
--- a/docs/blog/posts/release-hatch-160.md
+++ b/docs/blog/posts/release-hatch-160.md
@@ -62,14 +62,14 @@ and the following [matrix](../../config/environment/advanced.md#matrix):
 
     ```toml
     [[tool.hatch.envs.test.matrix]]
-    python = ["37", "38", "39", "310", "311"]
+    python = ["3.7", "3.8", "3.9", "3.10", "3.11"]
     ```
 
 === ":octicons-file-code-16: hatch.toml"
 
     ```toml
     [[envs.test.matrix]]
-    python = ["37", "38", "39", "310", "311"]
+    python = ["3.7", "3.8", "3.9", "3.10", "3.11"]
     ```
 
 then [locating](../../cli/reference.md#hatch-env-find) environments with the following command:
@@ -82,11 +82,11 @@ will show that the general directory structure is:
 
 ```
 .hatch
-├── test.py37
-├── test.py38
-├── test.py39
-├── test.py310
-└── test.py311
+├── test.py3.7
+├── test.py3.8
+├── test.py3.9
+├── test.py3.10
+└── test.py3.11
 ```
 
 This flat structure is required for detection of virtual environments by tools like Visual Studio Code and PyCharm.

--- a/docs/config/environment/advanced.md
+++ b/docs/config/environment/advanced.md
@@ -27,11 +27,11 @@ Environments can define a series of matrices with the `matrix` option:
     ]
 
     [[tool.hatch.envs.test.matrix]]
-    python = ["27", "38"]
+    python = ["2.7", "3.8"]
     version = ["42", "3.14"]
 
     [[tool.hatch.envs.test.matrix]]
-    python = ["38", "39"]
+    python = ["3.8", "3.9"]
     version = ["9000"]
     feature = ["foo", "bar"]
     ```
@@ -45,11 +45,11 @@ Environments can define a series of matrices with the `matrix` option:
     ]
 
     [[envs.test.matrix]]
-    python = ["27", "38"]
+    python = ["2.7", "3.8"]
     version = ["42", "3.14"]
 
     [[envs.test.matrix]]
-    python = ["38", "39"]
+    python = ["3.8", "3.9"]
     version = ["9000"]
     feature = ["foo", "bar"]
     ```
@@ -94,7 +94,7 @@ If the variables `py` or `python` are specified, then they will rank first in th
     ```toml
     [[tool.hatch.envs.test.matrix]]
     version = ["42"]
-    python = ["39", "pypy3"]
+    python = ["3.9", "pypy3"]
     ```
 
 === ":octicons-file-code-16: hatch.toml"
@@ -102,13 +102,13 @@ If the variables `py` or `python` are specified, then they will rank first in th
     ```toml
     [[envs.test.matrix]]
     version = ["42"]
-    python = ["39", "pypy3"]
+    python = ["3.9", "pypy3"]
     ```
 
 would generate the following environments:
 
 ```
-test.py39-42
+test.py3.9-42
 test.pypy3-42
 ```
 
@@ -172,7 +172,7 @@ Rather than [selecting](../../environment.md#selection) a single generated envir
     cov = 'pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=pkg --cov=tests'
 
     [[tool.hatch.envs.test.matrix]]
-    python = ["27", "38"]
+    python = ["2.7", "3.8"]
     version = ["42", "3.14"]
     ```
 
@@ -190,7 +190,7 @@ Rather than [selecting](../../environment.md#selection) a single generated envir
     cov = 'pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=pkg --cov=tests'
 
     [[envs.test.matrix]]
-    python = ["27", "38"]
+    python = ["2.7", "3.8"]
     version = ["42", "3.14"]
     ```
 
@@ -281,7 +281,7 @@ The [matrix](#matrix) variables used to generate each environment can be used to
     ]
 
     [[tool.hatch.envs.test.matrix]]
-    python = ["27", "38"]
+    python = ["2.7", "3.8"]
     version = ["legacy", "latest"]
     auth = ["oauth2", "krb5", "noauth"]
     ```
@@ -297,7 +297,7 @@ The [matrix](#matrix) variables used to generate each environment can be used to
     ]
 
     [[envs.test.matrix]]
-    python = ["27", "38"]
+    python = ["2.7", "3.8"]
     version = ["legacy", "latest"]
     auth = ["oauth2", "kerberos", "noauth"]
     ```
@@ -334,7 +334,7 @@ When a [matrix](#matrix) is defined, the `name` source can be used for regular e
 
         ```toml
         [tool.hatch.envs.test.overrides]
-        matrix.foo.python = "310"
+        matrix.foo.python = "3.10"
         matrix.bar.skip-install = { value = true, if = ["..."] }
         env.CI.dev-mode = [
           { value = false, if = ["..."] },
@@ -346,7 +346,7 @@ When a [matrix](#matrix) is defined, the `name` source can be used for regular e
 
         ```toml
         [envs.test.overrides]
-        matrix.foo.python = "310"
+        matrix.foo.python = "3.10"
         matrix.bar.skip-install = { value = true, if = ["..."] }
         env.CI.dev-mode = [
           { value = false, if = ["..."] },

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -144,11 +144,11 @@ Every environment can define its own set of [matrices](config/environment/advanc
     ]
 
     [[tool.hatch.envs.test.matrix]]
-    python = ["27", "38"]
+    python = ["2.7", "3.8"]
     version = ["42", "3.14"]
 
     [[tool.hatch.envs.test.matrix]]
-    python = ["38", "39"]
+    python = ["3.8", "3.9"]
     version = ["9000"]
     features = ["foo", "bar"]
     ```
@@ -162,11 +162,11 @@ Every environment can define its own set of [matrices](config/environment/advanc
     ]
 
     [[envs.test.matrix]]
-    python = ["27", "38"]
+    python = ["2.7", "3.8"]
     version = ["42", "3.14"]
 
     [[envs.test.matrix]]
-    python = ["38", "39"]
+    python = ["3.8", "3.9"]
     version = ["9000"]
     features = ["foo", "bar"]
     ```
@@ -182,18 +182,18 @@ $ hatch env show --ascii
 | default | virtual |
 +---------+---------+
                        Matrices
-+------+---------+--------------------+--------------+
-| Name | Type    | Envs               | Dependencies |
-+======+=========+====================+==============+
-| test | virtual | test.py27-42       | pytest       |
-|      |         | test.py27-3.14     |              |
-|      |         | test.py38-42       |              |
-|      |         | test.py38-3.14     |              |
-|      |         | test.py38-9000-foo |              |
-|      |         | test.py38-9000-bar |              |
-|      |         | test.py39-9000-foo |              |
-|      |         | test.py39-9000-bar |              |
-+------+---------+--------------------+--------------+
++------+---------+---------------------+--------------+
+| Name | Type    | Envs                | Dependencies |
++======+=========+=====================+==============+
+| test | virtual | test.py2.7-42       | pytest       |
+|      |         | test.py2.7-3.14     |              |
+|      |         | test.py3.8-42       |              |
+|      |         | test.py3.8-3.14     |              |
+|      |         | test.py3.8-9000-foo |              |
+|      |         | test.py3.8-9000-bar |              |
+|      |         | test.py3.9-9000-foo |              |
+|      |         | test.py3.9-9000-bar |              |
++------+---------+---------------------+--------------+
 ```
 
 ## Removal

--- a/docs/history.md
+++ b/docs/history.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Unreleased
 
+***Added:***
+
+- Update best practices in project templates and documentation
+
 ### [1.6.2](https://github.com/pypa/hatch/releases/tag/hatch-v1.6.2) - 2022-10-20 ### {: #hatch-v1.6.2 }
 
 ***Fixed:***

--- a/docs/meta/faq.md
+++ b/docs/meta/faq.md
@@ -204,11 +204,11 @@ The only caveat is that currently there is no support for re-creating an environ
         ]
 
         [[envs.default.matrix]]
-        python = ["27", "38"]
+        python = ["2.7", "3.8"]
         version = ["42", "3.14"]
 
         [[envs.default.matrix]]
-        python = ["38", "39"]
+        python = ["3.8", "3.9"]
         version = ["9000"]
         features = ["foo", "bar"]
         ```
@@ -234,11 +234,11 @@ The only caveat is that currently there is no support for re-creating an environ
         ]
 
         [[tool.hatch.envs.default.matrix]]
-        python = ["27", "38"]
+        python = ["2.7", "3.8"]
         version = ["42", "3.14"]
 
         [[tool.hatch.envs.default.matrix]]
-        python = ["38", "39"]
+        python = ["3.8", "3.9"]
         version = ["9000"]
         features = ["foo", "bar"]
         ```

--- a/hatch.toml
+++ b/hatch.toml
@@ -29,7 +29,7 @@ env.HERMETIC_TESTS.type = [
 ]
 
 [[envs.test.matrix]]
-python = ["37", "38", "39", "310"]
+python = ["3.7", "3.8", "3.9", "3.10"]
 
 [envs.coverage]
 detached = true

--- a/src/hatch/cli/env/run.py
+++ b/src/hatch/cli/env/run.py
@@ -84,7 +84,7 @@ def run(
         \b
         ```toml
         [[tool.hatch.envs.test.matrix]]
-        python = ["39", "310"]
+        python = ["3.9", "3.10"]
         version = ["42", "3.14", "9000"]
         ```
 
@@ -93,7 +93,7 @@ def run(
         \b
         ```toml
         [[envs.test.matrix]]
-        python = ["39", "310"]
+        python = ["3.9", "3.10"]
         version = ["42", "3.14", "9000"]
         ```
 
@@ -101,10 +101,10 @@ def run(
 
     \b
     ```
-    hatch env run -i py=310 -x version=9000 test:pytest
+    hatch env run -i py=3.10 -x version=9000 test:pytest
     ```
 
-    would execute `pytest` in the environments `test.py310-42` and `test.py310-3.14`.
+    would execute `pytest` in the environments `test.py3.10-42` and `test.py3.10-3.14`.
     Note that `py` may be used as an alias for `python`.
     """
     project = app.project

--- a/src/hatch/cli/run/__init__.py
+++ b/src/hatch/cli/run/__init__.py
@@ -27,7 +27,7 @@ def run(ctx, app, args):
         \b
         ```toml
         [[tool.hatch.envs.test.matrix]]
-        python = ["39", "310"]
+        python = ["3.9", "3.10"]
         version = ["42", "3.14", "9000"]
         ```
 
@@ -36,7 +36,7 @@ def run(ctx, app, args):
         \b
         ```toml
         [[envs.test.matrix]]
-        python = ["39", "310"]
+        python = ["3.9", "3.10"]
         version = ["42", "3.14", "9000"]
         ```
 
@@ -44,10 +44,10 @@ def run(ctx, app, args):
 
     \b
     ```
-    hatch run +py=310 -version=9000 test:pytest
+    hatch run +py=3.10 -version=9000 test:pytest
     ```
 
-    would execute `pytest` in the environments `test.py310-42` and `test.py310-3.14`.
+    would execute `pytest` in the environments `test.py3.10-42` and `test.py3.10-3.14`.
     Note that `py` may be used as an alias for `python`.
     """
     if args[0] in ('-h', '--help'):

--- a/src/hatch/template/files_default.py
+++ b/src/hatch/template/files_default.py
@@ -144,7 +144,7 @@ cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov={packa
 no-cov = "cov --no-cov {{args}}"
 
 [[tool.hatch.envs.test.matrix]]
-python = ["37", "38", "39", "310", "311"]
+python = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
 [tool.coverage.run]
 branch = true

--- a/tests/helpers/templates/new/default.py
+++ b/tests/helpers/templates/new/default.py
@@ -114,7 +114,7 @@ cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov={kwarg
 no-cov = "cov --no-cov {{args}}"
 
 [[tool.hatch.envs.test.matrix]]
-python = ["37", "38", "39", "310", "311"]
+python = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
 [tool.coverage.run]
 branch = true

--- a/tests/helpers/templates/new/feature_cli.py
+++ b/tests/helpers/templates/new/feature_cli.py
@@ -149,7 +149,7 @@ cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov={kwarg
 no-cov = "cov --no-cov {{args}}"
 
 [[tool.hatch.envs.test.matrix]]
-python = ["37", "38", "39", "310", "311"]
+python = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
 [tool.coverage.run]
 branch = true

--- a/tests/helpers/templates/new/feature_src_layout.py
+++ b/tests/helpers/templates/new/feature_src_layout.py
@@ -114,7 +114,7 @@ cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=src/{k
 no-cov = "cov --no-cov {{args}}"
 
 [[tool.hatch.envs.test.matrix]]
-python = ["37", "38", "39", "310", "311"]
+python = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
 [tool.coverage.run]
 branch = true

--- a/tests/helpers/templates/new/licenses_empty.py
+++ b/tests/helpers/templates/new/licenses_empty.py
@@ -77,7 +77,7 @@ cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov={kwarg
 no-cov = "cov --no-cov {{args}}"
 
 [[tool.hatch.envs.test.matrix]]
-python = ["37", "38", "39", "310", "311"]
+python = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
 [tool.coverage.run]
 branch = true

--- a/tests/helpers/templates/new/licenses_multiple.py
+++ b/tests/helpers/templates/new/licenses_multiple.py
@@ -117,7 +117,7 @@ cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov={kwarg
 no-cov = "cov --no-cov {{args}}"
 
 [[tool.hatch.envs.test.matrix]]
-python = ["37", "38", "39", "310", "311"]
+python = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
 [tool.coverage.run]
 branch = true

--- a/tests/helpers/templates/new/projects_urls_empty.py
+++ b/tests/helpers/templates/new/projects_urls_empty.py
@@ -109,7 +109,7 @@ cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov={kwarg
 no-cov = "cov --no-cov {{args}}"
 
 [[tool.hatch.envs.test.matrix]]
-python = ["37", "38", "39", "310", "311"]
+python = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
 [tool.coverage.run]
 branch = true

--- a/tests/helpers/templates/new/projects_urls_space_in_label.py
+++ b/tests/helpers/templates/new/projects_urls_space_in_label.py
@@ -112,7 +112,7 @@ cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov={kwarg
 no-cov = "cov --no-cov {{args}}"
 
 [[tool.hatch.envs.test.matrix]]
-python = ["37", "38", "39", "310", "311"]
+python = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
tox/virtualenv only support the shortened Python version format for legacy reasons