### PR TITLE
Allow management commands for installer binaries

### DIFF
--- a/.github/workflows/build-hatch.yml
+++ b/.github/workflows/build-hatch.yml
@@ -151,37 +151,29 @@ jobs:
         mv "$wheel" "../$PYAPP_REPO"
         echo "PYAPP_PROJECT_PATH=$wheel" >> $GITHUB_ENV
 
+    - name: Build binary
+      run: hatch build --target app
+
+    # Windows installers don't accept non-integer versions so we ubiquitously
+    # perform the following transformation: X.Y.Z.devN -> X.Y.Z.N
     - name: Set project version
       id: version
       run: |-
-        raw_version="$(hatch version)"
-        version="${raw_version/dev/}"
+        old_version="$(hatch version)"
+        version="${old_version/dev/}"
 
-        echo "raw-version=$raw_version" >> $GITHUB_OUTPUT
+        if [[ "$version" != "$old_version" ]]; then
+          cd dist/app
+          old_binary="$(ls)"
+          binary="${old_binary/$old_version/$version}"
+          mv "$old_binary" "$binary"
+        fi
+
         echo "version=$version" >> $GITHUB_OUTPUT
         echo "$version"
 
-    # We cannot use anchors because of https://github.com/actions/runner/issues/1182 and
-    # other solutions like writing a composite action are burdensome
-    - name: Set reusable script - Correct binary version
-      id: script-version
-      # Windows installers don't accept non-integer versions so we ubiquitously
-      # perform the following transformation: X.Y.Z.devN -> X.Y.Z.N
+    - name: Archive binary
       run: |-
-        cat <<"OUTER" >> $GITHUB_OUTPUT
-        script<<INNER
-        cd dist/app
-        old_binary="$(ls)"
-        binary="${old_binary/${{ steps.version.outputs.raw-version }}/${{ steps.version.outputs.version }}}"
-        mv "$old_binary" "$binary"
-        INNER
-        OUTER
-
-    - name: Set reusable script - Archive binary
-      id: script-archive
-      run: |-
-        cat <<"OUTER" >> $GITHUB_OUTPUT
-        script<<INNER
         mkdir packaging
         cd dist/app
 
@@ -193,53 +185,16 @@ jobs:
           chmod +x "$binary"
           tar -czf "../../packaging/$binary.tar.gz" "$binary"
         fi
-        INNER
-        OUTER
 
-    - name: Build managed binary
-      env:
-        PYAPP_SELF_COMMAND: "none"
-      run: hatch build --target app
-
-    - name: Correct binary version
-      if: steps.version.outputs.version != steps.version.outputs.raw-version
-      run: ${{ steps.script-version.outputs.script }}
-
-    - name: Archive binary
-      run: ${{ steps.script-archive.outputs.script }}
-
-    - name: Upload staged managed archive
+    - name: Upload staged archive
       if: runner.os != 'Linux'
       uses: actions/upload-artifact@v3
       with:
