### PR TITLE
Add type hints for hatchling.metadata

### DIFF
--- a/backend/src/hatchling/metadata/core.py
+++ b/backend/src/hatchling/metadata/core.py
@@ -316,7 +316,7 @@ class CoreMetadata:
         self,
         root: Path | str,
         config: dict[str, Any],
-        hatch_metadata: "HatchMetadataSettings",
+        hatch_metadata: HatchMetadataSettings,
         context: Context,
     ) -> None:
         self.root = root
@@ -1240,7 +1240,7 @@ class HatchMetadata:
         self._version: HatchVersionConfig | None = None
 
     @property
-    def metadata(self) -> "HatchMetadataSettings":
+    def metadata(self) -> HatchMetadataSettings:
         if self._metadata is None:
             metadata_config = self.config.get('metadata', {})
             if not isinstance(metadata_config, dict):
@@ -1273,7 +1273,7 @@ class HatchMetadata:
         return self._build_targets
 
     @property
-    def version(self) -> "HatchVersionConfig":
+    def version(self) -> HatchVersionConfig:
         if self._version is None:
             if 'version' not in self.config:
                 raise ValueError('Missing `tool.hatch.version` configuration')

--- a/backend/src/hatchling/metadata/core.py
+++ b/backend/src/hatchling/metadata/core.py
@@ -329,7 +329,7 @@ class CoreMetadata:
         self._version: str | None = None
         self._description: str | None = None
         self._readme: str | None = None
-        self._readme_content_type: str | None = None  # TODO: make into enum?
+        self._readme_content_type: str | None = None
         self._readme_path: str | None = None
         self._requires_python: str | None = None
         self._python_constraint: SpecifierSet | None = None
@@ -528,8 +528,6 @@ class CoreMetadata:
                 self._readme_path = readme_path
             else:
                 raise TypeError('Field `project.readme` must be a string or a table')
-
-            self._readme = self._readme  # TODO: should this be here?
 
         return self._readme
 

--- a/backend/src/hatchling/metadata/core.py
+++ b/backend/src/hatchling/metadata/core.py
@@ -135,7 +135,7 @@ class ProjectMetadata:
                 self._project_file = project_file
                 self._config = load_toml(project_file)
 
-        return self._config  # type: ignore
+        return self._config
 
     @property
     def build(self) -> BuildMetadata:
@@ -160,7 +160,7 @@ class ProjectMetadata:
             if metadata_hooks:
                 static_fields = set(self.core_raw_metadata)
                 if 'version' in self.hatch.config:
-                    self._get_version(metadata)
+                    self._version = self._get_version(metadata)
                     self.core_raw_metadata['version'] = self.version
 
                 for metadata_hook in metadata_hooks.values():
@@ -342,7 +342,7 @@ class CoreMetadata:
         self._maintainers_data: dict[str, list[str]] | None = None
         self._keywords: list[str] | None = None
         self._classifiers: list[str] | None = None
-        self._extra_classifiers = set()
+        self._extra_classifiers: set[str] = set()
         self._urls: dict[str, str] | None = None
         self._scripts: dict[str, str] | None = None
         self._gui_scripts: dict[str, str] | None = None
@@ -406,7 +406,6 @@ class CoreMetadata:
                         'Field `project.version` can only be resolved dynamically '
                         'if `version` is in field `project.dynamic`'
                     )
-                # TODO: what should happen here? Currently this leaves the version as None?
             else:
                 if 'version' in self.dynamic:
                     raise ValueError(

--- a/backend/src/hatchling/metadata/utils.py
+++ b/backend/src/hatchling/metadata/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from typing import TYPE_CHECKING
 
@@ -17,7 +19,7 @@ def normalize_project_name(project_name: str):
     return re.sub(r'[-_.]+', '-', project_name).lower()
 
 
-def get_normalized_dependency(requirement: "Requirement"):
+def get_normalized_dependency(requirement: Requirement):
     # Changes to this function affect reproducibility between versions
     from packaging.specifiers import SpecifierSet
 

--- a/backend/src/hatchling/metadata/utils.py
+++ b/backend/src/hatchling/metadata/utils.py
@@ -1,19 +1,23 @@
 import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from packaging.requirements import Requirement
 
 # NOTE: this module should rarely be changed because it is likely to be used by other packages like Hatch
 
 
-def is_valid_project_name(project_name):
+def is_valid_project_name(project_name: str):
     # https://peps.python.org/pep-0508/#names
     return re.search('^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$', project_name, re.IGNORECASE) is not None
 
 
-def normalize_project_name(project_name):
+def normalize_project_name(project_name: str):
     # https://peps.python.org/pep-0503/#normalized-names
     return re.sub(r'[-_.]+', '-', project_name).lower()
 
 
-def get_normalized_dependency(requirement):
+def get_normalized_dependency(requirement: "Requirement"):
     # Changes to this function affect reproducibility between versions
     from packaging.specifiers import SpecifierSet
 

--- a/docs/meta/authors.md
+++ b/docs/meta/authors.md
@@ -16,3 +16,4 @@
 - Ofek Lev [:material-web:](https://ofek.dev) [:material-github:](https://github.com/ofek) [:material-twitter:](https://twitter.com/Ofekmeister)
 - Olga Matoula [:material-github:](https://github.com/olgarithms) [:material-twitter:](https://twitter.com/olgarithms_)
 - Philip Blair [:material-email:](mailto:philip@pblair.org)
+- Robert Rosca [:material-github:](https://github.com/robertrosca)


### PR DESCRIPTION
Part of https://github.com/pypa/hatch/issues/564

Originally I removed the initialisation of attributes used to store property values and instead used `getattr` calls for it, as this avoids having to type-hint attributes which shouldn't be accessed as the property would should always be called anyway, but that does obscure some of the logic a bit so I changed it back to just type hinting all the attributes used for lazy properties.

This is the commit before that change https://github.com/pypa/hatch/commit/1a095f48bb936a8eabec682c8120f116449fb2cb if anybody prefers that style I'm happy to move back as well. It has some benefits but in this case the extra verbosity is probably worth having just to make it very clear what's going on.