### PR TITLE
Retroactively support `License-Expression` core metadata

### DIFF
--- a/backend/src/hatchling/metadata/spec.py
+++ b/backend/src/hatchling/metadata/spec.py
@@ -110,6 +110,9 @@ def construct_metadata_file_2_1(metadata, extra_dependencies=()):
             else:
                 metadata_file += f'{indent}{line}\n'
 
+    if metadata.core.license_expression:
+        metadata_file += f'License-Expression: {metadata.core.license_expression}\n'
+
     if metadata.core.license_files:
         for license_file in metadata.core.license_files:
             metadata_file += f'License-File: {license_file}\n'
@@ -187,6 +190,9 @@ def construct_metadata_file_2_2(metadata, extra_dependencies=()):
                 metadata_file += f'{line}\n'
             else:
                 metadata_file += f'{indent}{line}\n'
+
+    if metadata.core.license_expression:
+        metadata_file += f'License-Expression: {metadata.core.license_expression}\n'
 
     if metadata.core.license_files:
         for license_file in metadata.core.license_files:

--- a/docs/history/hatch.md
+++ b/docs/history/hatch.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ***Added:***
 
 - Expand home and environment variables in configured cache and data directories
+- Retroactively support `License-Expression` core metadata starting at version 2.1
 - Update project templates
 
 ***Fixed:***

--- a/tests/backend/metadata/test_spec.py
+++ b/tests/backend/metadata/test_spec.py
@@ -524,6 +524,22 @@ class TestCoreMetadataV21:
             """
         )
 
+    def test_license_expression(self, constructor, isolation, helpers):
+        metadata = ProjectMetadata(
+            str(isolation),
+            None,
+            {'project': {'name': 'My.App', 'version': '0.1.0', 'license': 'mit'}},
+        )
+
+        assert constructor(metadata) == helpers.dedent(
+            """
+            Metadata-Version: 2.1
+            Name: My.App
+            Version: 0.1.0
+            License-Expression: MIT
+            """
+        )
+
     def test_keywords_single(self, constructor, isolation, helpers):
         metadata = ProjectMetadata(
             str(isolation), None, {'project': {'name': 'My.App', 'version': '0.1.0', 'keywords': ['foo']}}
@@ -927,6 +943,22 @@ class TestCoreMetadataV22:
             Version: 0.1.0
             License: foo
                     bar
+            """
+        )
+
+    def test_license_expression(self, constructor, isolation, helpers):
+        metadata = ProjectMetadata(
+            str(isolation),
+            None,
+            {'project': {'name': 'My.App', 'version': '0.1.0', 'license': 'mit'}},
+        )
+
+        assert constructor(metadata) == helpers.dedent(
+            """
+            Metadata-Version: 2.2
+            Name: My.App
+            Version: 0.1.0
+            License-Expression: MIT
             """
         )
 


### PR DESCRIPTION
resolves https://github.com/pypa/hatch/issues/569