### PR TITLE
Allow hatch new --init without setup.py if setup.cfg is present

### DIFF
--- a/src/hatch/cli/new/__init__.py
+++ b/src/hatch/cli/new/__init__.py
@@ -26,7 +26,7 @@ def new(app, name, location, interactive, feature_cli, initialize, setuptools_op
     if initialize:
         interactive = True
         location = location or Path.cwd()
-        if (location / 'setup.py').is_file():
+        if (location / 'setup.py').is_file() or (location / 'setup.cfg').is_file():
             migration_possible = True
             if not name:
                 name = 'temporary'

--- a/src/hatch/cli/new/migrate.py
+++ b/src/hatch/cli/new/migrate.py
@@ -340,6 +340,12 @@ def migrate(root, setuptools_options):
         shutil.copytree(root, repo_dir, ignore=shutil.ignore_patterns('.git', '.tox'), copy_function=shutil.copy)
         shutil.copy(FILE, os.path.join(repo_dir, 'setuptools.py'))
         os.chdir(repo_dir)
+        setup_py = os.path.join(repo_dir, 'setup.py')
+
+        if not os.path.isfile(setup_py):
+            # Synthesize a small setup.py file since there is none
+            with open(setup_py, 'w', encoding='utf-8') as f:
+                f.write('import setuptools\nsetuptools.setup()\n')
 
         try:
             env = dict(os.environ)
@@ -347,7 +353,7 @@ def migrate(root, setuptools_options):
                 key, value = arg.split('=', 1)
                 env[f'{ENV_VAR_PREFIX}{key}'] = value
 
-            subprocess.check_call([sys.executable, os.path.join(repo_dir, 'setup.py')], env=env)
+            subprocess.check_call([sys.executable, setup_py], env=env)
 
             old_project_file = os.path.join(root, 'pyproject.toml')
             new_project_file = os.path.join(repo_dir, 'pyproject.toml')


### PR DESCRIPTION
`hatch new --init` did not do its Setuptools migration thing if there was no `setup.py` present, even if a `setup.cfg` was (which is a valid configuration when `setuptools` is the builder configured in `pyproject.toml`).

This makes it... do its thing. 😁 
