### PR TITLE
Add force flag for project creation in non-empty directories

### DIFF
--- a/src/hatch/cli/new/__init__.py
+++ b/src/hatch/cli/new/__init__.py
@@ -7,9 +7,19 @@ import click
 @click.option('--interactive', '-i', 'interactive', is_flag=True, help='Interactively choose details about the project')
 @click.option('--cli', 'feature_cli', is_flag=True, help='Give the project a command line interface')
 @click.option('--init', 'initialize', is_flag=True, help='Initialize an existing project')
+@click.option(
+    '--force',
+    '-f',
+    is_flag=True,
+    help=(
+        'Force project creation if location is not empty. '
+        'Any pre-existing files that are also part of the project template will be overwritten. '
+        'Use with caution as it may lead to loss of data.'
+    ),
+)
 @click.option('-so', 'setuptools_options', multiple=True, hidden=True)
 @click.pass_obj
-def new(app, name, location, interactive, feature_cli, initialize, setuptools_options):
+def new(app, name, location, interactive, feature_cli, initialize, force, setuptools_options):
     """Create or initialize a project."""
     import sys
     from copy import deepcopy
@@ -46,7 +56,7 @@ def new(app, name, location, interactive, feature_cli, initialize, setuptools_op
     if location.is_file():
         app.abort(f'Path `{location}` points to a file.')
     elif location.is_dir() and any(location.iterdir()):
-        if not initialize:
+        if not initialize and not force:
             app.abort(f'Directory `{location}` is not empty.')
 
         needs_config_update = (location / 'pyproject.toml').is_file()

--- a/tests/cli/new/test_new.py
+++ b/tests/cli/new/test_new.py
@@ -1,6 +1,7 @@
 import pytest
 
 from hatch.config.constants import ConfigEnvVars
+from hatch.template import File
 
 
 def remove_trailing_spaces(text):
@@ -99,6 +100,35 @@ def test_default_explicit_path(hatch, helpers, temp_dir):
         └── __init__.py
         LICENSE.txt
         README.md
+        pyproject.toml
+        """
+    )
+
+
+def test_default_explicit_path_forced(hatch, helpers, temp_dir):
+    project_name = 'My.App'
+
+    with temp_dir.as_cwd():
+        path = temp_dir / 'foo'
+        path.touch()
+
+        result = hatch('new', project_name, '.', '-f')
+
+    expected_files = [*helpers.get_template_files('new.default', project_name), File('foo')]
+    helpers.assert_files(temp_dir, expected_files)
+
+    assert result.exit_code == 0, result.output
+    assert remove_trailing_spaces(result.output) == helpers.dedent(
+        """
+        src
+        └── my_app
+            ├── __about__.py
+            └── __init__.py
+        tests
+        └── __init__.py
+        LICENSE.txt
+        README.md
+        foo
         pyproject.toml
         """
     )


### PR DESCRIPTION
Resolves pypa/hatch#1485

Adds flag `-f --force` to `hatch new` and one respective test case.

![Screenshot 2024-05-17 at 20 58 04](https://github.com/pypa/hatch/assets/26580934/2476f80c-0a4f-465e-ba8e-4d0b461b4063)