### PR TITLE
Add `.venv` to the list of directories that cannot be traversed

### DIFF
--- a/backend/src/hatchling/builders/constants.py
+++ b/backend/src/hatchling/builders/constants.py
@@ -3,6 +3,8 @@ DEFAULT_BUILD_DIRECTORY = 'dist'
 EXCLUDED_DIRECTORIES = frozenset((
     # Python bytecode
     '__pycache__',
+    # Single virtual environment
+    '.venv',
     # Git
     '.git',
     # Mercurial

--- a/docs/history/hatchling.md
+++ b/docs/history/hatchling.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ***Fixed:***
 
+- Add `.venv` to the list of directories that cannot be traversed
 - Output from the core Application utility now writes to stderr
 
 ## [1.24.1](https://github.com/pypa/hatch/releases/tag/hatchling-v1.24.1) - 2024-04-18 ## {: #hatchling-v1.24.1 }


### PR DESCRIPTION
https://github.com/pypa/packaging-problems/issues/751