### PR TITLE
feat: Add working_directory configuration option

### DIFF
--- a/docs/config/hatch.md
+++ b/docs/config/hatch.md
@@ -214,6 +214,24 @@ The following values have special meanings.
 | `isolated` (default) | `<DATA_DIR>/pythons` |
 | `shared` | `~/.pythons` |
 
+### Working directory
+
+=== ":octicons-file-code-16: config.toml"
+
+    ```toml
+    [dirs]
+    working_directory = "..."
+    ```
+
+This determines whether hatch should change the current directory to the project root when executing run commands or stay in the current directory.
+
+The following values are valid.
+
+| Value | Meaning |
+| --- | --- |
+| `project` (default) | Change the working directory to the project root |
+| `current` | Stay in the current directory |
+
 ## Terminal
 
 You can configure how all output is displayed using the `terminal.styles` table. These settings are also applied to all plugins.

--- a/src/hatch/cli/env/run.py
+++ b/src/hatch/cli/env/run.py
@@ -168,8 +168,8 @@ def run(
 
     any_compatible = False
     incompatible = {}
-    with project.location.as_cwd():
-        for env_name in environments:
+    for env_name in environments:
+        with project.location.as_cwd():
             environment = app.get_environment(env_name)
 
             try:
@@ -189,6 +189,16 @@ def run(
                 environment.exists = lambda: True
 
             app.prepare_environment(environment)
+
+            if app.config.dirs.working_directory == 'project':
+                app.run_shell_commands(
+                    environment,
+                    [environment.join_command_args(args)],
+                    force_continue=force_continue,
+                    show_code_on_error=False,
+                )
+
+        if app.config.dirs.working_directory == 'current':
             app.run_shell_commands(
                 environment,
                 [environment.join_command_args(args)],

--- a/src/hatch/config/model.py
+++ b/src/hatch/config/model.py
@@ -310,6 +310,7 @@ class DirsConfig(LazilyParsedConfig):
         self._field_project = FIELD_TO_PARSE
         self._field_env = FIELD_TO_PARSE
         self._field_python = FIELD_TO_PARSE
+        self._field_working_directory = FIELD_TO_PARSE
         self._field_data = FIELD_TO_PARSE
         self._field_cache = FIELD_TO_PARSE
 
@@ -377,6 +378,29 @@ class DirsConfig(LazilyParsedConfig):
     def python(self, value):
         self.raw_data['python'] = value
         self._field_python = FIELD_TO_PARSE
+
+    @property
+    def working_directory(self):
+        if self._field_working_directory is FIELD_TO_PARSE:
+            if 'working_directory' in self.raw_data:
+                working_directory = self.raw_data['working_directory']
+                if not isinstance(working_directory, str):
+                    self.raise_error('must be a string')
+
+                valid_options = ('project', 'current')
+                if working_directory not in valid_options:
+                    self.raise_error(f'must be one of: {", ".join(valid_options)}')
+
+                self._field_working_directory = working_directory
+            else:
+                self._field_working_directory = self.raw_data['working_directory'] = 'project'
+
+        return self._field_working_directory
+
+    @working_directory.setter
+    def working_directory(self, value):
+        self.raw_data['working_directory'] = value
+        self._field_working_directory = FIELD_TO_PARSE
 
     @property
     def data(self):

--- a/tests/cli/config/test_show.py
+++ b/tests/cli/config/test_show.py
@@ -18,6 +18,7 @@ def test_default_scrubbed(hatch, config_file, helpers, default_cache_dir, defaul
         [dirs]
         project = []
         python = "isolated"
+        working_directory = "project"
         data = "{default_data_directory}"
         cache = "{default_cache_directory}"
 
@@ -72,6 +73,7 @@ def test_reveal(hatch, config_file, helpers, default_cache_dir, default_data_dir
         [dirs]
         project = []
         python = "isolated"
+        working_directory = "project"
         data = "{default_data_directory}"
         cache = "{default_cache_directory}"
 

--- a/tests/config/test_model.py
+++ b/tests/config/test_model.py
@@ -19,6 +19,7 @@ def test_default(default_cache_dir, default_data_dir):
             'python': 'isolated',
             'data': str(default_data_dir),
             'cache': str(default_cache_dir),
+            'working_directory': 'project',
         },
         'projects': {},
         'publish': {'index': {'repo': 'main'}},
@@ -351,6 +352,7 @@ class TestDirs:
         assert config.dirs.python == config.dirs.python == 'isolated'
         assert config.dirs.cache == config.dirs.cache == default_cache_directory
         assert config.dirs.data == config.dirs.data == default_data_directory
+        assert config.dirs.working_directory == config.dirs.working_directory == 'project'
         assert config.raw_data == {
             'dirs': {
                 'project': [],
@@ -358,6 +360,7 @@ class TestDirs:
                 'python': 'isolated',
                 'data': default_data_directory,
                 'cache': default_cache_directory,
+                'working_directory': 'project',
             },
         }
 


### PR DESCRIPTION
In my projects, I often work in a subdirectory of the project root.
When executing scripts `hatch` changes its working directory to the project root, which is confusing when scripts take files as arguments.

This PR introduces a new global configuration option to allow the user to select how `hatch` should behave:

- change the working directory to the project root as it is now;
- execute the script in the current working directory.

I left the old behavior as the default one.
