### PR TITLE
Fix example in docs

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -78,7 +78,7 @@ Hatch ensures that environments are always compatible with the currently defined
 For example, add `cowsay` as a dependency then try to run it:
 
 ```console
-$ hatch run cowsay "Hello, world!"
+$ hatch run cowsay -t "Hello, world!"
 Syncing dependencies
   _____________
 | Hello, world! |


### PR DESCRIPTION
Updated environment.md example command using cowsay. Cowsay commands now need a -t flag in version 6+. This is referring to the issue #993.