### PR TITLE
Update links.txt - missing PEP 665 in use on FAQ

### DIFF
--- a/docs/.snippets/links.txt
+++ b/docs/.snippets/links.txt
@@ -3,4 +3,5 @@
 [PEP 517]: https://peps.python.org/pep-0517/
 [PEP 639]: https://peps.python.org/pep-0639/
 [PEP 660]: https://peps.python.org/pep-0660/
+[PEP 665]: https://peps.python.org/pep-0665/
 [project metadata standard]: https://packaging.python.org/en/latest/specifications/pyproject-toml/#declaring-project-metadata-the-project-table


### PR DESCRIPTION
fixes broken [PEP 665](https://peps.python.org/pep-0665/) link, adding it to where the snippet including other PEP links.

In use on https://hatch.pypa.io/1.9/meta/faq/ which is  https://github.com/pypa/hatch/blob/c20358d120d24afebc14bb4f51a75bb426989b33/docs/meta/faq.md?plain=1#L21