### PR TITLE
Use `:parent` instead of `../` to avoid dependency conflicts.

### DIFF
--- a/docs/config/dependency.md
+++ b/docs/config/dependency.md
@@ -234,7 +234,7 @@ The `<PATH>` can refer to a source archive, a wheel, or a directory containing a
 
     ```
     <NAME> @ {root:uri}/pkg_inside_project
-    <NAME> @ {root:uri}/../pkg_alongside_project
+    <NAME> @ {root:parent:uri}/pkg_alongside_project
     ```
 
 ### Remote


### PR DESCRIPTION
Tiny change that might help others avoid a small pain I ran into.

---

E.g.: I have projects ~/proj/top, ~/proj/mid, ~/proj/common.

If `mid/pyproject.toml` depends on `common @ {root:uri}/../common`,
and `top/pyproject.toml` depends on _both_ `mid @ {root:uri}/../mid` and `common @ {root:uri}/../common`, 
when installing `top`, `pip` will complain with a message like:

```console
The conflict is caused by:
    The user requested common 1.0.0 (from ~/proj/top/../common)
    mid 1.1.0 depends on common 1.0.0 (from ~/proj/mid/../common)
```

It would be nice if `pip` realized those were the same thing, but I can see why it thinks they conflict.

Using `:parent` pre-resolves the directory traversal and sidesteps the conflict.