### PR TITLE
Update Ruff

### DIFF
--- a/backend/scripts/update_licenses.py
+++ b/backend/scripts/update_licenses.py
@@ -21,8 +21,8 @@ def download_data(url):
             continue
         else:
             return json.loads(response.content.decode('utf-8'))
-    else:
-        raise Exception('Download failed')
+
+    raise Exception('Download failed')
 
 
 def main():

--- a/hatch.toml
+++ b/hatch.toml
@@ -49,7 +49,7 @@ detached = true
 dependencies = [
   "black>=22.6.0",
   "mypy>=0.990",
-  "ruff>=0.0.156",
+  "ruff>=0.0.176",
 ]
 [envs.lint.scripts]
 typing = "mypy --install-types --non-interactive {args:backend/src/hatchling src/hatch tests}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,11 +92,18 @@ select = [
   "F",
   "FBT",
   "I",
+  "ICN",
   "N",
+  "PLC",
+  "PLE",
+  "PLR",
+  "PLW",
   "Q",
   "RUF",
   "S",
+  "SIM",
   "T",
+  "TID",
   "UP",
   "W",
   "YTT",
@@ -130,8 +137,8 @@ ban-relative-imports = "all"
 "backend/src/hatchling/bridge/app.py" = ["T201"]
 "backend/tests/downstream/integrate.py" = ["T201"]
 "scripts/*" = ["T201"]
-# Tests can use relative imports and assertions
-"tests/**/*" = ["I252", "S101"]
+# Tests can use assertions and relative imports
+"tests/**/*" = ["S101", "TID252"]
 
 [tool.mypy]
 disallow_untyped_defs = false

--- a/src/hatch/template/files_default.py
+++ b/src/hatch/template/files_default.py
@@ -159,7 +159,7 @@ detached = true
 dependencies = [
   "black",
   "mypy",
-  "ruff",
+  "ruff>=0.0.176",
 ]
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive {{args:{package_location}{template_config['package_name']} tests}}"
@@ -185,7 +185,30 @@ skip-string-normalization = true
 [tool.ruff]
 target-version = "py37"
 line-length = 120
-select = ["A", "B", "C", "E", "F", "FBT", "I", "N", "Q", "RUF", "S", "T", "UP", "W", "YTT"]
+select = [
+  "A",
+  "ARG",
+  "B",
+  "C",
+  "E",
+  "F",
+  "FBT",
+  "I",
+  "ICN",
+  "N",
+  "PLC",
+  "PLE",
+  "PLR",
+  "PLW",
+  "Q",
+  "RUF",
+  "S",
+  "T",
+  "TID",
+  "UP",
+  "W",
+  "YTT",
+]
 ignore = [
   # Allow non-abstract empty methods in abstract base classes
   "B027",
@@ -208,8 +231,8 @@ known-first-party = ["{template_config['package_name']}"]
 ban-relative-imports = "all"
 
 [tool.ruff.per-file-ignores]
-# Tests can use relative imports and assertions
-"tests/**/*" = ["I252", "S101"]
+# Tests can use assertions and relative imports
+"tests/**/*" = ["S101", "TID252"]
 
 [tool.coverage.run]
 source_pkgs = ["{template_config['package_name']}", "tests"]

--- a/src/hatch/template/files_feature_cli.py
+++ b/src/hatch/template/files_feature_cli.py
@@ -25,8 +25,7 @@ from {package_name}.__about__ import __version__
 
 @click.group(context_settings={{"help_option_names": ["-h", "--help"]}}, invoke_without_command=True)
 @click.version_option(version=__version__, prog_name="{project_name}")
-@click.pass_context
-def {package_name}(ctx: click.Context):
+def {package_name}():
     click.echo("Hello world!")
 """
 

--- a/tests/helpers/templates/new/default.py
+++ b/tests/helpers/templates/new/default.py
@@ -129,7 +129,7 @@ detached = true
 dependencies = [
   "black",
   "mypy",
-  "ruff",
+  "ruff>=0.0.176",
 ]
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive {{args:src/{kwargs['package_name']} tests}}"
@@ -155,7 +155,30 @@ skip-string-normalization = true
 [tool.ruff]
 target-version = "py37"
 line-length = 120
-select = ["A", "B", "C", "E", "F", "FBT", "I", "N", "Q", "RUF", "S", "T", "UP", "W", "YTT"]
+select = [
+  "A",
+  "ARG",
+  "B",
+  "C",
+  "E",
+  "F",
+  "FBT",
+  "I",
+  "ICN",
+  "N",
+  "PLC",
+  "PLE",
+  "PLR",
+  "PLW",
+  "Q",
+  "RUF",
+  "S",
+  "T",
+  "TID",
+  "UP",
+  "W",
+  "YTT",
+]
 ignore = [
   # Allow non-abstract empty methods in abstract base classes
   "B027",
@@ -178,8 +201,8 @@ known-first-party = ["{kwargs['package_name']}"]
 ban-relative-imports = "all"
 
 [tool.ruff.per-file-ignores]
-# Tests can use relative imports and assertions
-"tests/**/*" = ["I252", "S101"]
+# Tests can use assertions and relative imports
+"tests/**/*" = ["S101", "TID252"]
 
 [tool.coverage.run]
 source_pkgs = ["{kwargs['package_name']}", "tests"]

--- a/tests/helpers/templates/new/feature_cli.py
+++ b/tests/helpers/templates/new/feature_cli.py
@@ -56,8 +56,7 @@ from {kwargs['package_name']}.__about__ import __version__
 
 @click.group(context_settings={{"help_option_names": ["-h", "--help"]}}, invoke_without_command=True)
 @click.version_option(version=__version__, prog_name="{kwargs['project_name']}")
-@click.pass_context
-def {kwargs['package_name']}(ctx: click.Context):
+def {kwargs['package_name']}():
     click.echo("Hello world!")
 """,
         ),
