### PR TITLE
Normaliza metadata the description field when contain line break

### DIFF
--- a/backend/src/hatchling/metadata/core.py
+++ b/backend/src/hatchling/metadata/core.py
@@ -462,9 +462,7 @@ class CoreMetadata:
             if not isinstance(description, str):
                 message = 'Field `project.description` must be a string'
                 raise TypeError(message)
-            if '\n' or '\r\n' in description:
-                description = description.replace('\r\n', ' ').replace('\n', ' ')
-            self._description = description
+            self._description = ' '.join(description.splitlines())
 
         return self._description
 

--- a/backend/src/hatchling/metadata/core.py
+++ b/backend/src/hatchling/metadata/core.py
@@ -462,7 +462,8 @@ class CoreMetadata:
             if not isinstance(description, str):
                 message = 'Field `project.description` must be a string'
                 raise TypeError(message)
-
+            if '\n' or '\r\n' in description:
+                description = description.replace('\r\n', ' ').replace('\n', ' ')
             self._description = description
 
         return self._description

--- a/tests/backend/metadata/test_core.py
+++ b/tests/backend/metadata/test_core.py
@@ -338,6 +338,11 @@ class TestDescription:
 
         assert metadata.core.description == metadata.core.description == 'foo'
 
+    def test_normaliza(self, isolation):
+        metadata = ProjectMetadata(str(isolation), None, {'project': {'description': '\nfirst line.\r\nsecond line'}})
+
+        assert metadata.core.description == metadata.core.description == ' first line. second line'
+
 
 class TestReadme:
     def test_dynamic(self, isolation):


### PR DESCRIPTION
https://github.com/pypa/hatch/issues/790

Remove line breaks from the description field if have.