### PR TITLE
fix: add dir in PYTHONPATH for `hatch new --init`

### DIFF
--- a/src/hatch/cli/new/migrate.py
+++ b/src/hatch/cli/new/migrate.py
@@ -352,6 +352,11 @@ def migrate(root, setuptools_options):
             for arg in setuptools_options:
                 key, value = arg.split('=', 1)
                 env[f'{ENV_VAR_PREFIX}{key}'] = value
+            # when PYTHONSAFEPATH is non-empty, current dir is not added automatically
+            if env.get('PYTHONPATH'):
+                env['PYTHONPATH'] += f':{repo_dir}'
+            else:
+                env["PYTHONPATH"] = repo_dir
 
             subprocess.check_call([sys.executable, setup_py], env=env)
 

--- a/src/hatch/cli/new/migrate.py
+++ b/src/hatch/cli/new/migrate.py
@@ -352,11 +352,12 @@ def migrate(root, setuptools_options):
             for arg in setuptools_options:
                 key, value = arg.split('=', 1)
                 env[f'{ENV_VAR_PREFIX}{key}'] = value
-            # when PYTHONSAFEPATH is non-empty, current dir is not added automatically
+
+            # When PYTHONSAFEPATH is non-empty, current dir is not added automatically
             if env.get('PYTHONPATH'):
-                env['PYTHONPATH'] += f':{repo_dir}'
+                env['PYTHONPATH'] += f'{repo_dir}{os.pathsep}'
             else:
-                env["PYTHONPATH"] = repo_dir
+                env['PYTHONPATH'] = repo_dir
 
             subprocess.check_call([sys.executable, setup_py], env=env)
 


### PR DESCRIPTION
When PYTHONSAFEPATH is non-empty, current dir is not added automatically. So the setuptools shim was not found. By appending the dir in PYTHONPATH, we make sure it's found.

Closes #769