### PR TITLE
fix: don't set macOS less than 11 on ARM

### DIFF
--- a/backend/src/hatchling/builders/wheel.py
+++ b/backend/src/hatchling/builders/wheel.py
@@ -792,16 +792,15 @@ Root-Is-Purelib: {'true' if build_data['pure_python'] else 'false'}
                     new_arch = 'universal2' if set(archs) == {'x86_64', 'arm64'} else archs[0]
                     tag_parts[2] = f'{plat[: plat.rfind(current_arch)]}{new_arch}'
 
-            if self.config.macos_max_compat:
+            plat = tag_parts[2]
+            if self.config.macos_max_compat and not plat.endswith('arm64'):
                 import re
 
-                plat = tag_parts[2]
                 sdk_match = re.search(r'macosx_(\d+_\d+)', plat)
                 if sdk_match:
-                    replacement = "11_0" if plat.endswith("arm64") else "10_16"
                     sdk_version_part = sdk_match.group(1)
                     if tuple(map(int, sdk_version_part.split('_'))) >= (11, 0):
-                        tag_parts[2] = plat.replace(sdk_version_part, replacement, 1)
+                        tag_parts[2] = plat.replace(sdk_version_part, '10_16', 1)
 
         return '-'.join(tag_parts)
 

--- a/backend/src/hatchling/builders/wheel.py
+++ b/backend/src/hatchling/builders/wheel.py
@@ -779,8 +779,8 @@ Root-Is-Purelib: {'true' if build_data['pure_python'] else 'false'}
         tag = next(iter(t for t in sys_tags() if 'manylinux' not in t.platform and 'musllinux' not in t.platform))
         tag_parts = [tag.interpreter, tag.abi, tag.platform]
 
-        archflags = os.environ.get('ARCHFLAGS', '')
         if sys.platform == 'darwin':
+            archflags = os.environ.get('ARCHFLAGS', '')
             if archflags and sys.version_info[:2] >= (3, 8):
                 import platform
                 import re
@@ -798,9 +798,10 @@ Root-Is-Purelib: {'true' if build_data['pure_python'] else 'false'}
                 plat = tag_parts[2]
                 sdk_match = re.search(r'macosx_(\d+_\d+)', plat)
                 if sdk_match:
+                    replacement = "11_0" if plat.endswith("arm64") else "10_16"
                     sdk_version_part = sdk_match.group(1)
                     if tuple(map(int, sdk_version_part.split('_'))) >= (11, 0):
-                        tag_parts[2] = plat.replace(sdk_version_part, '10_16', 1)
+                        tag_parts[2] = plat.replace(sdk_version_part, replacement, 1)
 
         return '-'.join(tag_parts)
 


### PR DESCRIPTION
ARM never supported macOS <11. I'm not positive this fixes all cases when someone sets `MACOSX_DEPLOYMENT_TARGET<11`, I'll have to check later when I'm on ARM.


Edit: didn't get the logic right. Let me try this on ARM in a bit then update it here.