### PR TITLE
Add support for context formatting in builder dependencies.

### DIFF
--- a/backend/src/hatchling/builders/config.py
+++ b/backend/src/hatchling/builders/config.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from collections.abc import Generator
 
     from hatchling.builders.plugin.interface import BuilderInterface
+    from hatchling.utils.context import Context
 
 
 class BuilderConfig:
@@ -61,6 +62,10 @@ class BuilderConfig:
     @property
     def target_config(self) -> dict[str, Any]:
         return self.__target_config
+
+    @property
+    def context(self) -> Context:
+        return self.__builder.metadata.context
 
     def include_path(self, relative_path: str, *, explicit: bool = False, is_package: bool = True) -> bool:
         return (
@@ -500,7 +505,7 @@ class BuilderConfig:
                 )
                 raise TypeError(message)
 
-            dependencies[dependency] = None
+            dependencies[self.context.format(dependency)] = None
 
         global_dependencies = self.build_config.get("dependencies", [])
         if not isinstance(global_dependencies, list):
@@ -512,7 +517,7 @@ class BuilderConfig:
                 message = f"Dependency #{i} of field `tool.hatch.build.dependencies` must be a string"
                 raise TypeError(message)
 
-            dependencies[dependency] = None
+            dependencies[self.context.format(dependency)] = None
 
         require_runtime_dependencies = self.require_runtime_dependencies
         require_runtime_features = dict.fromkeys(self.require_runtime_features)
@@ -565,7 +570,7 @@ class BuilderConfig:
                     message = f"Dependency #{i} of option `dependencies` of build hook `{hook_name}` must be a string"
                     raise TypeError(message)
 
-                dependencies[dependency] = None
+                dependencies[self.context.format(dependency)] = None
 
         if require_runtime_dependencies:
             for dependency in self.builder.metadata.core.dependencies:
@@ -583,7 +588,7 @@ class BuilderConfig:
 
     @cached_property
     def dynamic_dependencies(self) -> list[str]:
-        dependencies = []
+        dependencies: list[str] = []
         for hook_name, config in self.hook_config.items():
             build_hook_cls = self.builder.plugin_manager.build_hook.get(hook_name)
             if build_hook_cls is None:
@@ -598,7 +603,7 @@ class BuilderConfig:
             except ImportError:
                 continue
 
-            dependencies.extend(build_hook.dependencies())
+            dependencies.extend(map(self.context.format, build_hook.dependencies()))
 
         return dependencies
 

--- a/tests/backend/builders/test_config.py
+++ b/tests/backend/builders/test_config.py
@@ -62,6 +62,27 @@ class TestDirectory:
 
         assert builder.config.directory == absolute_path
 
+    def test_context_formatting(self, isolation, uri_slash_prefix):
+        absolute_path = str(isolation)
+        config = {
+            "tool": {
+                "hatch": {
+                    "build": {
+                        "dependencies": ["proj1 @ {root:uri}"],
+                        "targets": {"foo": {"dependencies": ["proj2 @ {root:uri}"]}},
+                    },
+                }
+            }
+        }
+        builder = MockBuilder(absolute_path, config=config)
+        builder.PLUGIN_NAME = "foo"
+
+        normalized_path = absolute_path.replace("\\", "/")
+        assert builder.config.dependencies == [
+            f"proj2 @ file:{uri_slash_prefix}{normalized_path}",
+            f"proj1 @ file:{uri_slash_prefix}{normalized_path}",
+        ]
+
 
 class TestSkipExcludedDirs:
     def test_default(self, isolation):


### PR DESCRIPTION
closes: #1199 

Hi @ofek !

Thanks for this great tool. I (like @oddfacade) want to be able to use local dependencies in my build configuration (for custom version schemes in setuptools_scm, which cannot directly import modules at the project root because they do not want to include the project root in the Python path during build; see my previous attempt to solve my problem in [PR](https://github.com/pypa/setuptools_scm/pull/863) to that project). This is my stab at a quick PR to enable support in Hatch for inserting a local module into the build environment, but I understand there is some discussion in #1331 about scaling back support for this context formatting, so if this is no longer desired feel free to reject it.

I have not added any unit tests yet, but feel free to suggest where and how many tests you think are required (or to simply add them if you prefer).