### PR TITLE
docs: functional custom version pattern example

### DIFF
--- a/docs/version.md
+++ b/docs/version.md
@@ -31,7 +31,7 @@ If this doesn't reflect how you store the version, you can define a different re
     ```toml
     [tool.hatch.version]
     path = "pkg/__init__.py"
-    pattern = "BUILD = 'b(?P<version>)'"
+    pattern = "BUILD = 'b(?P<version>[^']+)'"
     ```
 
 === ":octicons-file-code-16: hatch.toml"
@@ -39,7 +39,7 @@ If this doesn't reflect how you store the version, you can define a different re
     ```toml
     [version]
     path = "pkg/__init__.py"
-    pattern = "BUILD = 'b(?P<version>)'"
+    pattern = "BUILD = 'b(?P<version>[^']+)'"
     ```
 
 The pattern must have a named group called `version` that represents the version.


### PR DESCRIPTION
Noticed while trying to follow along with the versioning documentation that the example custom `pattern` would return only empty-string as the `version` match. (My late-night brain did not immediately realize why the output of `hatch version` was blank, but I got there in the end.)

My edited example is a simplistic pattern that matches whatever happens to be there, attempting no validation of the version number format.