### PR TITLE
fix: updated dependency hash

### DIFF
--- a/docs/history/hatch.md
+++ b/docs/history/hatch.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Fixed:***
+
+- Ensure that the `dependency_hash` method of the `environment` interface is called after `sync_dependencies` for cases where the hash is only known at that point, such as for dependency lockers
+
 ## [1.9.0](https://github.com/pypa/hatch/releases/tag/hatch-v1.9.0) - 2023-12-19 ## {: #hatch-v1.9.0 }
 
 ***Changed:***

--- a/src/hatch/cli/application.py
+++ b/src/hatch/cli/application.py
@@ -104,15 +104,13 @@ class Application(Terminal):
                     with self.status('Running post-installation commands'):
                         self.run_shell_commands(environment, environment.post_install_commands, source='post-install')
 
-        dep_hash = environment.dependency_hash()
+        new_dep_hash = environment.dependency_hash()
         current_dep_hash = self.env_metadata.dependency_hash(environment)
-        if dep_hash != current_dep_hash:
+        if new_dep_hash != current_dep_hash:
             with self.status('Checking dependencies'):
                 dependencies_in_sync = environment.dependencies_in_sync()
 
-            if dependencies_in_sync:
-                new_dep_hash = current_dep_hash
-            else:
+            if not dependencies_in_sync:
                 with self.status('Syncing dependencies'):
                     environment.sync_dependencies()
                     new_dep_hash = environment.dependency_hash()

--- a/src/hatch/cli/application.py
+++ b/src/hatch/cli/application.py
@@ -110,11 +110,13 @@ class Application(Terminal):
             with self.status('Checking dependencies'):
                 dependencies_in_sync = environment.dependencies_in_sync()
 
-            if not dependencies_in_sync:
+            if dependencies_in_sync:
+                new_dep_hash = current_dep_hash
+            else:
                 with self.status('Syncing dependencies'):
                     environment.sync_dependencies()
+                    new_dep_hash = environment.dependency_hash()
 
-            new_dep_hash = environment.dependency_hash()
             self.env_metadata.update_dependency_hash(environment, new_dep_hash)
 
     def run_shell_commands(

--- a/src/hatch/cli/application.py
+++ b/src/hatch/cli/application.py
@@ -114,7 +114,8 @@ class Application(Terminal):
                 with self.status('Syncing dependencies'):
                     environment.sync_dependencies()
 
-            self.env_metadata.update_dependency_hash(environment, dep_hash)
+            new_dep_hash = environment.dependency_hash()
+            self.env_metadata.update_dependency_hash(environment, new_dep_hash)
 
     def run_shell_commands(
         self,

--- a/tests/cli/run/test_run.py
+++ b/tests/cli/run/test_run.py
@@ -139,7 +139,7 @@ def test_no_compatibility_check_if_exists(hatch, helpers, temp_dir, config_file,
     assert str(env_path) in str(output_file.read_text())
 
     output_file.unlink()
-    # mocker.patch('hatch.env.virtual.VirtualEnvironment.check_compatibility', side_effect=Exception('incompatible'))
+    mocker.patch('hatch.env.virtual.VirtualEnvironment.check_compatibility', side_effect=Exception('incompatible'))
     with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
         result = hatch('run', 'python', '-c', "import pathlib,sys;pathlib.Path('test.txt').write_text(sys.executable)")
 

--- a/tests/cli/run/test_run.py
+++ b/tests/cli/run/test_run.py
@@ -139,7 +139,7 @@ def test_no_compatibility_check_if_exists(hatch, helpers, temp_dir, config_file,
     assert str(env_path) in str(output_file.read_text())
 
     output_file.unlink()
-    mocker.patch('hatch.env.virtual.VirtualEnvironment.check_compatibility', side_effect=Exception('incompatible'))
+    # mocker.patch('hatch.env.virtual.VirtualEnvironment.check_compatibility', side_effect=Exception('incompatible'))
     with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
         result = hatch('run', 'python', '-c', "import pathlib,sys;pathlib.Path('test.txt').write_text(sys.executable)")
 


### PR DESCRIPTION
resolves #1168 

This PR updates `dependency_hash` on an environment after `dependencies_in_sync` / `sync_dependencies` have been called. 