### PR TITLE
fix: respect three components Python version

### DIFF
--- a/backend/src/hatchling/builders/wheel.py
+++ b/backend/src/hatchling/builders/wheel.py
@@ -653,7 +653,9 @@ Root-Is-Purelib: {'true' if build_data['pure_python'] else 'false'}
         for major_version in get_known_python_major_versions():
             for minor_version in range(100):
                 for micro_version in range(100):
-                    if self.metadata.core.python_constraint.contains(f'{major_version}.{minor_version}.{micro_version}'):
+                    if self.metadata.core.python_constraint.contains(
+                        f'{major_version}.{minor_version}.{micro_version}'
+                    ):
                         supported_python_versions.append(f'py{major_version}')
                         break
                 else:

--- a/backend/src/hatchling/builders/wheel.py
+++ b/backend/src/hatchling/builders/wheel.py
@@ -652,9 +652,13 @@ Root-Is-Purelib: {'true' if build_data['pure_python'] else 'false'}
         supported_python_versions = []
         for major_version in get_known_python_major_versions():
             for minor_version in range(100):
-                if self.metadata.core.python_constraint.contains(f'{major_version}.{minor_version}'):
-                    supported_python_versions.append(f'py{major_version}')
-                    break
+                for micro_version in range(100):
+                    if self.metadata.core.python_constraint.contains(f'{major_version}.{minor_version}.{micro_version}'):
+                        supported_python_versions.append(f'py{major_version}')
+                        break
+                else:
+                    continue
+                break
 
         return f'{".".join(supported_python_versions)}-none-any'
 

--- a/backend/src/hatchling/builders/wheel.py
+++ b/backend/src/hatchling/builders/wheel.py
@@ -649,18 +649,29 @@ Root-Is-Purelib: {'true' if build_data['pure_python'] else 'false'}
         return metadata_file.lstrip()
 
     def get_default_tag(self) -> str:
+        known_major_versions = list(get_known_python_major_versions())
+        max_version_part = 100
         supported_python_versions = []
-        for major_version in get_known_python_major_versions():
-            for minor_version in range(100):
-                for micro_version in range(100):
-                    if self.metadata.core.python_constraint.contains(
-                        f'{major_version}.{minor_version}.{micro_version}'
-                    ):
-                        supported_python_versions.append(f'py{major_version}')
-                        break
-                else:
-                    continue
-                break
+        for major_version in known_major_versions:
+            for minor_version in range(max_version_part):
+                # Try an artificially high patch version to account for common cases like `>=3.11.4` or `>=3.10,<3.11`
+                if self.metadata.core.python_constraint.contains(f'{major_version}.{minor_version}.{max_version_part}'):
+                    supported_python_versions.append(f'py{major_version}')
+                    break
+
+        # Slow path, try all permutations to account for narrow support ranges like `<=3.11.4`
+        if not supported_python_versions:
+            for major_version in known_major_versions:
+                for minor_version in range(max_version_part):
+                    for patch_version in range(max_version_part):
+                        if self.metadata.core.python_constraint.contains(
+                            f'{major_version}.{minor_version}.{patch_version}'
+                        ):
+                            supported_python_versions.append(f'py{major_version}')
+                            break
+                    else:
+                        continue
+                    break
 
         return f'{".".join(supported_python_versions)}-none-any'
 

--- a/docs/history/hatchling.md
+++ b/docs/history/hatchling.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ***Fixed:***
 
 - Remove `editables` as a direct dependency
+- Fix default wheel tag when the supported Python version declaration is strict
 
 ## [1.21.1](https://github.com/pypa/hatch/releases/tag/hatchling-v1.21.1) - 2024-01-25 ## {: #hatchling-v1.21.1 }
 

--- a/tests/backend/builders/test_wheel.py
+++ b/tests/backend/builders/test_wheel.py
@@ -1001,8 +1001,8 @@ class TestBuildStandard:
     @pytest.mark.parametrize(
         ('python_constraint', 'expected_template_file'),
         [
-            ('>3', 'wheel.standard_default_python_constraint'),
-            ('==3.11.4', 'wheel.standard_default_python_constraint_three_components'),
+            pytest.param('>3', 'wheel.standard_default_python_constraint', id='>3'),
+            pytest.param('==3.11.4', 'wheel.standard_default_python_constraint_three_components', id='==3.11.4'),
         ],
     )
     def test_default_python_constraint(

--- a/tests/backend/builders/test_wheel.py
+++ b/tests/backend/builders/test_wheel.py
@@ -1002,10 +1002,12 @@ class TestBuildStandard:
         ('python_constraint', 'expected_template_file'),
         [
             ('>3', 'wheel.standard_default_python_constraint'),
-            ('==3.11.4', 'wheel.standard_default_python_constraint_three_components')
+            ('==3.11.4', 'wheel.standard_default_python_constraint_three_components'),
         ],
     )
