### PR TITLE
Add `:parent` path modifier

### DIFF
--- a/backend/src/hatchling/utils/context.py
+++ b/backend/src/hatchling/utils/context.py
@@ -26,6 +26,10 @@ class ContextFormatter(ABC):
         if not modifier:
             return os.path.normpath(path)
 
+        while modifier.endswith(':parent'):
+            path = os.path.dirname(path)
+            modifier = modifier[:-7]
+
         if modifier == 'uri':
             return path_to_uri(path)
 

--- a/backend/src/hatchling/utils/context.py
+++ b/backend/src/hatchling/utils/context.py
@@ -26,10 +26,19 @@ class ContextFormatter(ABC):
         if not modifier:
             return os.path.normpath(path)
 
-        while modifier.endswith(':parent'):
+        modifiers = modifier.split(':')[::-1]
+        while modifiers and modifiers[-1] == 'parent':
             path = os.path.dirname(path)
-            modifier = modifier[:-7]
+            modifiers.pop()
 
+        if not modifiers:
+            return path
+
+        if len(modifiers) > 1:
+            message = f'Expected a single path modifier and instead got: {", ".join(reversed(modifiers))}'
+            raise ValueError(message)
+
+        modifier = modifiers[0]
         if modifier == 'uri':
             return path_to_uri(path)
 

--- a/docs/config/context.md
+++ b/docs/config/context.md
@@ -21,6 +21,9 @@ All paths support the following modifiers:
 | --- | --- |
 | `uri` | The normalized absolute URI path prefixed by `file:` |
 | `real` | The path with all symbolic links resolved |
+| `parent` | The parent of the previous path |
+
+Note that the `parent` modifier can be chained to get the parent of the parent of the parent etc. It must be combined with either the `uri` or `real` modifier.
 
 ### System separators
 

--- a/docs/config/context.md
+++ b/docs/config/context.md
@@ -21,9 +21,17 @@ All paths support the following modifiers:
 | --- | --- |
 | `uri` | The normalized absolute URI path prefixed by `file:` |
 | `real` | The path with all symbolic links resolved |
-| `parent` | The parent of the previous path |
+| `parent` | The parent of the preceding path |
 
-Note that the `parent` modifier can be chained to get the parent of the parent of the parent etc. It must be combined with either the `uri` or `real` modifier.
+!!! tip
+    The `parent` modifier can be chained and may be combined with either the `uri` or `real` modifier, with the latter placed at the end. For example:
+
+    ```toml config-example
+    [tool.hatch.envs.test]
+    dependencies = [
+        "example-project @ {root:parent:parent:uri}/example-project",
+    ]
+    ```
 
 ### System separators
 

--- a/docs/history/hatchling.md
+++ b/docs/history/hatchling.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ***Added:***
 
 - Add `bypass-selection` option to the `wheel` build target to allow for empty (metadata-only) wheels
+- Add `parent` context modifier for path fields
 
 ***Fixed:***
 

--- a/tests/backend/utils/test_context.py
+++ b/tests/backend/utils/test_context.py
@@ -31,9 +31,30 @@ class TestRoot:
         normalized_path = str(isolation).replace(os.sep, '/')
         assert context.format('foo {root:uri}') == f'foo file:{uri_slash_prefix}{normalized_path}'
 
+    def test_uri_parent(self, isolation, uri_slash_prefix):
+        context = Context(isolation)
+        normalized_path = os.path.dirname(str(isolation)).replace(os.sep, '/')
+        assert context.format('foo {root:uri:parent}') == f'foo file:{uri_slash_prefix}{normalized_path}'
+
+    def test_uri_parent_parent(self, isolation, uri_slash_prefix):
+        context = Context(isolation)
+        normalized_path = os.path.dirname(os.path.dirname(str(isolation))).replace(os.sep, '/')
+        assert context.format('foo {root:uri:parent:parent}') == f'foo file:{uri_slash_prefix}{normalized_path}'
+
     def test_real(self, isolation):
         context = Context(isolation)
