### PR TITLE
Add standalone installation using zipapp

### DIFF
--- a/.github/workflows/build-hatch.yml
+++ b/.github/workflows/build-hatch.yml
@@ -8,6 +8,9 @@ on:
 concurrency:
   group: build-hatch-${{ github.head_ref }}
 
+env:
+  STABLE_PYTHON_VERSION: '3.11'
+
 jobs:
   build:
     name: Build wheels and source distribution
@@ -46,3 +49,33 @@ jobs:
         skip_existing: true
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN_HATCH }}
+
+  build-zipapp:
+    name: Build zipapp
+    needs:
+    - build
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python ${{ env.STABLE_PYTHON_VERSION }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ env.STABLE_PYTHON_VERSION }}
+
+    - name: Upgrade pip, Install shiv
+      run: |
+        python -m pip install --upgrade pip
+        pip install shiv
+
+    - name: Build zipapp
+      run: shiv -c hatch -o ./hatch.pyz .
+
+    - name: Test zipapp
+      run: python ./hatch.pyz --version
+
+    - name: Upload to releases
+      uses: softprops/action-gh-release@v1
+      with:
+        files: hatch.pyz

--- a/docs/history/hatch.md
+++ b/docs/history/hatch.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Added:***
+
+- Ship a [zipapp](https://docs.python.org/3/library/zipapp.html) of Hatch
+
 ## [1.7.0](https://github.com/pypa/hatch/releases/tag/hatch-v1.7.0) - 2023-04-03 ## {: #hatch-v1.7.0 }
 
 ***Changed:***

--- a/docs/install.md
+++ b/docs/install.md
@@ -21,6 +21,15 @@ pip install hatch
 pipx install hatch
 ```
 
+## Standalone (via zipapp)
+
+You can also use Hatch without installing it.
+The zipapp can be downloaded from [Github releases](https://github.com/pypa/hatch/releases) and you can invoke it with a Python 3.7+ interpreter:
+
+```
+python hatch.pyz new --init
+```
+
 ## Homebrew
 
 See the [formula](https://formulae.brew.sh/formula/hatch) for more details.


### PR DESCRIPTION
I have a use case where I need to install hatch in isolation (using [direnv](https://direnv.net/)), and currently I solve that using `pipx` (installed as a zipapp). But I figured I could add the possibility of installing Hatch directly using a zipapp. That way I could ditch the dependency on `pipx`.

Hopefully others will find it useful as well.

Stolen like a thief in the night from: https://github.com/pypa/pipx/pull/895

~In draft because I want to test the flow first.~

Successful run [here](https://github.com/BeyondEvil/hatch/actions/runs/4670156577/jobs/8269556626).