### PR TITLE
Add the requires_internet mark to a few tests

### DIFF
--- a/tests/cli/build/test_build.py
+++ b/tests/cli/build/test_build.py
@@ -145,6 +145,7 @@ def test_incompatible_environment(hatch, temp_dir, helpers):
 
 
 @pytest.mark.allow_backend_process
+@pytest.mark.requires_internet
 def test_no_compatibility_check_if_exists(hatch, temp_dir, helpers, mocker):
     project_name = 'My.App'
 

--- a/tests/cli/project/test_metadata.py
+++ b/tests/cli/project/test_metadata.py
@@ -382,6 +382,7 @@ Setting up build environment for missing dependencies
         helpers.assert_plugin_installation(mock_plugin_installation, [dependency])
 
     @pytest.mark.allow_backend_process
+    @pytest.mark.requires_internet
     def test_no_compatibility_check_if_exists(self, hatch, temp_dir, helpers, mocker):
         project_name = 'My.App'
 

--- a/tests/cli/version/test_version.py
+++ b/tests/cli/version/test_version.py
@@ -158,6 +158,7 @@ def test_plugin_dependencies_unmet(hatch, helpers, temp_dir, mock_plugin_install
     helpers.assert_plugin_installation(mock_plugin_installation, [dependency])
 
 
+@pytest.mark.requires_internet
 def test_no_compatibility_check_if_exists(hatch, helpers, temp_dir, mocker):
     project_name = 'My.App'
 


### PR DESCRIPTION
Three of the four `test_no_compatibility_check_if_exists` tests fail, and the captured `stderr` contains a network-related error, in an offline build for Fedora Linux. This adds the `requires_internet` mark to those tests.