### PR TITLE
Docs: extract title from content

### DIFF
--- a/docs/.hooks/title_from_content.py
+++ b/docs/.hooks/title_from_content.py
@@ -1,0 +1,7 @@
+def on_page_content(
+    html,  # noqa: ARG001
+    page,
+    **kwargs,  # noqa: ARG001
+):
+    if title := page._title_from_render:  # noqa: SLF001
+        page.meta['title'] = title

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,6 +139,7 @@ watch:
 
 hooks:
 - docs/.hooks/plugin_register.py
+- docs/.hooks/title_from_content.py
 
 plugins:
   # Enable for bug reports


### PR DESCRIPTION
* Refs https://github.com/mkdocs/mkdocs/issues/3532#issuecomment-1902757023

Caveat: this uses a private attribute, the next version of MkDocs will probably have something official instead