@@ -164,7 +163,7 @@ detached = true
 dependencies = [
   "black",
   "mypy",
-  "ruff",
+  "ruff>=0.0.176",
 ]
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive {{args:src/{kwargs['package_name']} tests}}"
@@ -190,7 +189,30 @@ skip-string-normalization = true
 [tool.ruff]
 target-version = "py37"
 line-length = 120
-select = ["A", "B", "C", "E", "F", "FBT", "I", "N", "Q", "RUF", "S", "T", "UP", "W", "YTT"]
+select = [
+  "A",
+  "ARG",
+  "B",
+  "C",
+  "E",
+  "F",
+  "FBT",
+  "I",
+  "ICN",
+  "N",
+  "PLC",
+  "PLE",
+  "PLR",
+  "PLW",
+  "Q",
+  "RUF",
+  "S",
+  "T",
+  "TID",
+  "UP",
+  "W",
+  "YTT",
+]
 ignore = [
   # Allow non-abstract empty methods in abstract base classes
   "B027",
@@ -213,8 +235,8 @@ known-first-party = ["{kwargs['package_name']}"]
 ban-relative-imports = "all"
 
 [tool.ruff.per-file-ignores]
-# Tests can use relative imports and assertions
-"tests/**/*" = ["I252", "S101"]
+# Tests can use assertions and relative imports
+"tests/**/*" = ["S101", "TID252"]
 
 [tool.coverage.run]
 source_pkgs = ["{kwargs['package_name']}", "tests"]

--- a/tests/helpers/templates/new/feature_no_src_layout.py
+++ b/tests/helpers/templates/new/feature_no_src_layout.py
@@ -129,7 +129,7 @@ detached = true
 dependencies = [
   "black",
   "mypy",
-  "ruff",
+  "ruff>=0.0.176",
 ]
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive {{args:{kwargs['package_name']} tests}}"
@@ -155,7 +155,30 @@ skip-string-normalization = true
 [tool.ruff]
 target-version = "py37"
 line-length = 120
-select = ["A", "B", "C", "E", "F", "FBT", "I", "N", "Q", "RUF", "S", "T", "UP", "W", "YTT"]
+select = [
+  "A",
+  "ARG",
+  "B",
+  "C",
+  "E",
+  "F",
+  "FBT",
+  "I",
+  "ICN",
+  "N",
+  "PLC",
+  "PLE",
+  "PLR",
+  "PLW",
+  "Q",
+  "RUF",
+  "S",
+  "T",
+  "TID",
+  "UP",
+  "W",
+  "YTT",
+]
 ignore = [
   # Allow non-abstract empty methods in abstract base classes
   "B027",
@@ -178,8 +201,8 @@ known-first-party = ["{kwargs['package_name']}"]
 ban-relative-imports = "all"
 
 [tool.ruff.per-file-ignores]
-# Tests can use relative imports and assertions
-"tests/**/*" = ["I252", "S101"]
+# Tests can use assertions and relative imports
+"tests/**/*" = ["S101", "TID252"]
 
 [tool.coverage.run]
 source_pkgs = ["{kwargs['package_name']}", "tests"]

--- a/tests/helpers/templates/new/licenses_empty.py
+++ b/tests/helpers/templates/new/licenses_empty.py
@@ -92,7 +92,7 @@ detached = true
 dependencies = [
   "black",
   "mypy",
-  "ruff",
+  "ruff>=0.0.176",
 ]
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive {{args:src/{kwargs['package_name']} tests}}"
@@ -118,7 +118,30 @@ skip-string-normalization = true
 [tool.ruff]
 target-version = "py37"
 line-length = 120
-select = ["A", "B", "C", "E", "F", "FBT", "I", "N", "Q", "RUF", "S", "T", "UP", "W", "YTT"]
+select = [
+  "A",
+  "ARG",
+  "B",
+  "C",
+  "E",
+  "F",
+  "FBT",
+  "I",
+  "ICN",
+  "N",
+  "PLC",
+  "PLE",
+  "PLR",
+  "PLW",
+  "Q",
+  "RUF",
+  "S",
+  "T",
+  "TID",
+  "UP",
+  "W",
+  "YTT",
+]
 ignore = [
   # Allow non-abstract empty methods in abstract base classes
   "B027",
@@ -141,8 +164,8 @@ known-first-party = ["{kwargs['package_name']}"]
 ban-relative-imports = "all"
 
 [tool.ruff.per-file-ignores]
-# Tests can use relative imports and assertions
-"tests/**/*" = ["I252", "S101"]
+# Tests can use assertions and relative imports
+"tests/**/*" = ["S101", "TID252"]
 
 [tool.coverage.run]
 source_pkgs = ["{kwargs['package_name']}", "tests"]

--- a/tests/helpers/templates/new/licenses_multiple.py
+++ b/tests/helpers/templates/new/licenses_multiple.py
@@ -132,7 +132,7 @@ detached = true
 dependencies = [
   "black",
   "mypy",
-  "ruff",
+  "ruff>=0.0.176",
 ]
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive {{args:src/{kwargs['package_name']} tests}}"
@@ -158,7 +158,30 @@ skip-string-normalization = true
 [tool.ruff]
 target-version = "py37"
 line-length = 120
-select = ["A", "B", "C", "E", "F", "FBT", "I", "N", "Q", "RUF", "S", "T", "UP", "W", "YTT"]
+select = [
+  "A",
+  "ARG",
+  "B",
+  "C",
+  "E",
+  "F",
+  "FBT",
+  "I",
+  "ICN",
+  "N",
+  "PLC",
+  "PLE",
+  "PLR",
+  "PLW",
+  "Q",
+  "RUF",
+  "S",
+  "T",
+  "TID",
+  "UP",
+  "W",
+  "YTT",
+]
 ignore = [
   # Allow non-abstract empty methods in abstract base classes
   "B027",
@@ -181,8 +204,8 @@ known-first-party = ["{kwargs['package_name']}"]
 ban-relative-imports = "all"
 
 [tool.ruff.per-file-ignores]
-# Tests can use relative imports and assertions
-"tests/**/*" = ["I252", "S101"]
+# Tests can use assertions and relative imports
+"tests/**/*" = ["S101", "TID252"]
 
 [tool.coverage.run]
 source_pkgs = ["{kwargs['package_name']}", "tests"]

--- a/tests/helpers/templates/new/projects_urls_empty.py
+++ b/tests/helpers/templates/new/projects_urls_empty.py
@@ -124,7 +124,7 @@ detached = true
 dependencies = [
   "black",
   "mypy",
-  "ruff",
+  "ruff>=0.0.176",
 ]
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive {{args:src/{kwargs['package_name']} tests}}"
@@ -150,7 +150,30 @@ skip-string-normalization = true
 [tool.ruff]
 target-version = "py37"
 line-length = 120
-select = ["A", "B", "C", "E", "F", "FBT", "I", "N", "Q", "RUF", "S", "T", "UP", "W", "YTT"]
+select = [
+  "A",
+  "ARG",
+  "B",
+  "C",
+  "E",
+  "F",
+  "FBT",
+  "I",
+  "ICN",
+  "N",
+  "PLC",
+  "PLE",
+  "PLR",
+  "PLW",
+  "Q",
+  "RUF",
+  "S",
+  "T",
+  "TID",
+  "UP",
+  "W",
+  "YTT",
+]
 ignore = [
   # Allow non-abstract empty methods in abstract base classes
   "B027",
@@ -173,8 +196,8 @@ known-first-party = ["{kwargs['package_name']}"]
 ban-relative-imports = "all"
 
 [tool.ruff.per-file-ignores]
-# Tests can use relative imports and assertions
-"tests/**/*" = ["I252", "S101"]
+# Tests can use assertions and relative imports
+"tests/**/*" = ["S101", "TID252"]
 
 [tool.coverage.run]
 source_pkgs = ["{kwargs['package_name']}", "tests"]

--- a/tests/helpers/templates/new/projects_urls_space_in_label.py
+++ b/tests/helpers/templates/new/projects_urls_space_in_label.py
@@ -127,7 +127,7 @@ detached = true
 dependencies = [
   "black",
   "mypy",
-  "ruff",
+  "ruff>=0.0.176",
 ]
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive {{args:src/{kwargs['package_name']} tests}}"
@@ -153,7 +153,30 @@ skip-string-normalization = true
 [tool.ruff]
 target-version = "py37"
 line-length = 120
-select = ["A", "B", "C", "E", "F", "FBT", "I", "N", "Q", "RUF", "S", "T", "UP", "W", "YTT"]
+select = [
+  "A",
+  "ARG",
+  "B",
+  "C",
+  "E",
+  "F",
+  "FBT",
+  "I",
+  "ICN",
+  "N",
+  "PLC",
+  "PLE",
+  "PLR",
+  "PLW",
+  "Q",
+  "RUF",
+  "S",
+  "T",
+  "TID",
+  "UP",
+  "W",
+  "YTT",
+]
 ignore = [
   # Allow non-abstract empty methods in abstract base classes
   "B027",
@@ -176,8 +199,8 @@ known-first-party = ["{kwargs['package_name']}"]
 ban-relative-imports = "all"
 
 [tool.ruff.per-file-ignores]
-# Tests can use relative imports and assertions
-"tests/**/*" = ["I252", "S101"]
+# Tests can use assertions and relative imports
+"tests/**/*" = ["S101", "TID252"]
 
 [tool.coverage.run]
 source_pkgs = ["{kwargs['package_name']}", "tests"]


### PR DESCRIPTION
- `I252` renamed to `TID252` (saw the warning)
- Added `ARG`, `ICN`, `PLC`, `PLE`, `PLR`, `PLW`, & `SIM`
- Not dogfooding `ARG` b/c the diff is too big and I lack time
- `RET` is interesting but gonna wait b/c the diff is too big and dunno if I should encourage that style for others e.g. https://github.com/pypa/hatch/blob/hatch-v1.6.3/src/hatch/env/context.py#L56-L61 would become 2 `if` statements and a dedented `return`

cc @blink1073 