### PR TITLE
Lock lint tool versions

### DIFF
--- a/backend/src/hatchling/builders/wheel.py
+++ b/backend/src/hatchling/builders/wheel.py
@@ -600,7 +600,8 @@ Root-Is-Purelib: {'true' if build_data['pure_python'] else 'false'}
         supported_python_versions = []
         for major_version in get_known_python_major_versions():
             for minor_version in range(100):
-                if self.metadata.core.python_constraint.contains(f'{major_version}.{minor_version}'):
+                constraint = self.metadata.core.python_constraint
+                if constraint is not None and constraint.contains(f'{major_version}.{minor_version}'):
                     supported_python_versions.append(f'py{major_version}')
                     break
 

--- a/backend/src/hatchling/metadata/core.py
+++ b/backend/src/hatchling/metadata/core.py
@@ -621,7 +621,7 @@ class CoreMetadata:
         return self._requires_python
 
     @property
-    def python_constraint(self) -> SpecifierSet:
+    def python_constraint(self) -> SpecifierSet | None:
         if self._python_constraint is None:
             _ = self.requires_python
 

--- a/backend/src/hatchling/version/scheme/standard.py
+++ b/backend/src/hatchling/version/scheme/standard.py
@@ -33,9 +33,15 @@ class StandardScheme(VersionSchemeInterface):
                     original, release=update_release(original, [original.major, original.minor, original.micro + 1])
                 )
             elif version in ('a', 'b', 'c', 'rc', 'alpha', 'beta', 'pre', 'preview'):
-                phase, number = _parse_letter_version(version, 0)
+                parsed_version = _parse_letter_version(version, 0)
+                if not parsed_version:  # TODO: do something better?
+                    raise ValueError(f'Invalid version `{version}`')  # noqa: EM102
+                phase, number = parsed_version
                 if original.pre:
-                    current_phase, current_number = _parse_letter_version(*original.pre)
+                    parsed_pre_version = _parse_letter_version(*original.pre)
+                    if not parsed_pre_version:  # TODO: do something better?
+                        raise ValueError(f'Invalid pre-version `{original.pre}`')  # noqa: EM102
+                    current_phase, current_number = parsed_pre_version
                     if phase == current_phase:
                         number = current_number + 1
 

--- a/hatch.toml
+++ b/hatch.toml
@@ -47,9 +47,9 @@ write-summary-report = "python scripts/write_coverage_summary_report.py"
 [envs.lint]
 detached = true
 dependencies = [
-  "black>=22.6.0",
-  "mypy>=0.990",
-  "ruff>=0.0.202",
+  "black==23.1.0",
+  "mypy==0.991",
+  "ruff==0.0.239",
 ]
 [envs.lint.scripts]
 typing = "mypy --install-types --non-interactive {args:backend/src/hatchling src/hatch tests}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,8 @@ ignore = [
   "S105", "S106", "S107",
   # https://github.com/charliermarsh/ruff/issues/1949
   "PLR2004",
+  # Too many arguments to function call
+  "PLR0913",
 ]
 unfixable = [
   # Don't touch unused imports

--- a/tests/utils/test_structures.py
+++ b/tests/utils/test_structures.py
@@ -41,7 +41,6 @@ class TestEnvVars:
         pattern = f'{env_var[:-2]}*'
 
         with EnvVars({env_var: 'foo'}):
-
             with EnvVars(exclude=[get_random_name(), pattern]):
                 assert env_var not in os.environ
 


### PR DESCRIPTION
It's tiresome to keep the code up to par just due to changes in lint tools; in particular Ruff versions move pretty fast.

Updates could be done manually when needed.