### PR TITLE
Add commands to hatch cli from plugins

### DIFF
--- a/backend/src/hatchling/plugin/specs.py
+++ b/backend/src/hatchling/plugin/specs.py
@@ -1,6 +1,6 @@
 import pluggy
 
-hookspec = pluggy.HookspecMarker('hatch')
+hookspec = pluggy.HookspecMarker("hatch")
 
 
 @hookspec
@@ -21,3 +21,8 @@ def hatch_register_build_hook() -> None:
 @hookspec
 def hatch_register_metadata_hook() -> None:
     """Register new classes that adhere to the metadata hook interface."""
+
+
+@hookspec
+def hatch_register_commands() -> None:
+    """Register new commands to cli"""

--- a/src/hatch/cli/__init__.py
+++ b/src/hatch/cli/__init__.py
@@ -10,6 +10,7 @@ from hatch.cli.config import config
 from hatch.cli.dep import dep
 from hatch.cli.env import env
 from hatch.cli.new import new
+from hatch.cli.plugin import load_plugins
 from hatch.cli.project import project
 from hatch.cli.publish import publish
 from hatch.cli.run import run
@@ -198,6 +199,8 @@ hatch.add_command(run)
 hatch.add_command(shell)
 hatch.add_command(status)
 hatch.add_command(version)
+
+load_plugins(hatch)
 
 
 def main():  # no cov

--- a/src/hatch/cli/plugin.py
+++ b/src/hatch/cli/plugin.py
@@ -1,0 +1,16 @@
+from itertools import chain
+
+import pluggy
+from click import Group
+from hatchling.plugin import specs
+
+
+def load_plugins(hatch: Group):
+    pm = pluggy.PluginManager("hatch")
+
+    pm.add_hookspecs(specs)
+    pm.load_setuptools_entrypoints("hatch")
+
+    plugins = pm.hook.hatch_register_commands()
+    for plugin in chain.from_iterable(plugins):
+        hatch.add_command(plugin)


### PR DESCRIPTION
As discussed in https://github.com/pypa/hatch/issues/798

- [ ] Load command from plugins using `pluggy`
- [ ] Create tests
- [ ] Document the use of the hook