-        name: staged-managed-${{ runner.os }}
+        name: staged-${{ runner.os }}
         path: packaging/*
         if-no-files-found: error
 
-    - name: Reset artifact directories
-      run: rm -rf dist/app packaging
-
-    - name: Build standalone binary
-      run: hatch build --target app
-
-    - name: Correct binary version
-      if: steps.version.outputs.version != steps.version.outputs.raw-version
-      run: ${{ steps.script-version.outputs.script }}
-
-    - name: Archive binary
-      run: ${{ steps.script-archive.outputs.script }}
-
-    - name: Upload staged standalone archive
-      if: runner.os != 'Linux'
-      uses: actions/upload-artifact@v3
-      with:
-        name: staged-standalone-${{ runner.os }}
-        path: packaging/*
-        if-no-files-found: error
-
-    # There are no installers nor extra steps like signing for Linux so we
-    # can upload directly at this point
-    - name: Upload standalone archive
+    - name: Upload archive
       if: runner.os == 'Linux'
       uses: actions/upload-artifact@v3
       with:
@@ -268,26 +223,22 @@ jobs:
     - name: Install PyOxidizer ${{ env.PYOXIDIZER_VERSION }}
       run: pip install pyoxidizer==${{ env.PYOXIDIZER_VERSION }}
 
-    # We cannot use anchors because of https://github.com/actions/runner/issues/1182 and
-    # other solutions like writing a composite action are burdensome
-    - name: Set reusable script - Extract binaries
-      id: script-extract
+    - name: Download staged binaries
+      uses: actions/download-artifact@v3
+      with:
+        name: staged-${{ runner.os }}
+        path: archives
+
+    - name: Extract staged binaries
       run: |-
-        cat <<"OUTER" >> $GITHUB_OUTPUT
-        script<<INNER
         mkdir bin
         for f in archives/*; do
           7z e "$f" -obin
         done
-        INNER
-        OUTER
 
-    - name: Set reusable script - Prepare binaries
-      id: script-prepare
-      # bin/<APP_NAME>-<VERSION>-<TARGET>.exe -> targets/<TARGET>/<APP_NAME>.exe
+    # bin/<APP_NAME>-<VERSION>-<TARGET>.exe -> targets/<TARGET>/<APP_NAME>.exe
+    - name: Prepare binaries
       run: |-
-        cat <<"OUTER" >> $GITHUB_OUTPUT
-        script<<INNER
         mkdir targets
         for f in bin/*; do
           if [[ "$f" =~ ${{ env.VERSION }}-(.+).exe$ ]]; then
@@ -296,42 +247,6 @@ jobs:
             mv "$f" "targets/$target/${{ env.APP_NAME }}.exe"
           fi
         done
-        INNER
-        OUTER
-
-    - name: Download staged standalone binaries
-      uses: actions/download-artifact@v3
-      with:
-        name: staged-standalone-${{ runner.os }}
-        path: archives
-
-    - name: Extract staged standalone binaries
-      run: ${{ steps.script-extract.outputs.script }}
-
-    - name: Prepare standalone binaries
-      run: ${{ steps.script-prepare.outputs.script }}
-
-    - name: Upload standalone binaries
-      uses: actions/upload-artifact@v3
-      with:
-        name: standalone
-        path: archives/*
-        if-no-files-found: error
-
-    - name: Reset artifact directories
-      run: rm -rf archives bin targets
-
-    - name: Download staged managed binaries
-      uses: actions/download-artifact@v3
-      with:
-        name: staged-managed-${{ runner.os }}
-        path: archives
-
-    - name: Extract staged managed binaries
-      run: ${{ steps.script-extract.outputs.script }}
-
-    - name: Prepare managed binaries
-      run: ${{ steps.script-prepare.outputs.script }}
 
     - name: Build installers
       run: >-
@@ -343,6 +258,13 @@ jobs:
       run: |-
         mkdir installers
         mv build/*/release/*/*.{exe,msi} installers
+
+    - name: Upload binaries
+      uses: actions/upload-artifact@v3
+      with:
+        name: standalone
+        path: archives/*
+        if-no-files-found: error
 
     - name: Upload installers
       uses: actions/upload-artifact@v3
@@ -371,36 +293,27 @@ jobs:
     - name: Install PyOxidizer ${{ env.PYOXIDIZER_VERSION }}
       run: pip install pyoxidizer==${{ env.PYOXIDIZER_VERSION }}
 
-    # TODO: Use the next official release after 0.22.0 by removing these 2 blocks, uncommenting
-    # the following one, and changing the artifact name to reflect the next version. See:
-    # https://github.com/indygreg/apple-platform-rs/issues/82
-    #
-    # We use the artifact from the latest scheduled nightly job because installing
-    # with Cargo from scratch takes ~10 minutes
     - name: Install rcodesign
-      uses: dawidd6/action-download-artifact@v2
+      env:
+        ARCHIVE_NAME: "apple-codesign-0.26.0-x86_64-apple-darwin"
+      run: >-
+        curl -L
+        "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F0.26.0/$ARCHIVE_NAME.tar.gz"
+        |
+        tar --strip-components=1 -xzf - -C /usr/local/bin "$ARCHIVE_NAME/rcodesign"
+
+    - name: Download staged binaries
+      uses: actions/download-artifact@v3
       with:
-        repo: indygreg/apple-platform-rs
-        workflow: rcodesign.yml
-        event: schedule
-        workflow_conclusion: success
-        name: exe-rcodesign-x86_64-apple-darwin
-        path: /usr/local/bin
-        search_artifacts: true
-        check_artifacts: true
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        name: staged-${{ runner.os }}
+        path: archives
 
-    - name: Finalize rcodesign
-      run: chmod +x /usr/local/bin/rcodesign
-
-    # - name: Install rcodesign
-    #   env:
-    #     ARCHIVE_NAME: "apple-codesign-0.22.0-x86_64-apple-darwin"
-    #   run: >-
-    #     curl -L
-    #     "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F0.22.0/$ARCHIVE_NAME.tar.gz"
-    #     |
-    #     tar --strip-components=1 -xzf - -C /usr/local/bin "$ARCHIVE_NAME/rcodesign"
+    - name: Extract staged binaries
+      run: |-
+        mkdir bin
+        for f in archives/*; do
+          tar -xzf "$f" -C bin
+        done
 
     - name: Write credentials
       env:
@@ -416,26 +329,9 @@ jobs:
         echo "$APPLE_DEVELOPER_ID_INSTALLER_PRIVATE_KEY" > /tmp/private-key-installer.pem
         echo "$APPLE_APP_STORE_CONNECT_API_DATA" > /tmp/app-store-connect.json
 
-    # We cannot use anchors because of https://github.com/actions/runner/issues/1182 and
-    # other solutions like writing a composite action are burdensome
-    - name: Set reusable script - Extract binaries
-      id: script-extract
+    # https://developer.apple.com/documentation/security/hardened_runtime
+    - name: Sign binaries
       run: |-
-        cat <<"OUTER" >> $GITHUB_OUTPUT
-        script<<INNER
-        mkdir bin
-        for f in archives/*; do
-          tar -xzf "$f" -C bin
-        done
-        INNER
-        OUTER
-
-    - name: Set reusable script - Sign binaries
-      id: script-sign
-      # https://developer.apple.com/documentation/security/hardened_runtime
-      run: |-
-        cat <<"OUTER" >> $GITHUB_OUTPUT
-        script<<INNER
         for f in bin/*; do
           rcodesign sign -vv \
           --pem-source /tmp/certificate-application.pem \
@@ -443,15 +339,10 @@ jobs:
           --code-signature-flags runtime \
           "$f"
         done
-        INNER
-        OUTER
 
-    - name: Set reusable script - Notarize binaries
-      id: script-notarize
-      # https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution
+    # https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution
+    - name: Notarize binaries
       run: |-
-        cat <<"OUTER" >> $GITHUB_OUTPUT
-        script<<INNER
         mkdir notarize-bin
 
         cd bin
@@ -465,25 +356,8 @@ jobs:
           --api-key-path /tmp/app-store-connect.json \
           "$f"
         done
-        INNER
-        OUTER
 
-    - name: Download staged standalone binaries
-      uses: actions/download-artifact@v3
-      with:
-        name: staged-standalone-${{ runner.os }}
-        path: archives
-
-    - name: Extract staged standalone binaries
-      run: ${{ steps.script-extract.outputs.script }}
-
-    - name: Sign standalone binaries
-      run: ${{ steps.script-sign.outputs.script }}
-
-    - name: Notarize standalone binaries
-      run: ${{ steps.script-notarize.outputs.script }}
-
-    - name: Archive standalone binaries
+    - name: Archive binaries
       run: |-
         rm archives/*
         cd bin
@@ -492,33 +366,8 @@ jobs:
           tar -czf "../archives/$f.tar.gz" "$f"
         done
 
-    - name: Upload standalone binaries
-      uses: actions/upload-artifact@v3
-      with:
-        name: standalone
-        path: archives/*
-        if-no-files-found: error
-
-    - name: Reset artifact directories
-      run: rm -rf archives bin notarize-bin
-
-    - name: Download staged managed binaries
-      uses: actions/download-artifact@v3
-      with:
-        name: staged-managed-${{ runner.os }}
-        path: archives
-
-    - name: Extract staged managed binaries
-      run: ${{ steps.script-extract.outputs.script }}
-
-    - name: Sign managed binaries
-      run: ${{ steps.script-sign.outputs.script }}
-
-    - name: Notarize managed binaries
-      run: ${{ steps.script-notarize.outputs.script }}
-
     # bin/<APP_NAME>-<VERSION>-<TARGET> -> targets/<TARGET>/<APP_NAME>
-    - name: Prepare managed binaries
+    - name: Prepare binaries
       run: |-
         mkdir targets
         for f in bin/*; do
@@ -570,6 +419,13 @@ jobs:
         --api-key-path /tmp/app-store-connect.json
         --staple
         "signed/${{ steps.pkg.outputs.path }}"
+
+    - name: Upload binaries
+      uses: actions/upload-artifact@v3
+      with:
+        name: standalone
+        path: archives/*
+        if-no-files-found: error
 
     - name: Upload installer
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
https://github.com/pypa/hatch/pull/973 was a mistake, people don't want that.

To revert, I basically copied the code of the workflow file from before that commit then applied manually:

- https://github.com/pypa/hatch/commit/6a1f8dca0d9df3f2bbea6f3c7e8c509ec234da75
- https://github.com/pypa/hatch/commit/68c8cafd0b922395462736d8d1bd5579ce1db5d5
- https://github.com/pypa/hatch/commit/86393f9a69a4a0a7e8acf9c3efc6814d224ccd75

Additionally, there has been a new release of apple-codesign which fixes the bug that has plagued us so we now use that rather than artifacts from their CI