-        assert context.format('foo {root:real}') == f'foo {os.path.realpath(isolation)}'
+        real_path = os.path.realpath(isolation)
+        assert context.format('foo {root:real}') == f'foo {real_path}'
+
+    def test_real_parent(self, isolation):
+        context = Context(isolation)
+        real_path = os.path.dirname(os.path.realpath(isolation))
+        assert context.format('foo {root:real:parent}') == f'foo {real_path}'
+
+    def test_real_parent_parent(self, isolation):
+        context = Context(isolation)
+        real_path = os.path.dirname(os.path.dirname(os.path.realpath(isolation)))
+        assert context.format('foo {root:real:parent:parent}') == f'foo {real_path}'
 
     def test_unknown_modifier(self, isolation):
         context = Context(isolation)

--- a/tests/backend/utils/test_context.py
+++ b/tests/backend/utils/test_context.py
@@ -26,6 +26,16 @@ class TestRoot:
         context = Context(isolation)
         assert context.format('foo {root}') == f'foo {isolation}'
 
+    def test_parent(self, isolation):
+        context = Context(isolation)
+        path = os.path.dirname(str(isolation))
+        assert context.format('foo {root:parent}') == f'foo {path}'
+
+    def test_parent_parent(self, isolation):
+        context = Context(isolation)
+        path = os.path.dirname(os.path.dirname(str(isolation)))
+        assert context.format('foo {root:parent:parent}') == f'foo {path}'
+
     def test_uri(self, isolation, uri_slash_prefix):
         context = Context(isolation)
         normalized_path = str(isolation).replace(os.sep, '/')
@@ -34,12 +44,12 @@ class TestRoot:
     def test_uri_parent(self, isolation, uri_slash_prefix):
         context = Context(isolation)
         normalized_path = os.path.dirname(str(isolation)).replace(os.sep, '/')
-        assert context.format('foo {root:uri:parent}') == f'foo file:{uri_slash_prefix}{normalized_path}'
+        assert context.format('foo {root:parent:uri}') == f'foo file:{uri_slash_prefix}{normalized_path}'
 
     def test_uri_parent_parent(self, isolation, uri_slash_prefix):
         context = Context(isolation)
         normalized_path = os.path.dirname(os.path.dirname(str(isolation))).replace(os.sep, '/')
-        assert context.format('foo {root:uri:parent:parent}') == f'foo file:{uri_slash_prefix}{normalized_path}'
+        assert context.format('foo {root:parent:parent:uri}') == f'foo file:{uri_slash_prefix}{normalized_path}'
 
     def test_real(self, isolation):
         context = Context(isolation)
@@ -49,18 +59,24 @@ class TestRoot:
     def test_real_parent(self, isolation):
         context = Context(isolation)
         real_path = os.path.dirname(os.path.realpath(isolation))
-        assert context.format('foo {root:real:parent}') == f'foo {real_path}'
+        assert context.format('foo {root:parent:real}') == f'foo {real_path}'
 
     def test_real_parent_parent(self, isolation):
         context = Context(isolation)
         real_path = os.path.dirname(os.path.dirname(os.path.realpath(isolation)))
-        assert context.format('foo {root:real:parent:parent}') == f'foo {real_path}'
+        assert context.format('foo {root:parent:parent:real}') == f'foo {real_path}'
 
     def test_unknown_modifier(self, isolation):
         context = Context(isolation)
 
         with pytest.raises(ValueError, match='Unknown path modifier: bar'):
             context.format('foo {root:bar}')
+
+    def test_too_many_modifiers_after_parent(self, isolation):
+        context = Context(isolation)
+
+        with pytest.raises(ValueError, match='Expected a single path modifier and instead got: foo, bar, baz'):
+            context.format('foo {root:parent:foo:bar:baz}')
 
 
 class TestHome:


### PR DESCRIPTION
Add a new `:parent` modifier for path. This can be specified any numbers of times, with each addition stripping one level from the path.

This is useful in the context of a monorepo to help normalise paths between sibling packages.

Resolves: #825