### PR TITLE
hatchling: Allow using empty string to add prefixes to the distribution path

### DIFF
--- a/backend/src/hatchling/builders/config.py
+++ b/backend/src/hatchling/builders/config.py
@@ -664,11 +664,8 @@ class BuilderConfig:
 
                     sources[normalize_relative_directory(source)] = ''
             elif isinstance(raw_sources, dict):
-                for i, (source, path) in enumerate(raw_sources.items(), 1):
-                    if not source:
-                        message = f'Source #{i} in field `{sources_location}` cannot be an empty string'
-                        raise ValueError(message)
-                    elif not isinstance(path, str):
+                for source, path in raw_sources.items():
+                    if not isinstance(path, str):
                         message = f'Path for source `{source}` in field `{sources_location}` must be a string'
                         raise TypeError(message)
 
@@ -678,7 +675,7 @@ class BuilderConfig:
                     else:
                         normalized_path += os.sep
 
-                    sources[normalize_relative_directory(source)] = normalized_path
+                    sources[normalize_relative_directory(source) if source else source] = normalized_path
             else:
                 message = f'Field `{sources_location}` must be a mapping or array of strings'
                 raise TypeError(message)
@@ -790,7 +787,9 @@ class BuilderConfig:
     def get_distribution_path(self, relative_path: str) -> str:
         # src/foo/bar.py -> foo/bar.py
         for source, replacement in self.sources.items():
-            if relative_path.startswith(source):
+            if source == '':
+                return replacement + relative_path
+            elif relative_path.startswith(source):
                 return relative_path.replace(source, replacement, 1)
 
         return relative_path

--- a/docs/config/build.md
+++ b/docs/config/build.md
@@ -255,6 +255,24 @@ If you want to remove path prefixes entirely, rather than setting each to an emp
     sources = ["src"]
     ```
 
+If you want to add prefix to the path, you can use an empty string. For example, the following configuration:
+
+=== ":octicons-file-code-16: pyproject.toml"
+
+    ```toml
+    [tool.hatch.build.sources]
+    "" = "bar"
+    ```
+
+=== ":octicons-file-code-16: hatch.toml"
+
+    ```toml
+    [build.sources]
+    "" = "bar"
+    ```
+
+would distribute the file `file.ext` as `bar/file.ext`.
+
 The [packages](#packages) option itself relies on sources. Defining `#!toml packages = ["src/foo"]` for the `wheel` target is equivalent to the following:
 
 === ":octicons-file-code-16: pyproject.toml"

--- a/tests/backend/builders/test_config.py
+++ b/tests/backend/builders/test_config.py
@@ -684,8 +684,10 @@ class TestSources:
         config = {'tool': {'hatch': {'build': {'sources': {'': 'renamed'}}}}}
         builder = MockBuilder(str(isolation), config=config)
 
-        with pytest.raises(ValueError, match='Source #1 in field `tool.hatch.build.sources` cannot be an empty string'):
-            _ = builder.config.sources
+        assert len(builder.config.sources) == 1
+        assert builder.config.sources[''] == pjoin('renamed', '')
+        assert builder.config.get_distribution_path('bar.py') == pjoin('renamed', 'bar.py')
+        assert builder.config.get_distribution_path(pjoin('foo', 'bar.py')) == pjoin('renamed', 'foo', 'bar.py')
 
     def test_global_mapping_path_empty_string(self, isolation):
         config = {'tool': {'hatch': {'build': {'sources': {'src/foo': ''}}}}}
@@ -757,10 +759,9 @@ class TestSources:
         builder = MockBuilder(str(isolation), config=config)
         builder.PLUGIN_NAME = 'foo'
 
-        with pytest.raises(
-            ValueError, match='Source #1 in field `tool.hatch.build.targets.foo.sources` cannot be an empty string'
-        ):
-            _ = builder.config.sources
+        assert len(builder.config.sources) == 1
+        assert builder.config.sources[''] == pjoin('renamed', '')
+        assert builder.config.get_distribution_path(pjoin('bar.py')) == pjoin('renamed', 'bar.py')
 
     def test_target_mapping_path_empty_string(self, isolation):
         config = {'tool': {'hatch': {'build': {'targets': {'foo': {'sources': {'src/foo': ''}}}}}}}


### PR DESCRIPTION
Closes #802

Rather than using a dot (in the issue linked above), this propose to use the empty string.