### PR TITLE
Use derived target version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,10 +86,8 @@ exclude = [
 [tool.black]
 line-length = 120
 skip-string-normalization = true
-target-version = ["py38"]
 
 [tool.ruff]
-target-version = "py38"
 line-length = 120
 select = [
   "A",

--- a/src/hatch/template/files_default.py
+++ b/src/hatch/template/files_default.py
@@ -178,12 +178,10 @@ all = [
 ]
 
 [tool.black]
-target-version = ["py38"]
 line-length = 120
 skip-string-normalization = true
 
 [tool.ruff]
-target-version = "py38"
 line-length = 120
 select = [
   "A",

--- a/tests/helpers/templates/new/default.py
+++ b/tests/helpers/templates/new/default.py
@@ -147,12 +147,10 @@ all = [
 ]
 
 [tool.black]
-target-version = ["py38"]
 line-length = 120
 skip-string-normalization = true
 
 [tool.ruff]
-target-version = "py38"
 line-length = 120
 select = [
   "A",

--- a/tests/helpers/templates/new/feature_cli.py
+++ b/tests/helpers/templates/new/feature_cli.py
@@ -181,12 +181,10 @@ all = [
 ]
 
 [tool.black]
-target-version = ["py38"]
 line-length = 120
 skip-string-normalization = true
 
 [tool.ruff]
-target-version = "py38"
 line-length = 120
 select = [
   "A",

--- a/tests/helpers/templates/new/feature_no_src_layout.py
+++ b/tests/helpers/templates/new/feature_no_src_layout.py
@@ -147,12 +147,10 @@ all = [
 ]
 
 [tool.black]
-target-version = ["py38"]
 line-length = 120
 skip-string-normalization = true
 
 [tool.ruff]
-target-version = "py38"
 line-length = 120
 select = [
   "A",

--- a/tests/helpers/templates/new/licenses_empty.py
+++ b/tests/helpers/templates/new/licenses_empty.py
@@ -110,12 +110,10 @@ all = [
 ]
 
 [tool.black]
-target-version = ["py38"]
 line-length = 120
 skip-string-normalization = true
 
 [tool.ruff]
-target-version = "py38"
 line-length = 120
 select = [
   "A",

--- a/tests/helpers/templates/new/licenses_multiple.py
+++ b/tests/helpers/templates/new/licenses_multiple.py
@@ -150,12 +150,10 @@ all = [
 ]
 
 [tool.black]
-target-version = ["py38"]
 line-length = 120
 skip-string-normalization = true
 
 [tool.ruff]
-target-version = "py38"
 line-length = 120
 select = [
   "A",

--- a/tests/helpers/templates/new/projects_urls_empty.py
+++ b/tests/helpers/templates/new/projects_urls_empty.py
@@ -142,12 +142,10 @@ all = [
 ]
 
 [tool.black]
-target-version = ["py38"]
 line-length = 120
 skip-string-normalization = true
 
 [tool.ruff]
-target-version = "py38"
 line-length = 120
 select = [
   "A",

--- a/tests/helpers/templates/new/projects_urls_space_in_label.py
+++ b/tests/helpers/templates/new/projects_urls_space_in_label.py
@@ -145,12 +145,10 @@ all = [
 ]
 
 [tool.black]
-target-version = ["py38"]
 line-length = 120
 skip-string-normalization = true
 
 [tool.ruff]
-target-version = "py38"
 line-length = 120
 select = [
   "A",


### PR DESCRIPTION
It’s derived from `requires-python` in both Ruff:

> ## [target-version](https://beta.ruff.rs/docs/settings/#target-version)
> […]
> If omitted, and Ruff is configured via a `pyproject.toml` file, the target version will be inferred from its `project.requires-python` field (e.g., `requires-python = ">=3.8"`).

and Black (in https://github.com/psf/black/pull/3219):

> ## [`-t`, `--target-version`](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#command-line-options)
> […] By default, Black will try to infer this from the project metadata in pyproject.toml. […]