### PR TITLE
Support boolean values for the `config set` command

### DIFF
--- a/docs/history/hatch.md
+++ b/docs/history/hatch.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Fix displaying the version with the `version` command when the version is static and build dependencies are unmet
 - Fix the `support-legacy` option for the `sdist` target when using a src-layout project structure
+- Support boolean values for the `config set` command
 
 ### [1.6.3](https://github.com/pypa/hatch/releases/tag/hatch-v1.6.3) - 2022-10-24 ### {: #hatch-v1.6.3 }
 

--- a/src/hatch/cli/config/__init__.py
+++ b/src/hatch/cli/config/__init__.py
@@ -112,14 +112,13 @@ def set_value(app, key, value):
         value = data.pop()
 
     if value.startswith(('{', '[')):
-        from ast import literal_eval        
+        from ast import literal_eval
+
         value = literal_eval(value)
-
-    elif value.lower() == 'false':
-        value = False
-
     elif value.lower() == 'true':
         value = True
+    elif value.lower() == 'false':
+        value = False
 
     branch_config[key] = new_config[key] = value
 

--- a/src/hatch/cli/config/__init__.py
+++ b/src/hatch/cli/config/__init__.py
@@ -113,8 +113,13 @@ def set_value(app, key, value):
 
     if value.startswith(('{', '[')):
         from ast import literal_eval
-
         value = literal_eval(value)
+
+    elif value.lower() == "false":
+        value = False
+
+    elif value.lower() == "true":
+        value = True
 
     branch_config[key] = new_config[key] = value
 

--- a/src/hatch/cli/config/__init__.py
+++ b/src/hatch/cli/config/__init__.py
@@ -112,13 +112,13 @@ def set_value(app, key, value):
         value = data.pop()
 
     if value.startswith(('{', '[')):
-        from ast import literal_eval
+        from ast import literal_eval        
         value = literal_eval(value)
 
-    elif value.lower() == "false":
+    elif value.lower() == 'false':
         value = False
 
-    elif value.lower() == "true":
+    elif value.lower() == 'true':
         value = True
 
     branch_config[key] = new_config[key] = value

--- a/tests/cli/config/test_set.py
+++ b/tests/cli/config/test_set.py
@@ -215,3 +215,33 @@ def test_project_location_complex_set_first_project(hatch, config_file, helpers,
     config_file.load()
     assert config_file.model.project == 'foo'
     assert config_file.model.projects['foo'].location == str(temp_dir)
+
+
+def test_template_licence_headers(hatch, config_file, helpers, temp_dir):
+    assert config_file.model.template.licenses.headers == True
+
+    with temp_dir.as_cwd():
+        result = hatch('config', 'set', 'template.licenses.headers', 'false')
+    assert result.exit_code == 0, result.output
+    assert result.output == helpers.dedent(
+        """
+        New setting:
+        [template.licenses]
+        headers = false
+        """
+    )
+    config_file.load()
+    assert config_file.model.template.licenses.headers == False
+
+    with temp_dir.as_cwd():
+        result = hatch('config', 'set', 'template.licenses.headers', 'TruE')
+    assert result.exit_code == 0, result.output
+    assert result.output == helpers.dedent(
+        """
+        New setting:
+        [template.licenses]
+        headers = true
+        """
+    )
+    config_file.load()
+    assert config_file.model.template.licenses.headers == True

--- a/tests/cli/config/test_set.py
+++ b/tests/cli/config/test_set.py
@@ -218,7 +218,7 @@ def test_project_location_complex_set_first_project(hatch, config_file, helpers,
 
 
 def test_template_licence_headers(hatch, config_file, helpers, temp_dir):
-    assert config_file.model.template.licenses.headers == True
+    assert config_file.model.template.licenses.headers is True
 
     with temp_dir.as_cwd():
         result = hatch('config', 'set', 'template.licenses.headers', 'false')
@@ -231,7 +231,7 @@ def test_template_licence_headers(hatch, config_file, helpers, temp_dir):
         """
     )
     config_file.load()
-    assert config_file.model.template.licenses.headers == False
+    assert config_file.model.template.licenses.headers is False
 
     with temp_dir.as_cwd():
         result = hatch('config', 'set', 'template.licenses.headers', 'TruE')
@@ -244,4 +244,4 @@ def test_template_licence_headers(hatch, config_file, helpers, temp_dir):
         """
     )
     config_file.load()
-    assert config_file.model.template.licenses.headers == True
+    assert config_file.model.template.licenses.headers is True

--- a/tests/cli/config/test_set.py
+++ b/tests/cli/config/test_set.py
@@ -217,11 +217,12 @@ def test_project_location_complex_set_first_project(hatch, config_file, helpers,
     assert config_file.model.projects['foo'].location == str(temp_dir)
 
 
-def test_template_licence_headers(hatch, config_file, helpers, temp_dir):
+def test_booleans(hatch, config_file, helpers, temp_dir):
     assert config_file.model.template.licenses.headers is True
 
     with temp_dir.as_cwd():
         result = hatch('config', 'set', 'template.licenses.headers', 'false')
+
     assert result.exit_code == 0, result.output
     assert result.output == helpers.dedent(
         """
@@ -230,11 +231,13 @@ def test_template_licence_headers(hatch, config_file, helpers, temp_dir):
         headers = false
         """
     )
+
     config_file.load()
     assert config_file.model.template.licenses.headers is False
 
     with temp_dir.as_cwd():
         result = hatch('config', 'set', 'template.licenses.headers', 'TruE')
+
     assert result.exit_code == 0, result.output
     assert result.output == helpers.dedent(
         """
@@ -243,5 +246,6 @@ def test_template_licence_headers(hatch, config_file, helpers, temp_dir):
         headers = true
         """
     )
+
     config_file.load()
     assert config_file.model.template.licenses.headers is True


### PR DESCRIPTION
I was trying to use the CLI `hatch config set template.licenses.header false`, but no matter what I typed (`false`, `False`, `0`, `"false"` etc), I kept receiving the error "must be a boolean" which originates from here https://github.com/pypa/hatch/blob/d3eeb62a0c094681d30284a084d6a7c50f8864a6/src/hatch/config/model.py#L569-L581

Originally I tried to fix the issue by doing a type cast after line 573 in `hatch/src/hatch/config/model.py`, while this got rid of the error, it resulted in the output to the console being wrong; ie `"FalSe"` was cast to `False` and I think the underlying model was updated correctly, but the console would show:

```text
New setting:
[template.licenses]
headers = "FalSe"
```

So instead I tried to fix the issue in `src/hatch/cli/config/__init__.py` in a bit of a primitive way; for any command `hatch config set` where the value parameter is either `true` or `false` (case insensitive), the value will be converted into Boolean type *before* attempting to update the model.

However this approach causes a new problem; if the user ever wanted to set some other string type setting to the literal text "TRUE" for whatever reason it would be unexpectedly cast to a Boolean before being stored in the model.

I could not figure out a better fix... Hope this helps anyway, and many thanks for the project :)