### PR TITLE
Add Haystack to the list of projects using hatch

### DIFF
--- a/docs/community/users.md
+++ b/docs/community/users.md
@@ -13,6 +13,7 @@ The following is not intended to be a complete enumeration. Be sure to view the 
 | [Django Wiki](https://github.com/django-wiki/django-wiki/blob/1b03661c3fe7260b0eb82565cc3812b96de6b674/pyproject.toml#L1-L3)
 | [FastAPI](https://github.com/tiangolo/fastapi/blob/1073062c7f2c48bcc28bcedbdc009c18c171f6fb/pyproject.toml#L1-L3)
 | [Gradio](https://github.com/gradio-app/gradio/blob/f43481c18ac6468fbf30bf9a80981b7eab453961/pyproject.toml#L1-L3)
+| [Haystack](https://github.com/deepset-ai/haystack/blob/e4c3817d01c7c81c0accbdb543a0ab5cc9e86ade/pyproject.toml#L1-L5)
 | [HTTPX](https://github.com/encode/httpx/blob/45b7cfaad3a8987ea35fa5bf092bbdda485444fd/pyproject.toml#L1-L3)
 | [iCalendar for Humans](https://github.com/ics-py/ics-py/blob/133a0955f6efbb83ff0eae45ad0bbe6902a8f2f1/pyproject.toml#L61-L63)
 | [LinkChecker](https://github.com/linkchecker/linkchecker/blob/de40321b57a2271e90e696b5320c0409faaa895d/pyproject.toml#L29-L34)


### PR DESCRIPTION
Haystack is an open source NLP framework and we use hatch to build and release packages.