### PR TITLE
Add UniDep to metadata-hook plugins

### DIFF
--- a/docs/plugins/metadata-hook/reference.md
+++ b/docs/plugins/metadata-hook/reference.md
@@ -11,6 +11,7 @@ Metadata hooks allow for the modification of [project metadata](../../config/met
 - [hatch-nodejs-version](https://github.com/agoose77/hatch-nodejs-version) - uses fields from NodeJS `package.json` files
 - [hatch-odoo](https://github.com/acsone/hatch-odoo) - determine dependencies based on manifests of Odoo add-ons
 - [hatch-requirements-txt](https://github.com/repo-helper/hatch-requirements-txt) - read project dependencies from `requirements.txt` files
+- [UniDep](https://github.com/basnijholt/unidep) - for unified `pip` and `conda` dependency management using a single `requirements.yaml` file for both 
 
 ::: hatchling.metadata.plugin.interface.MetadataHookInterface
     options:


### PR DESCRIPTION
UniDep is a tool that allows for a single source of truth when working in projects that have both conda and pip dependencies.

It supports Hatchling: https://github.com/basnijholt/unidep?tab=readme-ov-file#hatchling-integration