### PR TITLE
Fix: minor typo in contributing file

### DIFF
--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -63,5 +63,5 @@ hatch run docs:serve
 Build and validate the documentation website:
 
 ```bash
-hatch run build-check
+hatch run docs:build-check
 ```


### PR DESCRIPTION
@ofek i hope it's ok to just submit a tiny pr like this without an issue. i kept trying to run the docs build:check command and it was failing. and then i realized it was just a small typo in the contributing file. 

this PR just fixes that one file. Now i can check things locally. I'll try to fix the warning in my other open PR next.