### PR TITLE
Fix the `README.md` file template for new projects to avoid Markdown linting issues

### DIFF
--- a/docs/history/hatch.md
+++ b/docs/history/hatch.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Set the `packaging` dependency version as `>=23.2` to avoid its URL validation which can conflict with context formatting
 - Fix the exit code when there happens to be an unhandled exception
 - No longer capture both stdout and stderr streams when parsing metadata payloads from build environments
+- Fix the `README.md` file template for new projects to avoid Markdown linting issues
 
 ## [1.9.4](https://github.com/pypa/hatch/releases/tag/hatch-v1.9.4) - 2024-03-12 ## {: #hatch-v1.9.4 }
 

--- a/src/hatch/template/files_default.py
+++ b/src/hatch/template/files_default.py
@@ -29,7 +29,7 @@ class Readme(File):
 {extra_badges}
 -----
 
-**Table of Contents**
+## Table of Contents
 
 - [Installation](#installation)
 {extra_toc}

--- a/tests/helpers/templates/new/basic.py
+++ b/tests/helpers/templates/new/basic.py
@@ -39,7 +39,7 @@ __version__ = "0.0.1"
 
 -----
 
-**Table of Contents**
+## Table of Contents
 
 - [Installation](#installation)
 - [License](#license)

--- a/tests/helpers/templates/new/default.py
+++ b/tests/helpers/templates/new/default.py
@@ -49,7 +49,7 @@ __version__ = "0.0.1"
 
 -----
 
-**Table of Contents**
+## Table of Contents
 
 - [Installation](#installation)
 - [License](#license)

--- a/tests/helpers/templates/new/feature_cli.py
+++ b/tests/helpers/templates/new/feature_cli.py
@@ -78,7 +78,7 @@ def {kwargs['package_name']}():
 
 -----
 
-**Table of Contents**
+## Table of Contents
 
 - [Installation](#installation)
 - [License](#license)

--- a/tests/helpers/templates/new/feature_no_src_layout.py
+++ b/tests/helpers/templates/new/feature_no_src_layout.py
@@ -49,7 +49,7 @@ __version__ = "0.0.1"
 
 -----
 
-**Table of Contents**
+## Table of Contents
 
 - [Installation](#installation)
 - [License](#license)

--- a/tests/helpers/templates/new/licenses_empty.py
+++ b/tests/helpers/templates/new/licenses_empty.py
@@ -17,7 +17,7 @@ def get_files(**kwargs):
 
 -----
 
-**Table of Contents**
+## Table of Contents
 
 - [Installation](#installation)
 

--- a/tests/helpers/templates/new/licenses_multiple.py
+++ b/tests/helpers/templates/new/licenses_multiple.py
@@ -48,7 +48,7 @@ __version__ = "0.0.1"
 
 -----
 
-**Table of Contents**
+## Table of Contents
 
 - [Installation](#installation)
 - [License](#license)

--- a/tests/helpers/templates/new/projects_urls_empty.py
+++ b/tests/helpers/templates/new/projects_urls_empty.py
@@ -47,7 +47,7 @@ __version__ = "0.0.1"
 
 -----
 
-**Table of Contents**
+## Table of Contents
 
 - [Installation](#installation)
 - [License](#license)

--- a/tests/helpers/templates/new/projects_urls_space_in_label.py
+++ b/tests/helpers/templates/new/projects_urls_space_in_label.py
@@ -47,7 +47,7 @@ __version__ = "0.0.1"
 
 -----
 
-**Table of Contents**
+## Table of Contents
 
 - [Installation](#installation)
 - [License](#license)

--- a/tests/helpers/templates/sdist/standard_include.py
+++ b/tests/helpers/templates/sdist/standard_include.py
@@ -31,7 +31,7 @@ Description-Content-Type: text/markdown
 
 -----
 
-**Table of Contents**
+## Table of Contents
 
 - [Installation](#installation)
 - [License](#license)

--- a/tests/helpers/templates/sdist/standard_include_config_file.py
+++ b/tests/helpers/templates/sdist/standard_include_config_file.py
@@ -32,7 +32,7 @@ Description-Content-Type: text/markdown
 
 -----
 
-**Table of Contents**
+## Table of Contents
 
 - [Installation](#installation)
 - [License](#license)


### PR DESCRIPTION
Resolves https://github.com/pypa/hatch/pull/1409

Supersedes https://github.com/pypa/hatch/pull/1409