### PR TITLE
Change the name of the type checking environment in new project templates

### DIFF
--- a/src/hatch/template/files_default.py
+++ b/src/hatch/template/files_default.py
@@ -166,11 +166,11 @@ cov = [
 [[tool.hatch.envs.all.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
-[tool.hatch.envs.typing]
+[tool.hatch.envs.types]
 dependencies = [
   "mypy>=1.0.0",
 ]
-[tool.hatch.envs.typing.scripts]
+[tool.hatch.envs.types.scripts]
 check = "mypy --install-types --non-interactive {{args:{package_location}{template_config['package_name']} tests}}"
 
 [tool.coverage.run]

--- a/tests/helpers/templates/new/default.py
+++ b/tests/helpers/templates/new/default.py
@@ -124,11 +124,11 @@ cov = [
 [[tool.hatch.envs.all.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
-[tool.hatch.envs.typing]
+[tool.hatch.envs.types]
 dependencies = [
   "mypy>=1.0.0",
 ]
-[tool.hatch.envs.typing.scripts]
+[tool.hatch.envs.types.scripts]
 check = "mypy --install-types --non-interactive {{args:src/{kwargs['package_name']} tests}}"
 
 [tool.coverage.run]

--- a/tests/helpers/templates/new/feature_cli.py
+++ b/tests/helpers/templates/new/feature_cli.py
@@ -158,11 +158,11 @@ cov = [
 [[tool.hatch.envs.all.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
-[tool.hatch.envs.typing]
+[tool.hatch.envs.types]
 dependencies = [
   "mypy>=1.0.0",
 ]
-[tool.hatch.envs.typing.scripts]
+[tool.hatch.envs.types.scripts]
 check = "mypy --install-types --non-interactive {{args:src/{kwargs['package_name']} tests}}"
 
 [tool.coverage.run]

--- a/tests/helpers/templates/new/feature_no_src_layout.py
+++ b/tests/helpers/templates/new/feature_no_src_layout.py
@@ -124,11 +124,11 @@ cov = [
 [[tool.hatch.envs.all.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
-[tool.hatch.envs.typing]
+[tool.hatch.envs.types]
 dependencies = [
   "mypy>=1.0.0",
 ]
-[tool.hatch.envs.typing.scripts]
+[tool.hatch.envs.types.scripts]
 check = "mypy --install-types --non-interactive {{args:{kwargs['package_name']} tests}}"
 
 [tool.coverage.run]

--- a/tests/helpers/templates/new/licenses_empty.py
+++ b/tests/helpers/templates/new/licenses_empty.py
@@ -87,11 +87,11 @@ cov = [
 [[tool.hatch.envs.all.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
-[tool.hatch.envs.typing]
+[tool.hatch.envs.types]
 dependencies = [
   "mypy>=1.0.0",
 ]
-[tool.hatch.envs.typing.scripts]
+[tool.hatch.envs.types.scripts]
 check = "mypy --install-types --non-interactive {{args:src/{kwargs['package_name']} tests}}"
 
 [tool.coverage.run]

--- a/tests/helpers/templates/new/licenses_multiple.py
+++ b/tests/helpers/templates/new/licenses_multiple.py
@@ -127,11 +127,11 @@ cov = [
 [[tool.hatch.envs.all.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
-[tool.hatch.envs.typing]
+[tool.hatch.envs.types]
 dependencies = [
   "mypy>=1.0.0",
 ]
-[tool.hatch.envs.typing.scripts]
+[tool.hatch.envs.types.scripts]
 check = "mypy --install-types --non-interactive {{args:src/{kwargs['package_name']} tests}}"
 
 [tool.coverage.run]

--- a/tests/helpers/templates/new/projects_urls_empty.py
+++ b/tests/helpers/templates/new/projects_urls_empty.py
@@ -119,11 +119,11 @@ cov = [
 [[tool.hatch.envs.all.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
-[tool.hatch.envs.typing]
+[tool.hatch.envs.types]
 dependencies = [
   "mypy>=1.0.0",
 ]
-[tool.hatch.envs.typing.scripts]
+[tool.hatch.envs.types.scripts]
 check = "mypy --install-types --non-interactive {{args:src/{kwargs['package_name']} tests}}"
 
 [tool.coverage.run]

--- a/tests/helpers/templates/new/projects_urls_space_in_label.py
+++ b/tests/helpers/templates/new/projects_urls_space_in_label.py
@@ -122,11 +122,11 @@ cov = [
 [[tool.hatch.envs.all.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
-[tool.hatch.envs.typing]
+[tool.hatch.envs.types]
 dependencies = [
   "mypy>=1.0.0",
 ]
-[tool.hatch.envs.typing.scripts]
+[tool.hatch.envs.types.scripts]
 check = "mypy --install-types --non-interactive {{args:src/{kwargs['package_name']} tests}}"
 
 [tool.coverage.run]


### PR DESCRIPTION
I don't want to do `type` because that is too similar to a built-in of the Windows command prompt