### PR TITLE
Handle nonzero version epoch in StandardScheme (fix #1032)

### DIFF
--- a/backend/src/hatchling/version/scheme/standard.py
+++ b/backend/src/hatchling/version/scheme/standard.py
@@ -69,8 +69,8 @@ class StandardScheme(VersionSchemeInterface):
 def reset_version_parts(version: Version, **kwargs: Any) -> None:
     # https://github.com/pypa/packaging/blob/20.9/packaging/version.py#L301-L310
     internal_version = version._version
-    parts: dict[str, Any] = {'epoch': 0}
-    ordered_part_names = ('release', 'pre', 'post', 'dev', 'local')
+    parts: dict[str, Any] = {}
+    ordered_part_names = ('epoch', 'release', 'pre', 'post', 'dev', 'local')
 
     reset = False
     for part_name in ordered_part_names:

--- a/tests/backend/version/scheme/test_standard.py
+++ b/tests/backend/version/scheme/test_standard.py
@@ -119,3 +119,21 @@ class TestMultiple:
         scheme = StandardScheme(str(isolation), {})
 
         assert scheme.update(operations, '0.0.1', {}) == expected
+
+
+class TestWithEpoch:
+    @pytest.mark.parametrize(
+        'operations, expected',
+        [
+            ('patch,dev,release', '1!0.0.2'),
+            ('fix,rc', '1!0.0.2rc0'),
+            ('minor,dev', '1!0.1.0.dev0'),
+            ('minor,preview', '1!0.1.0rc0'),
+            ('major,beta', '1!1.0.0b0'),
+            ('major,major,major', '1!3.0.0'),
+        ],
+    )
+    def test_correct(self, isolation, operations, expected):
+        scheme = StandardScheme(str(isolation), {})
+
+        assert scheme.update(operations, '1!0.0.1', {}) == expected


### PR DESCRIPTION
This fixes #1032, where `hatch version` would strip version epochs when incrementing the version.

As far as I can tell, it's fine to remove `epoch: 0` here because `version._version.epoch` defaults to 0 if not set.
