### PR TITLE
Fix the `fmt` command when automatically installing plugin dependencies

### DIFF
--- a/docs/history/hatch.md
+++ b/docs/history/hatch.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Maintain consistent data paths for case insensitive file systems
 - When projects derive dependencies from metadata hooks, there is now by default a status indicator for when the hooks are executed for better responsiveness
 - Properly support projects with a `pyproject.toml` file but no `project` table e.g. applications
+- Fix the `fmt` command when automatically installing plugin dependencies
 - Fix dependency inheritance for the template of the `types` environment for new projects
 - Fix warnings related to tar file extraction on Python 3.12+ when unpacking Python distributions for installation
 - De-select Ruff rule `E501` for the `fmt` command by default since it conflicts with the formatter

--- a/src/hatch/cli/fmt/__init__.py
+++ b/src/hatch/cli/fmt/__init__.py
@@ -25,10 +25,12 @@ def fmt(
     sync: bool,
 ):
     """Format and lint source code."""
-    from hatch.cli.fmt.core import StaticAnalysisEnvironment
-
     if linter and formatter:
         app.abort('Cannot specify both --linter and --formatter')
+
+    from hatch.cli.fmt.core import StaticAnalysisEnvironment
+
+    app.ensure_environment_plugin_dependencies()
 
     for context in app.runner_context(['hatch-static-analysis']):
         sa_env = StaticAnalysisEnvironment(context.env)


### PR DESCRIPTION
Resolves https://github.com/pypa/hatch/issues/1379