### PR TITLE
Properly escape spaces for URI context formatting

### DIFF
--- a/backend/src/hatchling/utils/fs.py
+++ b/backend/src/hatchling/utils/fs.py
@@ -18,6 +18,6 @@ def locate_file(root: str, file_name: str) -> str | None:
 
 def path_to_uri(path: str) -> str:
     if os.sep == '/':
-        return f'file://{os.path.abspath(path)}'
+        return f'file://{os.path.abspath(path).replace(" ", "%20")}'
 
-    return f'file:///{os.path.abspath(path).replace(os.sep, "/")}'
+    return f'file:///{os.path.abspath(path).replace(" ", "%20").replace(os.sep, "/")}'

--- a/docs/history/hatchling.md
+++ b/docs/history/hatchling.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Allow using an empty string for the `sources` option to add a prefix to distribution paths
 - Fix the `wheel` target for case insensitive file systems when the project metadata name does not match the directory name on disk
 - Prevent duplicate paths when projects require the `sources` option while build hooks overwrite included paths
+- Properly escape spaces for URI context formatting
 
 ## [1.18.0](https://github.com/pypa/hatch/releases/tag/hatchling-v1.18.0) - 2023-06-12 ## {: #hatchling-v1.18.0 }
 

--- a/tests/backend/utils/test_fs.py
+++ b/tests/backend/utils/test_fs.py
@@ -3,7 +3,13 @@ import os
 from hatchling.utils.fs import path_to_uri
 
 
-def test_path_to_uri(isolation, uri_slash_prefix):
-    bad_path = f'{isolation}{os.sep}'
-    normalized_path = str(isolation).replace(os.sep, '/')
-    assert path_to_uri(bad_path) == f'file:{uri_slash_prefix}{normalized_path}'
+class TestPathToURI:
+    def test_unix(self, isolation, uri_slash_prefix):
+        bad_path = f'{isolation}{os.sep}'
+        normalized_path = str(isolation).replace(os.sep, '/')
+        assert path_to_uri(bad_path) == f'file:{uri_slash_prefix}{normalized_path}'
+
+    def test_character_escaping(self, temp_dir, uri_slash_prefix):
+        path = temp_dir / 'foo bar'
+        normalized_path = str(path).replace(os.sep, '/').replace(' ', '%20')
+        assert path_to_uri(path) == f'file:{uri_slash_prefix}{normalized_path}'


### PR DESCRIPTION
I originally thought about using [urllib.parse.quote](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.quote) but I think other special characters are actually fine for file system URIs.

Resolves #1096 