### PR TITLE
Improve syncing of dependencies provided through git URLs

### DIFF
--- a/backend/src/hatchling/dep/core.py
+++ b/backend/src/hatchling/dep/core.py
@@ -93,33 +93,30 @@ def dependency_in_sync(
                 vcs_info = direct_url_data['vcs_info']
                 vcs = vcs_info['vcs']
                 commit_id = vcs_info['commit_id']
+                requested_revision = vcs_info['requested_revision'] if 'requested_revision' in vcs_info else None
 
-                # Try a few variations, see:
-                # https://peps.python.org/pep-0440/#direct-references
-                if requirement.url != f'{vcs}+{url}@{commit_id}':
-                    requested_revision = vcs_info['requested_revision'] if 'requested_revision' in vcs_info else None
+                # Try a few variations, see https://peps.python.org/pep-0440/#direct-references
+                if (
+                    requested_revision and requirement.url == f'{vcs}+{url}@{requested_revision}#{commit_id}'
+                ) or requirement.url == f'{vcs}+{url}@{commit_id}':
+                    return True
+                elif requirement.url == f'{vcs}+{url}' or requirement.url == f'{vcs}+{url}@{requested_revision}':
+                    import subprocess
 
-                    if (
-                        requested_revision and requirement.url == f'{vcs}+{url}@{requested_revision}#{commit_id}'
-                    ) or requirement.url == f'{vcs}+{url}#{commit_id}':
-                        return True
-                    elif requirement.url == f'{vcs}+{url}' or requirement.url == f'{vcs}+{url}@{requested_revision}':
-                        import subprocess
-
-                        if vcs == 'git':
-                            vcs_cmd = [vcs, 'ls-remote', url]
-                            if requested_revision:
-                                vcs_cmd.append(requested_revision)
-                        # TODO: add elifs for hg, svn, and bzr https://github.com/pypa/hatch/issues/760
-                        else:
-                            return False
-                        result = subprocess.run(vcs_cmd, capture_output=True, text=True)
-                        if result.returncode:
-                            return False
-                        latest_commit_id, *_ = result.stdout.split()
-                        return commit_id == latest_commit_id
+                    if vcs == 'git':
+                        vcs_cmd = [vcs, 'ls-remote', url]
+                        if requested_revision:
+                            vcs_cmd.append(requested_revision)
+                    # TODO: add elifs for hg, svn, and bzr https://github.com/pypa/hatch/issues/760
                     else:
                         return False
+                    result = subprocess.run(vcs_cmd, capture_output=True, text=True)
+                    if result.returncode:
+                        return False
+                    latest_commit_id, *_ = result.stdout.split()
+                    return commit_id == latest_commit_id
+                else:
+                    return False
 
     return True
 

--- a/backend/src/hatchling/dep/core.py
+++ b/backend/src/hatchling/dep/core.py
@@ -97,10 +97,27 @@ def dependency_in_sync(
                 # Try a few variations, see:
                 # https://peps.python.org/pep-0440/#direct-references
                 if requirement.url != f'{vcs}+{url}@{commit_id}':
-                    if 'requested_revision' in vcs_info:
-                        requested_revision = vcs_info['requested_revision']
-                        if requirement.url != f'{vcs}+{url}@{requested_revision}#{commit_id}':
+                    requested_revision = vcs_info['requested_revision'] if 'requested_revision' in vcs_info else None
+
+                    if (
+                        requested_revision and requirement.url == f'{vcs}+{url}@{requested_revision}#{commit_id}'
+                    ) or requirement.url == f'{vcs}+{url}#{commit_id}':
+                        return True
+                    elif requirement.url == f'{vcs}+{url}' or requirement.url == f'{vcs}+{url}@{requested_revision}':
+                        import subprocess
+
+                        if vcs == 'git':
+                            vcs_cmd = [vcs, 'ls-remote', url]
+                            if requested_revision:
+                                vcs_cmd.append(requested_revision)
+                        # TODO: add elifs for hg, svn, and bzr https://github.com/pypa/hatch/issues/760
+                        else:
                             return False
+                        result = subprocess.run(vcs_cmd, capture_output=True, text=True)
+                        if result.returncode:
+                            return False
+                        latest_commit_id, *_ = result.stdout.split()
+                        return commit_id == latest_commit_id
                     else:
                         return False
 

--- a/tests/backend/dep/test_core.py
+++ b/tests/backend/dep/test_core.py
@@ -70,6 +70,7 @@ def test_extra_met(platform):
 
 
 @pytest.mark.requires_internet
+@pytest.mark.requires_git
 def test_dependency_git_revision(platform):
     with TempVirtualEnv(sys.executable, platform) as venv:
         platform.run_command(
@@ -79,6 +80,7 @@ def test_dependency_git_revision(platform):
 
 
 @pytest.mark.requires_internet
+@pytest.mark.requires_git
 def test_dependency_git_commit(platform):
     with TempVirtualEnv(sys.executable, platform) as venv:
         platform.run_command(
@@ -93,6 +95,7 @@ def test_dependency_git_commit(platform):
 
 
 @pytest.mark.requires_internet
+@pytest.mark.requires_git
 def test_dependency_git(platform):
     with TempVirtualEnv(sys.executable, platform) as venv:
         platform.run_command(

--- a/tests/backend/dep/test_core.py
+++ b/tests/backend/dep/test_core.py
@@ -67,3 +67,35 @@ def test_extra_met(platform):
     with TempVirtualEnv(sys.executable, platform) as venv:
         platform.run_command(['pip', 'install', 'requests[security]==2.25.1'], check=True, capture_output=True)
         assert dependencies_in_sync([Requirement('requests[security]==2.25.1')], venv.sys_path)
+
+
+@pytest.mark.requires_internet
+def test_dependency_git_revision(platform):
+    with TempVirtualEnv(sys.executable, platform) as venv:
+        platform.run_command(
+            ['pip', 'install', 'requests@git+https://github.com/psf/requests@main'], check=True, capture_output=True
+        )
+        assert dependencies_in_sync([Requirement('requests@git+https://github.com/psf/requests@main')], venv.sys_path)
+
+
+@pytest.mark.requires_internet
+def test_dependency_git_commit(platform):
+    with TempVirtualEnv(sys.executable, platform) as venv:
+        platform.run_command(
+            ['pip', 'install', 'requests@git+https://github.com/psf/requests#7f694b79e114c06fac5ec06019cada5a61e5570f'],
+            check=True,
+            capture_output=True,
+        )
+        assert dependencies_in_sync(
+            [Requirement('requests@git+https://github.com/psf/requests#7f694b79e114c06fac5ec06019cada5a61e5570f')],
+            venv.sys_path,
+        )
+
+
+@pytest.mark.requires_internet
+def test_dependency_git(platform):
+    with TempVirtualEnv(sys.executable, platform) as venv:
+        platform.run_command(
+            ['pip', 'install', 'requests@git+https://github.com/psf/requests'], check=True, capture_output=True
+        )
+        assert dependencies_in_sync([Requirement('requests@git+https://github.com/psf/requests')], venv.sys_path)

--- a/tests/backend/dep/test_core.py
+++ b/tests/backend/dep/test_core.py
@@ -71,6 +71,16 @@ def test_extra_met(platform):
 
 @pytest.mark.requires_internet
 @pytest.mark.requires_git
+def test_dependency_git(platform):
+    with TempVirtualEnv(sys.executable, platform) as venv:
+        platform.run_command(
+            ['pip', 'install', 'requests@git+https://github.com/psf/requests'], check=True, capture_output=True
+        )
+        assert dependencies_in_sync([Requirement('requests@git+https://github.com/psf/requests')], venv.sys_path)
+
+
+@pytest.mark.requires_internet
+@pytest.mark.requires_git
 def test_dependency_git_revision(platform):
     with TempVirtualEnv(sys.executable, platform) as venv:
         platform.run_command(
@@ -84,21 +94,11 @@ def test_dependency_git_revision(platform):
 def test_dependency_git_commit(platform):
     with TempVirtualEnv(sys.executable, platform) as venv:
         platform.run_command(
-            ['pip', 'install', 'requests@git+https://github.com/psf/requests#7f694b79e114c06fac5ec06019cada5a61e5570f'],
+            ['pip', 'install', 'requests@git+https://github.com/psf/requests@7f694b79e114c06fac5ec06019cada5a61e5570f'],
             check=True,
             capture_output=True,
         )
         assert dependencies_in_sync(
-            [Requirement('requests@git+https://github.com/psf/requests#7f694b79e114c06fac5ec06019cada5a61e5570f')],
+            [Requirement('requests@git+https://github.com/psf/requests@7f694b79e114c06fac5ec06019cada5a61e5570f')],
             venv.sys_path,
         )
-
-
-@pytest.mark.requires_internet
-@pytest.mark.requires_git
-def test_dependency_git(platform):
-    with TempVirtualEnv(sys.executable, platform) as venv:
-        platform.run_command(
-            ['pip', 'install', 'requests@git+https://github.com/psf/requests'], check=True, capture_output=True
-        )
-        assert dependencies_in_sync([Requirement('requests@git+https://github.com/psf/requests')], venv.sys_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -350,7 +350,7 @@ def pytest_runtest_setup(item):
         if marker.name == 'requires_unix' and PLATFORM.windows:
             pytest.skip('Not running on a Linux-based platform')
 
-        if marker.name == 'requires_git' and subprocess.check_call(['git', 'help']) != 0:
+        if marker.name == 'requires_git' and not shutil.which('git'):
             pytest.skip('Git not present in the environment')
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -350,6 +350,9 @@ def pytest_runtest_setup(item):
         if marker.name == 'requires_unix' and PLATFORM.windows:
             pytest.skip('Not running on a Linux-based platform')
 
+        if marker.name == 'requires_git' and subprocess.check_call(['git', 'help']) != 0:
+            pytest.skip('Git not present in the environment')
+
 
 def pytest_configure(config):
     config.addinivalue_line('markers', 'requires_windows: Tests intended for Windows operating systems')
@@ -357,6 +360,7 @@ def pytest_configure(config):
     config.addinivalue_line('markers', 'requires_linux: Tests intended for Linux operating systems')
     config.addinivalue_line('markers', 'requires_unix: Tests intended for Linux-based operating systems')
     config.addinivalue_line('markers', 'requires_internet: Tests that require access to the internet')
+    config.addinivalue_line('markers', 'requires_git: Tests that require the git command available in the environment')
 
     config.addinivalue_line('markers', 'allow_backend_process: Force the use of backend communication')
 


### PR DESCRIPTION
This pull request improve syncing of dependencies provided through git URLs, cf. issue https://github.com/pypa/hatch/issues/760

This implementation uses `subprocess.run` to run the `git` command to retrieve the latest commit for a git repository branch. It should support most cases mentioned in https://peps.python.org/pep-0440/#direct-references 

I added 3 tests for git URL dependencies in `tests/backend/dep/test_core.py` which raises the coverage for this file from 61% to 91%. 

⚠️ The `git` command needs to be present in the test environment for the tests to pass. So I added a pytest mark `requires_git`  that checks `subprocess.check_call(['git', 'help'])`, and skip the test if a status code different than 0 is returned

I made sure to run the following scripts:

- `cov`
- `lint:fmt`
- `lint:all` I am getting errors related to `PLW2901` and `S112` , but in files that I did not change, so I guess this has to do with the ruff config or new checks in a new version

## 🌡️ The issue with mercurial

For mercurial it does not work because the revision given by `hg identify` is different from the commit_id in the `vcs_info` retrieved by hatchling , for example here with https://www.mercurial-scm.org/repo/python-hglib (note we get the same results if we specify the rev default):

```bash
{'url': 'https://www.mercurial-scm.org/repo/python-hglib', 'vcs_info': {'commit_id': '216', 'vcs': 'hg'}}

hg identify https://www.mercurial-scm.org/repo/python-hglib --id 
68588c652ac6
```

If we want to add Mercurial handling it would look like this:

```python
                        if vcs == 'git':
                            vcs_cmd = [vcs, 'ls-remote', url]
                            if requested_revision:
                                vcs_cmd.append(requested_revision)
                        elif vcs == 'hg':
                            vcs_cmd = [vcs, 'identify', '--id', url]
                            if requested_revision:
                                vcs_cmd.extend(['--rev', requested_revision])
```

And it can be easily tested in `tests/backend/dep/test_core.py`  (you can add `mercurial` to the tests dependencies in `hatch.toml`):

```python
@pytest.mark.requires_internet
def test_dependency_hg(platform):
    with TempVirtualEnv(sys.executable, platform) as venv:
        platform.run_command(
            ['pip', 'install', 'python-hglib@hg+https://www.mercurial-scm.org/repo/python-hglib'],
            check=True,
            capture_output=True,
        )
        assert dependencies_in_sync(
            [Requirement('python-hglib@hg+https://www.mercurial-scm.org/repo/python-hglib')], venv.sys_path
        )
```