### PR TITLE
Propose `__TOKEN__` as default when prompting a username for `hatch publish`

### DIFF
--- a/src/hatch/publish/index.py
+++ b/src/hatch/publish/index.py
@@ -78,7 +78,7 @@ class IndexPublisher(PublisherInterface):
                     if options['no_prompt']:
                         self.app.abort('Missing required option: user')
                     else:
-                        user = updated_user = self.app.prompt('Enter your username')
+                        user = updated_user = self.app.prompt('Enter your username', default='__TOKEN__')
         index.user = user
 
         updated_auth = None

--- a/tests/cli/publish/test_publish.py
+++ b/tests/cli/publish/test_publish.py
@@ -342,7 +342,7 @@ def test_prompt(hatch, devpi, temp_dir_cache, helpers, published_project_name, c
     assert result.exit_code == 0, result.output
     assert result.output == helpers.dedent(
         f"""
-        Enter your username: {devpi.user}
+        Enter your username [__TOKEN__]: {devpi.user}
         Enter your credentials:{' '}
         {artifacts[0].relative_to(path)} ... success
 
@@ -385,7 +385,7 @@ def test_initialize_auth(hatch, devpi, temp_dir_cache, helpers, published_projec
     assert result.exit_code == 0, result.output
     assert result.output == helpers.dedent(
         f"""
-        Enter your username: {devpi.user}
+        Enter your username [__TOKEN__]: {devpi.user}
         Enter your credentials:{' '}
         """
     )


### PR DESCRIPTION
Fixes https://github.com/pypa/hatch/issues/998