### PR TITLE
Remove 32-bit builds for Windows

### DIFF
--- a/.github/workflows/build-hatch.yml
+++ b/.github/workflows/build-hatch.yml
@@ -75,8 +75,6 @@ jobs:
         # Windows
         - target: x86_64-pc-windows-msvc
           os: windows-2022
-        - target: i686-pc-windows-msvc
-          os: windows-2022
         # macOS
         - target: aarch64-apple-darwin
           os: macos-12

--- a/docs/install.md
+++ b/docs/install.md
@@ -54,10 +54,6 @@
                 ```
                 msiexec /passive /i https://github.com/pypa/hatch/releases/download/hatch-v<HATCH_LATEST_VERSION>/hatch-<HATCH_LATEST_VERSION>-x64.msi
                 ```
-            === "x86"
-                ```
-                msiexec /passive /i https://github.com/pypa/hatch/releases/download/hatch-v<HATCH_LATEST_VERSION>/hatch-<HATCH_LATEST_VERSION>-x86.msi
-                ```
         2. Restart your terminal.
         3. To verify that the shell can find and run the `hatch` command in your `PATH`, use the following command.
 
@@ -83,7 +79,6 @@ After downloading the archive corresponding to your platform and architecture, e
 
 === "Windows"
     - [hatch-<HATCH_LATEST_VERSION>-x86_64-pc-windows-msvc.zip](https://github.com/pypa/hatch/releases/download/hatch-v<HATCH_LATEST_VERSION>/hatch-<HATCH_LATEST_VERSION>-x86_64-pc-windows-msvc.zip)
-    - [hatch-<HATCH_LATEST_VERSION>-i686-pc-windows-msvc.zip](https://github.com/pypa/hatch/releases/download/hatch-v<HATCH_LATEST_VERSION>/hatch-<HATCH_LATEST_VERSION>-i686-pc-windows-msvc.zip)
 
 ## pip
 

--- a/pyoxidizer.bzl
+++ b/pyoxidizer.bzl
@@ -7,8 +7,6 @@ AUTHOR = "Python Packaging Authority"
 def make_msi(target):
     if target == "x86_64-pc-windows-msvc":
         arch = "x64"
-    elif target == "i686-pc-windows-msvc":
-        arch = "x86"
     else:
         arch = "unknown"
 
@@ -48,17 +46,11 @@ def make_exe_installer():
     )
 
     bundle.add_vc_redistributable("x64")
-    bundle.add_vc_redistributable("x86")
 
     bundle.add_wix_msi_builder(
         builder=make_msi("x86_64-pc-windows-msvc"),
         display_internal_ui=True,
         install_condition="VersionNT64",
-    )
-    bundle.add_wix_msi_builder(
-        builder=make_msi("i686-pc-windows-msvc"),
-        display_internal_ui=True,
-        install_condition="Not VersionNT64",
     )
 
     return bundle


### PR DESCRIPTION
I wanted to figure out how to cross compile Windows ARM but that will come in the next release since I don't have time