### PR TITLE
Fix test suite for setups with separate "/home" and "/" disk partitions

### DIFF
--- a/src/hatch/utils/fs.py
+++ b/src/hatch/utils/fs.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import pathlib
-import shutil
 import sys
 from contextlib import contextmanager
 from typing import Generator
@@ -77,6 +76,8 @@ class Path(_PathBase):
 
     @contextmanager
     def temp_hide(self) -> Generator[Path, None, None]:
+        import shutil
+
         with temp_directory() as temp_dir:
             temp_path = Path(temp_dir, self.name)
             try:

--- a/src/hatch/utils/fs.py
+++ b/src/hatch/utils/fs.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import pathlib
+import shutil
 import sys
 from contextlib import contextmanager
 from typing import Generator
@@ -79,7 +80,7 @@ class Path(_PathBase):
         with temp_directory() as temp_dir:
             temp_path = Path(temp_dir, self.name)
             try:
-                self.replace(temp_dir / self.name)
+                shutil.move(self, temp_dir / self.name)
             except FileNotFoundError:
                 pass
 
@@ -87,7 +88,7 @@ class Path(_PathBase):
                 yield temp_path
             finally:
                 try:
-                    temp_path.replace(self)
+                    shutil.move(temp_path, self)
                 except FileNotFoundError:
                     pass
 


### PR DESCRIPTION
Hi!

Two unit tests (test_config_file_creation_verbose, test_config_file_creation_default) fail on my machine because I have separate partitions for "/home" and "/". The /tmp directory where the tests write the necessary files is in one partition, and the hatch configuration file is in another. I did a bit of research and it seems the solution is to replace pathlib.replace with shutils.move.

![image](https://user-images.githubusercontent.com/4572839/208297715-2818b947-ffa0-422f-a746-22995800b204.png)

Alternatively, I could keep the original code and try to handle it in a exception clause of OSError (assuming i can identify the error type as "invalid cross link device"). Please tell me how to prefer it.
