### PR TITLE
remove safe application

### DIFF
--- a/src/hatch/cli/application.py
+++ b/src/hatch/cli/application.py
@@ -76,7 +76,7 @@ class Application(Terminal):
             isolated_data_directory,
             self.platform,
             self.verbosity,
-            self.get_safe_application(),
+            self,
         )
 
     # Ensure that this method is clearly written since it is
@@ -252,28 +252,6 @@ class Application(Terminal):
         if text:
             self.display_error(text, **kwargs)
         self.__exit_func(code)
-
-    def get_safe_application(self) -> SafeApplication:
-        return SafeApplication(self)
-
-
-class SafeApplication:
-    def __init__(self, app: Application):
-        self.abort = app.abort
-        self.display = app.display
-        self.display_critical = app.display_critical
-        self.display_info = app.display_info
-        self.display_error = app.display_error
-        self.display_success = app.display_success
-        self.display_waiting = app.display_waiting
-        self.display_warning = app.display_warning
-        self.display_debug = app.display_debug
-        self.display_mini_header = app.display_mini_header
-        # Divergence from what the backend provides
-        self.prompt = app.prompt
-        self.confirm = app.confirm
-        self.status = app.status
-        self.status_if = app.status_if
 
 
 class EnvironmentMetadata:

--- a/src/hatch/cli/publish/__init__.py
+++ b/src/hatch/cli/publish/__init__.py
@@ -103,7 +103,7 @@ def publish(
         app.abort(f'Unknown publisher: {publisher_name}')
 
     publisher = publisher_class(
-        app.get_safe_application(),
+        app,
         app.project.location,
         app.cache_dir / 'publish' / publisher_name,
         app.project.config.publish.get(publisher_name, {}),


### PR DESCRIPTION
This PR passes the `Application` object to the `environment` and `publish` plugins instead of the `SafeApplication`. Having access the the `Application` object in an environment plugin can be extremely powerful.

In this case [hatch-pip-compile](https://github.com/juftin/hatch-pip-compile) would like access to the `Application.prepare_environment` and `Application.get_environment` functionality so that an environment can create its "constraint" environment (a `hatch-pip-compile` concept where environments can use each others lockfiles as constraints).

Relates to #1227 - I figured I'd create a PR out of it as well. 

I understand the `SafeApplication` likely has "safe" in the name for a reason - what was the original reason to create the `SafeApplication`? In particular I'm interested in `prepare_environment` and `get_environment` so I'd be open to other options as well.