### PR TITLE
Add vcs exclude patterns before other patterns.

### DIFF
--- a/backend/src/hatchling/builders/config.py
+++ b/backend/src/hatchling/builders/config.py
@@ -191,6 +191,9 @@ class BuilderConfig:
 
             all_exclude_patterns = self.default_global_exclude()
 
+            if not self.ignore_vcs:
+                all_exclude_patterns.extend(self.load_vcs_exclusion_patterns())
+
             exclude_patterns = exclude_config.get('exclude', self.default_exclude())
             if not isinstance(exclude_patterns, list):
                 message = f'Field `{exclude_location}` must be an array of strings'
@@ -206,9 +209,6 @@ class BuilderConfig:
                     raise ValueError(message)
 
                 all_exclude_patterns.append(exclude_pattern)
-
-            if not self.ignore_vcs:
-                all_exclude_patterns.extend(self.load_vcs_exclusion_patterns())
 
             if all_exclude_patterns:
                 self.__exclude_spec = pathspec.GitIgnoreSpec.from_lines(all_exclude_patterns)

--- a/tests/backend/builders/test_config.py
+++ b/tests/backend/builders/test_config.py
@@ -1854,7 +1854,11 @@ class TestPatternExclude:
             assert builder.config.exclude_spec.match_file(f'foo{separator}file.py')
             assert not builder.config.exclude_spec.match_file(f'bar{separator}file.py')
 
-    def test_vcs_git_exclude_whitelisted_file(self, temp_dir):
+    @pytest.mark.parametrize('separator', ['/', '\\'])
+    def test_vcs_git_exclude_whitelisted_file(self, temp_dir, separator, platform):
+        if separator == '\\' and not platform.windows:
+            pytest.skip('Not running on Windows')
+
         with temp_dir.as_cwd():
             config = {'tool': {'hatch': {'build': {'exclude': ['foo/bar']}}}}
             builder = MockBuilder(str(temp_dir), config=config)
@@ -1862,8 +1866,8 @@ class TestPatternExclude:
             vcs_ignore_file = temp_dir / '.gitignore'
             vcs_ignore_file.write_text('foo/*\n!foo/bar')
 
-            assert builder.config.path_is_excluded('foo/deb') is True
-            assert builder.config.path_is_excluded('foo/bar') is True
+            assert builder.config.path_is_excluded(f'foo{separator}deb') is True
+            assert builder.config.path_is_excluded(f'foo{separator}bar') is True
 
     @pytest.mark.parametrize('separator', ['/', '\\'])
     def test_vcs_mercurial(self, temp_dir, separator, platform):

--- a/tests/backend/builders/test_config.py
+++ b/tests/backend/builders/test_config.py
@@ -1854,6 +1854,17 @@ class TestPatternExclude:
             assert builder.config.exclude_spec.match_file(f'foo{separator}file.py')
             assert not builder.config.exclude_spec.match_file(f'bar{separator}file.py')
 
+    def test_vcs_git_exclude_whitelisted_file(self, temp_dir):
+        with temp_dir.as_cwd():
+            config = {'tool': {'hatch': {'build': {'exclude': ['foo/bar']}}}}
+            builder = MockBuilder(str(temp_dir), config=config)
+
+            vcs_ignore_file = temp_dir / '.gitignore'
+            vcs_ignore_file.write_text('foo/*\n!foo/bar')
+
+            assert builder.config.path_is_excluded('foo/deb') is True
+            assert builder.config.path_is_excluded('foo/bar') is True
+
     @pytest.mark.parametrize('separator', ['/', '\\'])
     def test_vcs_mercurial(self, temp_dir, separator, platform):
         if separator == '\\' and not platform.windows:


### PR DESCRIPTION
Whitelists are possible in the vcs configuration.
These whitelists would override any configured
exclusions.
Configured exclusion should take precedence over
vcs configuration.

Issue #1276