### PR TITLE
feat: Add Django 4.2 to the list of classifiers

### DIFF
--- a/backend/src/hatchling/metadata/classifiers.py
+++ b/backend/src/hatchling/metadata/classifiers.py
@@ -1,4 +1,4 @@
-VERSION = '2023.2.8'
+VERSION = '2023.2.20'
 
 SORTED_CLASSIFIERS = [
     'Development Status :: 1 - Planning',

--- a/backend/src/hatchling/metadata/classifiers.py
+++ b/backend/src/hatchling/metadata/classifiers.py
@@ -119,6 +119,7 @@ SORTED_CLASSIFIERS = [
     'Framework :: Django :: 4',
     'Framework :: Django :: 4.0',
     'Framework :: Django :: 4.1',
+    'Framework :: Django :: 4.2',
     'Framework :: Django CMS',
     'Framework :: Django CMS :: 3.4',
     'Framework :: Django CMS :: 3.5',


### PR DESCRIPTION
PyPI already has packages under new classifier:
- https://pypi.org/search/?c=Framework+%3A%3A+Django+%3A%3A+4.2
- https://pypi.org/classifiers/

New version is about to be released in April, while we already have 4.2b1 beta release version.