-    def test_default_python_constraint(self, hatch, helpers, temp_dir, config_file, python_constraint, expected_template_file):
+    def test_default_python_constraint(
+        self, hatch, helpers, temp_dir, config_file, python_constraint, expected_template_file
+    ):
         config_file.model.template.plugins['default']['src-layout'] = False
         config_file.save()
 

--- a/tests/backend/builders/test_wheel.py
+++ b/tests/backend/builders/test_wheel.py
@@ -998,7 +998,14 @@ class TestBuildStandard:
         )
         helpers.assert_files(extraction_directory, expected_files)
 
-    def test_default_python_constraint(self, hatch, helpers, temp_dir, config_file):
+    @pytest.mark.parametrize(
+        ('python_constraint', 'expected_template_file'),
+        [
+            ('>3', 'wheel.standard_default_python_constraint'),
+            ('==3.11.4', 'wheel.standard_default_python_constraint_three_components')
+        ],
+    )
+    def test_default_python_constraint(self, hatch, helpers, temp_dir, config_file, python_constraint, expected_template_file):
         config_file.model.template.plugins['default']['src-layout'] = False
         config_file.save()
 
@@ -1011,7 +1018,7 @@ class TestBuildStandard:
 
         project_path = temp_dir / 'my-app'
         config = {
-            'project': {'name': project_name, 'requires-python': '>3', 'dynamic': ['version']},
+            'project': {'name': project_name, 'requires-python': python_constraint, 'dynamic': ['version']},
             'tool': {
                 'hatch': {
                     'version': {'path': 'my_app/__about__.py'},
@@ -1043,7 +1050,7 @@ class TestBuildStandard:
 
         metadata_directory = f'{builder.project_id}.dist-info'
         expected_files = helpers.get_template_files(
-            'wheel.standard_default_python_constraint', project_name, metadata_directory=metadata_directory
+            expected_template_file, project_name, metadata_directory=metadata_directory
         )
         helpers.assert_files(extraction_directory, expected_files)
 

--- a/tests/helpers/templates/wheel/standard_default_python_constraint_three_components.py
+++ b/tests/helpers/templates/wheel/standard_default_python_constraint_three_components.py
@@ -1,0 +1,49 @@
+from hatch.template import File
+from hatch.utils.fs import Path
+from hatchling.__about__ import __version__
+from hatchling.metadata.spec import DEFAULT_METADATA_VERSION
+
+from ..new.feature_no_src_layout import get_files as get_template_files
+from .utils import update_record_file_contents
+
+
+def get_files(**kwargs):
+    metadata_directory = kwargs.get('metadata_directory', '')
+
+    files = []
+    for f in get_template_files(**kwargs):
+        if str(f.path) == 'LICENSE.txt':
+            files.append(File(Path(metadata_directory, 'licenses', f.path), f.contents))
+
+        if f.path.parts[0] != kwargs['package_name']:
+            continue
+
+        files.append(f)
+
+    files.extend((
+        File(
+            Path(metadata_directory, 'WHEEL'),
+            f"""\
+Wheel-Version: 1.0
+Generator: hatchling {__version__}
+Root-Is-Purelib: true
+Tag: py3-none-any
+""",
+        ),
+        File(
+            Path(metadata_directory, 'METADATA'),
+            f"""\
+Metadata-Version: {DEFAULT_METADATA_VERSION}
+Name: {kwargs['project_name']}
+Version: 0.0.1
+License-File: LICENSE.txt
+Requires-Python: ==3.11.4
+""",
+        ),
+    ))
+
+    record_file = File(Path(metadata_directory, 'RECORD'), '')
+    update_record_file_contents(record_file, files)
+    files.append(record_file)
+
+    return files


### PR DESCRIPTION
Prior to this PR, a `requires-python` version constraint of three components (e.g. `==3.11.4`) caused hatchling to fail detecting the supported Python versions and create invalid wheel filenames such as `mypackage-0.1.0--none-any.whl`. This fix takes micro versions into account as well and produces for the above three components version constraint the expected filename `mypackage-0.1.0-py3-none-any.whl`.

Related discussion: https://github.com/pypa/hatch/discussions/1277