### PR TITLE
fix(docs): default `config.toml` location on macOS

### DIFF
--- a/docs/config/hatch.md
+++ b/docs/config/hatch.md
@@ -6,7 +6,7 @@ Configuration for Hatch itself is stored in a `config.toml` file located by defa
 
 | Platform | Path |
 | --- | --- |
-| macOS | `~/Library/Preferences/hatch` |
+| macOS | `~/Library/Application Support/hatch` |
 | Windows | `%USERPROFILE%\AppData\Local\hatch` |
 | Unix | `$XDG_CONFIG_HOME/hatch` (the [XDG_CONFIG_HOME](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables) environment variable default is `~/.config`) |
 


### PR DESCRIPTION
The [`platformdirs`](https://pypi.org/project/platformdirs/) module used to find the default platform-specific config directory looks in a different directory than what is specified in the docs.