### PR TITLE
Add coverage options for hatch-test scripts

### DIFF
--- a/docs/config/internal/testing.md
+++ b/docs/config/internal/testing.md
@@ -60,6 +60,34 @@ You can also set the number of seconds to wait between retries by setting the `r
 retry-delay = 1
 ```
 
+### Coverage combine arguments
+
+You can define arguments for the coverage [combine](https://coverage.readthedocs.io/en/latest/cmd.html#cmd-combine) command by setting the `combine-args` option, which must be an array of strings. For example, if you wanted to keep the original coverage files so that they are not automatically deleted, you could set the following:
+
+```toml config-example
+[tool.hatch.envs.hatch-test]
+combine-args = ["--keep"]
+```
+
+### Coverage reporting style
+
+You can define the coverage [reporting](https://coverage.readthedocs.io/en/latest/cmd.html#reporting) style by setting the `reporting` option, which must be a string. For example, if you wanted to generate a report in the `html` style, you could set the following:
+
+```toml config-example
+[tool.hatch.envs.hatch-test]
+reporting = "html"
+```
+The default reporting style is `report`.
+
+### Coverage reporting arguments
+
+You can define arguments for the coverage [reporting style](#coverage-reporting-style) by setting the `reporting-args` option, which must be an array of strings. For example, if you wanted to show line numbers of statements in each module that were not executed, you could set the following:
+
+```toml config-example
+[tool.hatch.envs.hatch-test]
+reporting-args = ["--show-missing"]
+```
+
 ## Customize environment
 
 You can fully alter the behavior of the environment used by the [`test`](../../cli/reference.md#hatch-test) command.

--- a/src/hatch/cli/test/__init__.py
+++ b/src/hatch/cli/test/__init__.py
@@ -191,8 +191,12 @@ def test(
 
     if cover:
         for context in app.runner_context([selected_envs[0]]):
-            context.add_shell_command('cov-combine')
+            combine_args: list[str] = list(context.env.config.get('combine-args', []))
+            context.add_shell_command(['cov-combine', *combine_args])
 
         if not cover_quiet:
             for context in app.runner_context([selected_envs[0]]):
-                context.add_shell_command('cov-report')
+                reporting: str = context.env.config.get('reporting', 'report')
+                reporting_args: list[str] = list(context.env.config.get('reporting-args', []))
+                context.env_vars['HATCH_COV_REPORTING_STYLE'] = reporting
+                context.add_shell_command(['cov-report', *reporting_args])

--- a/src/hatch/env/internal/test.py
+++ b/src/hatch/env/internal/test.py
@@ -18,8 +18,8 @@ def get_default_config() -> dict[str, Any]:
         'scripts': {
             'run': 'pytest{env:HATCH_TEST_ARGS:} {args}',
             'run-cov': 'coverage run -m pytest{env:HATCH_TEST_ARGS:} {args}',
-            'cov-combine': 'coverage combine',
-            'cov-report': 'coverage report',
+            'cov-combine': 'coverage combine {args}',
+            'cov-report': 'coverage {env:HATCH_COV_REPORTING_STYLE:} {args}',
         },
         'matrix': [{'python': ['3.12', '3.11', '3.10', '3.9', '3.8']}],
     }


### PR DESCRIPTION
It has been a very educational experience following the documentation of `hatch` to update my _setup.py_-style projects to follow the latest best-practices. Thank you @ofek for all the time you spend developing helpful tools.

This PR is in regards to the `hatch test` command that was added in version 1.10.0.

While converting a project that used the [coverage html](https://coverage.readthedocs.io/en/7.5.1/cmd.html#html-reporting-coverage-html) command, I needed to redefine all scripts in the `[envs.hatch-test.scripts]` table even though I used the default `run`, `run-cov` and `cov-combine` scripts, e.g.,

```toml
[envs.hatch-test.scripts]
run = "pytest{env:HATCH_TEST_ARGS:} {args}"   # default
run-cov = "coverage run -m pytest{env:HATCH_TEST_ARGS:} {args}"  # default
cov-combine = "coverage combine"  # default
cov-report = "coverage html"  # replaced 'report' with 'html'
```

This PR proposes that the following options may be defined in the `[envs.hatch-test]` table
* `combine-args`: array of strings, for the `cov-combine` script
* `reporting`: string, for the `cov-report` script
* `reporting-args`: array of strings, for the `cov-report` script

so that, for my particular use case, I could now define the `[envs.hatch-test]` table as

```toml
[envs.hatch-test]
reporting = "html"
```

Another example. Suppose someone wants to silence all messages from `coverage combine` and show the lines that were excluded in the tests when reporting
```toml
[envs.hatch-test]
combine-args = ["--quiet"]
reporting-args = ["--show-missing"]
```

Thanking you for any comments or suggestions you may have. No worries if this PR does not align with the way you want `hatch-test.scripts` to be used &dash; feel free to close it.