### PR TITLE
feat: Add Environment :: WebAssembly and Framework :: Pydantic to trove classifiers

### DIFF
--- a/backend/src/hatchling/metadata/classifiers.py
+++ b/backend/src/hatchling/metadata/classifiers.py
@@ -1,4 +1,4 @@
-VERSION = '2022.12.22'
+VERSION = '2023.1.20'
 
 SORTED_CLASSIFIERS = [
     'Development Status :: 1 - Planning',
@@ -65,6 +65,9 @@ SORTED_CLASSIFIERS = [
     'Environment :: Web Environment :: Buffet',
     'Environment :: Web Environment :: Mozilla',
     'Environment :: Web Environment :: ToscaWidgets',
+    'Environment :: WebAssembly',
+    'Environment :: WebAssembly :: Emscripten',
+    'Environment :: WebAssembly :: WASI',
     'Environment :: Win32 (MS Windows)',
     'Environment :: X11 Applications',
     'Environment :: X11 Applications :: GTK',
@@ -179,6 +182,8 @@ SORTED_CLASSIFIERS = [
     'Framework :: Plone :: Addon',
     'Framework :: Plone :: Core',
     'Framework :: Plone :: Theme',
+    'Framework :: Pydantic',
+    'Framework :: Pydantic :: 1',
     'Framework :: Pylons',
     'Framework :: Pyramid',
     'Framework :: Pytest',


### PR DESCRIPTION
* Add `Environment :: WebAssembly` and `Framework :: Pydantic` to valid [PyPI trove classifiers](https://pypi.org/classifiers/).
   - c.f. https://discuss.python.org/t/do-we-want-classifiers-for-webassembly-on-pypi/22712

This was only very recently added in https://github.com/pypa/trove-classifiers/pull/129.

Closes #727 (duplicate).