### PR TITLE
Clarify default file selection for wheels

### DIFF
--- a/docs/plugins/builder/wheel.md
+++ b/docs/plugins/builder/wheel.md
@@ -37,7 +37,7 @@ When the user has not set any [file selection](../../config/build.md#file-select
 2. `src/<NAME>/__init__.py`
 3. `<NAME>.py`
 4. `<NAMESPACE>/<NAME>/__init__.py`
-5. Otherwise, every Python package and file that does not start with the word `test` will be included
+5. Otherwise, every Python package and every file that does not start with the word `test` will be included
 
 ## Reproducibility
 


### PR DESCRIPTION
The sentence was previously ambiguous and wasn't clear whether the "Python" adjective referred to the "file" noun as well.

In fact all non-.py files are included, so reword slightly to better clarify.