### PR TITLE
fix: swap default for macos-max-compat

### DIFF
--- a/backend/src/hatchling/builders/wheel.py
+++ b/backend/src/hatchling/builders/wheel.py
@@ -402,7 +402,7 @@ class WheelBuilderConfig(BuilderConfig):
     @property
     def macos_max_compat(self) -> bool:
         if self.__macos_max_compat is None:
-            macos_max_compat = self.target_config.get('macos-max-compat', True)
+            macos_max_compat = self.target_config.get('macos-max-compat', False)
             if not isinstance(macos_max_compat, bool):
                 message = f'Field `tool.hatch.build.targets.{self.plugin_name}.macos-max-compat` must be a boolean'
                 raise TypeError(message)

--- a/docs/plugins/builder/wheel.md
+++ b/docs/plugins/builder/wheel.md
@@ -21,7 +21,7 @@ The builder plugin name is `wheel`.
 | `shared-scripts` | | A mapping similar to the [forced inclusion](../../config/build.md#forced-inclusion) option corresponding to the `scripts` subdirectory within the standard [data directory](https://packaging.python.org/en/latest/specifications/binary-distribution-format/#the-data-directory) that will be installed in a given Python environment, usually under `Scripts` on Windows or `bin` otherwise, and would normally be available on PATH |
 | `extra-metadata` | | A mapping similar to the [forced inclusion](../../config/build.md#forced-inclusion) option corresponding to extra [metadata](https://peps.python.org/pep-0427/#the-dist-info-directory) that will be shipped in a directory named `extra_metadata` |
 | `strict-naming` | `true` | Whether or not file names should contain the normalized version of the project name |
-| `macos-max-compat` | `true` | Whether or not on macOS, when build hooks have set the `infer_tag` [build data](#build-data), the wheel name should signal broad support rather than specific versions for newer SDK versions.<br><br>Note: The default will become `false`, and this option eventually removed, sometime after consumers like pip start supporting these newer SDK versions. |
+| `macos-max-compat` | `false` | Whether or not on macOS, when build hooks have set the `infer_tag` [build data](#build-data), the wheel name should signal broad support rather than specific versions for newer SDK versions.<br><br>Note: This option will eventually be removed. |
 | `bypass-selection` | `false` | Whether or not to suppress the error when one has not defined any file selection options and all heuristics have failed to determine what to ship |
 
 ## Versions

--- a/tests/backend/builders/test_wheel.py
+++ b/tests/backend/builders/test_wheel.py
@@ -602,13 +602,13 @@ class TestMacOSMaxCompat:
     def test_default(self, isolation):
         builder = WheelBuilder(str(isolation))
 
-        assert builder.config.macos_max_compat is builder.config.macos_max_compat is True
+        assert builder.config.macos_max_compat is builder.config.macos_max_compat is False
 
     def test_correct(self, isolation):
-        config = {'tool': {'hatch': {'build': {'targets': {'wheel': {'macos-max-compat': False}}}}}}
+        config = {'tool': {'hatch': {'build': {'targets': {'wheel': {'macos-max-compat': True}}}}}}
         builder = WheelBuilder(str(isolation), config=config)
 
-        assert builder.config.macos_max_compat is False
+        assert builder.config.macos_max_compat is True
 
     def test_not_boolean(self, isolation):
         config = {'tool': {'hatch': {'build': {'targets': {'wheel': {'macos-max-compat': 9000}}}}}}

--- a/tests/backend/builders/test_wheel.py
+++ b/tests/backend/builders/test_wheel.py
@@ -3684,9 +3684,6 @@ class TestBuildStandard:
 
         tag = next(sys_tags())
         tag_parts = [tag.interpreter, tag.abi, tag.platform]
-        sdk_version_major, sdk_version_minor = tag_parts[2].split('_')[1:3]
-        if int(sdk_version_major) >= 11:
-            tag_parts[2] = tag_parts[2].replace(f'{sdk_version_major}_{sdk_version_minor}', '10_16', 1)
 
         expected_tag = '-'.join(tag_parts)
         assert expected_artifact == str(build_path / f'{builder.project_id}-{expected_tag}.whl')

--- a/tests/backend/builders/test_wheel.py
+++ b/tests/backend/builders/test_wheel.py
@@ -1342,7 +1342,7 @@ class TestBuildStandard:
                 'hatch': {
                     'version': {'path': 'my_app/__about__.py'},
                     'build': {
-                        'targets': {'wheel': {'versions': ['standard'], 'macos-max-compat': False}},
+                        'targets': {'wheel': {'versions': ['standard']}},
                         'artifacts': ['my_app/lib.so'],
                         'hooks': {'custom': {'path': DEFAULT_BUILD_SCRIPT}},
                     },
@@ -1424,7 +1424,7 @@ class TestBuildStandard:
                 'hatch': {
                     'version': {'path': 'my_app/__about__.py'},
                     'build': {
-                        'targets': {'wheel': {'versions': ['standard'], 'macos-max-compat': False}},
+                        'targets': {'wheel': {'versions': ['standard']}},
                         'artifacts': ['my_app/lib.so'],
                         'hooks': {'custom': {'path': DEFAULT_BUILD_SCRIPT}},
                     },
@@ -1507,7 +1507,7 @@ class TestBuildStandard:
                 'hatch': {
                     'version': {'path': 'my_app/__about__.py'},
                     'build': {
-                        'targets': {'wheel': {'versions': ['standard'], 'macos-max-compat': False}},
+                        'targets': {'wheel': {'versions': ['standard']}},
                         'artifacts': ['my_app/lib.so'],
                         'hooks': {'custom': {'path': DEFAULT_BUILD_SCRIPT}},
                     },
@@ -1590,7 +1590,7 @@ class TestBuildStandard:
                 'hatch': {
                     'version': {'path': 'my_app/__about__.py'},
                     'build': {
-                        'targets': {'wheel': {'versions': ['standard'], 'macos-max-compat': False}},
+                        'targets': {'wheel': {'versions': ['standard']}},
                         'hooks': {'custom': {'path': DEFAULT_BUILD_SCRIPT}},
                     },
                 },
@@ -1675,7 +1675,7 @@ class TestBuildStandard:
                 'hatch': {
                     'version': {'path': 'my_app/__about__.py'},
                     'build': {
-                        'targets': {'wheel': {'versions': ['standard'], 'macos-max-compat': False}},
+                        'targets': {'wheel': {'versions': ['standard']}},
                         'hooks': {'custom': {'path': DEFAULT_BUILD_SCRIPT}},
                     },
                 },
@@ -1761,7 +1761,7 @@ class TestBuildStandard:
                 'hatch': {
                     'version': {'path': 'my_app/__about__.py'},
                     'build': {
-                        'targets': {'wheel': {'versions': ['standard'], 'macos-max-compat': False}},
+                        'targets': {'wheel': {'versions': ['standard']}},
                         'hooks': {'custom': {'path': DEFAULT_BUILD_SCRIPT}},
                     },
                 },
@@ -1842,7 +1842,7 @@ class TestBuildStandard:
                 'hatch': {
                     'version': {'path': 'src/my_app/__about__.py'},
                     'build': {
-                        'targets': {'wheel': {'versions': ['standard'], 'macos-max-compat': False}},
+                        'targets': {'wheel': {'versions': ['standard']}},
                         'hooks': {'custom': {'path': DEFAULT_BUILD_SCRIPT}},
                     },
                 },
@@ -2430,7 +2430,7 @@ class TestBuildStandard:
                 'hatch': {
                     'version': {'path': 'my_app/__about__.py'},
                     'build': {
-                        'targets': {'wheel': {'versions': ['standard'], 'macos-max-compat': False}},
+                        'targets': {'wheel': {'versions': ['standard']}},
                         'artifacts': ['my_app/lib.so'],
                         'hooks': {'custom': {'path': DEFAULT_BUILD_SCRIPT}},
                     },
@@ -3575,7 +3575,7 @@ class TestBuildStandard:
                 'hatch': {
                     'version': {'path': 'my_app/__about__.py'},
                     'build': {
-                        'targets': {'wheel': {'versions': ['standard'], 'macos-max-compat': False}},
+                        'targets': {'wheel': {'versions': ['standard']}},
                         'artifacts': ['my_app/lib.so'],
                         'hooks': {'custom': {'path': DEFAULT_BUILD_SCRIPT}},
                     },
@@ -3619,7 +3619,8 @@ class TestBuildStandard:
         helpers.assert_files(extraction_directory, expected_files)
 
     @pytest.mark.requires_macos
-    def test_macos_max_compat(self, hatch, helpers, temp_dir, config_file):
+    @pytest.mark.parametrize('macos_max_compat', [True, False])
+    def test_macos_max_compat(self, hatch, helpers, temp_dir, config_file, macos_max_compat):
         config_file.model.template.plugins['default']['src-layout'] = False
         config_file.save()
 
@@ -3660,7 +3661,7 @@ class TestBuildStandard:
                 'hatch': {
                     'version': {'path': 'my_app/__about__.py'},
                     'build': {
-                        'targets': {'wheel': {'versions': ['standard']}},
+                        'targets': {'wheel': {'versions': ['standard'], 'macos-max-compat': macos_max_compat}},
                         'artifacts': ['my_app/lib.so'],
                         'hooks': {'custom': {'path': DEFAULT_BUILD_SCRIPT}},
                     },
@@ -3684,6 +3685,10 @@ class TestBuildStandard:
 
         tag = next(sys_tags())
         tag_parts = [tag.interpreter, tag.abi, tag.platform]
+        if macos_max_compat:
+            sdk_version_major, sdk_version_minor = tag_parts[2].split('_')[1:3]
+            if int(sdk_version_major) >= 11:
+                tag_parts[2] = tag_parts[2].replace(f'{sdk_version_major}_{sdk_version_minor}', '10_16', 1)
 
         expected_tag = '-'.join(tag_parts)
         assert expected_artifact == str(build_path / f'{builder.project_id}-{expected_tag}.whl')


### PR DESCRIPTION
Users cannot get macOS 12+ as a minimum with this forcing 10.16.

I'd like to make https://github.com/pypa/hatch/issues/1445 a followup, as users might need to target an older macOS than the one they are running (cibuildwheel always does this, for example).