### PR TITLE
Add a contributing page

### DIFF
--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -1,0 +1,67 @@
+# Contributing
+
+The usual process to make a contribution is to:
+
+1. Check for existing related issues
+2. Fork the repository and create a new branch
+3. Make your changes
+4.  Make sure formatting, linting and tests passes.
+5. Add tests if possible to cover the lines you added.
+6. Commit, and send a Pull Request.
+
+## Clone the repository
+
+Clone the `hatch` repository, `cd` into it, and create a new branch for your contribution:
+
+```bash
+cd hatch
+git checkout -b add-my-contribution
+```
+
+## Run the tests
+
+Run the test suite while developing:
+
+```bash
+hatch run dev
+```
+
+Run the test suite with coverage report:
+
+```bash
+hatch run cov
+```
+
+Run the extended test suite with coverage:
+
+```bash
+hatch run full
+```
+
+## Lint
+
+Run automated formatting:
+
+```bash
+hatch run lint:fmt
+```
+
+Run full linting and type checking:
+
+```bash
+hatch run lint:all
+```
+
+## Docs
+
+Start the documentation in development:
+
+```bash
+hatch run docs:serve
+```
+
+Build and validate the documentation website:
+
+```bash
+hatch run build-check
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
     - Community:
       - Users: community/users.md
       - Highlights: community/highlights.md
+      - Contributing: community/contributing.md
   - Configuration:
     - Metadata: config/metadata.md
     - Dependencies: config/dependency.md


### PR DESCRIPTION
@ofek  This PR adds a **contributing** page to the **community** section to detail the recommended process to make a contribution to hatch

The process is relatively straightforward and well defined, but it is always a bit tedious to go decrypt the scripts in the `pyproject.toml`/`hatch.toml` to remember how to run the tests, linting or doc generation

Adding a contributing page would make the process smoother and encourage newcomers to contribute (also it's a nice way to show how clean a development process can be when using `hatch`!)

This have been asked about at least in 1 issue afaik: https://github.com/pypa/hatch/issues/835

I am not sure this should go to **community**, or **meta**, or **How-to** though (feel free to move it if necessary)