### PR TITLE
Change default publish username to lowercase __token__

### DIFF
--- a/src/hatch/publish/index.py
+++ b/src/hatch/publish/index.py
@@ -83,7 +83,7 @@ class IndexPublisher(PublisherInterface):
                         if options['no_prompt']:
                             self.app.abort('Missing required option: user')
                         else:
-                            user = updated_user = self.app.prompt('Enter your username', default='__TOKEN__')
+                            user = updated_user = self.app.prompt('Enter your username', default='__token__')
         index.user = user
 
         updated_auth = None

--- a/tests/cli/publish/test_publish.py
+++ b/tests/cli/publish/test_publish.py
@@ -342,7 +342,7 @@ def test_prompt(hatch, devpi, temp_dir_cache, helpers, published_project_name, c
     assert result.exit_code == 0, result.output
     assert result.output == helpers.dedent(
         f"""
-        Enter your username [__TOKEN__]: {devpi.user}
+        Enter your username [__token__]: {devpi.user}
         Enter your credentials:{' '}
         {artifacts[0].relative_to(path)} ... success
 
@@ -385,7 +385,7 @@ def test_initialize_auth(hatch, devpi, temp_dir_cache, helpers, published_projec
     assert result.exit_code == 0, result.output
     assert result.output == helpers.dedent(
         f"""
-        Enter your username [__TOKEN__]: {devpi.user}
+        Enter your username [__token__]: {devpi.user}
         Enter your credentials:{' '}
         """
     )


### PR DESCRIPTION
Note: I ran the tests as requested at https://hatch.pypa.io/latest/community/contributing/, but a number of them failed. None of the failures seem to be related to anything that I changed; I suspect that they are a product of my not having the full test environment. 

Others don't seem to exist -- the `lint` and `docs` don't seem to be defined. 