### PR TITLE
Fix Markdown Lint Error on Template

### DIFF
--- a/src/hatch/template/files_default.py
+++ b/src/hatch/template/files_default.py
@@ -29,7 +29,7 @@ class Readme(File):
 {extra_badges}
 -----
 
-**Table of Contents**
+## Table of Contents
 
 - [Installation](#installation)
 {extra_toc}


### PR DESCRIPTION
# Fix Markdown Lint Error on Template

![image](https://github.com/pypa/hatch/assets/5193877/5e46b231-a7d7-4d65-afbf-29efc9793fe8)
