### PR TITLE
[DRAFT] Add version to metadata hook, use version to retrieve deps

### DIFF
--- a/backend/src/hatchling/build.py
+++ b/backend/src/hatchling/build.py
@@ -30,8 +30,8 @@ def build_sdist(sdist_directory: str, config_settings: dict[str, Any] | None = N
     """
     from hatchling.builders.sdist import SdistBuilder
 
-    builder = SdistBuilder(os.getcwd())
-    return os.path.basename(next(builder.build(directory=sdist_directory, versions=['standard'])))
+    builder = SdistBuilder(os.getcwd(), versions=['standard'])
+    return os.path.basename(next(builder.build(directory=sdist_directory)))
 
 
 def get_requires_for_build_wheel(config_settings: dict[str, Any] | None = None) -> list[str]:  # noqa: ARG001
@@ -54,8 +54,8 @@ def build_wheel(
     """
     from hatchling.builders.wheel import WheelBuilder
 
-    builder = WheelBuilder(os.getcwd())
-    return os.path.basename(next(builder.build(directory=wheel_directory, versions=['standard'])))
+    builder = WheelBuilder(os.getcwd(), versions=['standard'])
+    return os.path.basename(next(builder.build(directory=wheel_directory)))
 
 
 def get_requires_for_build_editable(config_settings: dict[str, Any] | None = None) -> list[str]:  # noqa: ARG001
@@ -79,9 +79,8 @@ def build_editable(
     """
     from hatchling.builders.wheel import WheelBuilder
 
-    builder = WheelBuilder(os.getcwd())
-    return os.path.basename(next(builder.build(directory=wheel_directory, versions=['editable'])))
-
+    builder = WheelBuilder(os.getcwd(), versions=['editable'])
+    return os.path.basename(next(builder.build(directory=wheel_directory)))
 
 # Any builder that has build-time hooks like Hatchling and setuptools cannot technically keep PEP 517's identical
 # metadata promise e.g. C extensions would require different tags in the `WHEEL` file. Therefore, we consider the
@@ -106,8 +105,7 @@ if 'PIP_BUILD_TRACKER' not in os.environ:
         https://peps.python.org/pep-0517/#prepare-metadata-for-build-wheel
         """
         from hatchling.builders.wheel import WheelBuilder
-
-        builder = WheelBuilder(os.getcwd())
+        builder = WheelBuilder(os.getcwd(), versions=["standard"])
 
         directory = os.path.join(metadata_directory, f'{builder.artifact_project_id}.dist-info')
         if not os.path.isdir(directory):
@@ -128,7 +126,7 @@ if 'PIP_BUILD_TRACKER' not in os.environ:
         from hatchling.builders.constants import EDITABLES_REQUIREMENT
         from hatchling.builders.wheel import WheelBuilder
 
-        builder = WheelBuilder(os.getcwd())
+        builder = WheelBuilder(os.getcwd(), versions=['editable'])
 
         directory = os.path.join(metadata_directory, f'{builder.artifact_project_id}.dist-info')
         if not os.path.isdir(directory):

--- a/backend/src/hatchling/builders/plugin/interface.py
+++ b/backend/src/hatchling/builders/plugin/interface.py
@@ -60,6 +60,7 @@ class BuilderInterface(ABC, Generic[BuilderConfigBound, PluginManagerBound]):
         config: dict[str, Any] | None = None,
         metadata: ProjectMetadata | None = None,
         app: Application | None = None,
+        versions: list[str] | None = None,
     ) -> None:
         self.__root = root
         self.__plugin_manager = cast(PluginManagerBound, plugin_manager)
@@ -67,6 +68,7 @@ class BuilderInterface(ABC, Generic[BuilderConfigBound, PluginManagerBound]):
         self.__metadata = metadata
         self.__app = app
         self.__config = cast(BuilderConfigBound, None)
+        self.__versions = versions
         self.__project_config: dict[str, Any] | None = None
         self.__hatch_config: dict[str, Any] | None = None
         self.__build_config: dict[str, Any] | None = None
@@ -80,7 +82,6 @@ class BuilderInterface(ABC, Generic[BuilderConfigBound, PluginManagerBound]):
         self,
         *,
         directory: str | None = None,
-        versions: list[str] | None = None,
         hooks_only: bool | None = None,
         clean: bool | None = None,
         clean_hooks_after: bool | None = None,
@@ -101,7 +102,7 @@ class BuilderInterface(ABC, Generic[BuilderConfigBound, PluginManagerBound]):
 
         version_api = self.get_version_api()
 
-        versions = versions or self.config.versions
+        versions = self.__versions or self.config.versions
         if versions:
             unknown_versions = set(versions) - set(version_api)
             if unknown_versions:
@@ -290,8 +291,8 @@ class BuilderInterface(ABC, Generic[BuilderConfigBound, PluginManagerBound]):
         if self.__metadata is None:
             from hatchling.metadata.core import ProjectMetadata
 
-            self.__metadata = ProjectMetadata(self.root, self.plugin_manager, self.__raw_config)
-
+            self.__metadata = ProjectMetadata(self.root, self.plugin_manager, self.__raw_config,
+                                              self.__versions)
         return self.__metadata
 
     @property

--- a/backend/src/hatchling/builders/wheel.py
+++ b/backend/src/hatchling/builders/wheel.py
@@ -495,7 +495,6 @@ class WheelBuilder(BuilderInterface):
         from editables import EditableProject
 
         build_data['tag'] = self.get_default_tag()
-
         with WheelArchive(
             self.artifact_project_id, reproducible=self.config.reproducible
         ) as archive, RecordFile() as records:

--- a/backend/src/hatchling/cli/metadata/__init__.py
+++ b/backend/src/hatchling/cli/metadata/__init__.py
@@ -9,6 +9,7 @@ def metadata_impl(
     called_by_app: bool,  # noqa: ARG001
     field: str,
     compact: bool,
+    version: str = "standard",
 ) -> None:
     import json
     import os
@@ -22,7 +23,7 @@ def metadata_impl(
 
     root = os.getcwd()
     plugin_manager = PluginManager()
-    project_metadata = ProjectMetadata(root, plugin_manager)
+    project_metadata = ProjectMetadata(root, plugin_manager, build_versions=[version])
 
     metadata = resolve_metadata_fields(project_metadata)
     if field:  # no cov
@@ -55,4 +56,5 @@ def metadata_command(
     parser.add_argument('field', nargs='?')
     parser.add_argument('-c', '--compact', action='store_true')
     parser.add_argument('--app', dest='called_by_app', action='store_true', help=argparse.SUPPRESS)
+    parser.add_argument('--version', dest='version', default="standard")
     parser.set_defaults(func=metadata_impl)

--- a/backend/src/hatchling/metadata/plugin/interface.py
+++ b/backend/src/hatchling/metadata/plugin/interface.py
@@ -34,6 +34,7 @@ class MetadataHookInterface(ABC):  # no cov
     def __init__(self, root: str, config: dict) -> None:
         self.__root = root
         self.__config = config
+        self.__version: str = "standard"
 
     @property
     def root(self) -> str:
@@ -52,6 +53,20 @@ class MetadataHookInterface(ABC):  # no cov
         ```
         """
         return self.__config
+
+    @property
+    def version(self) -> str:
+        """
+        Gets the version of build (standard/editable) that is being run.
+        """
+        return self.__version
+
+    @version.setter
+    def version(self, version: str) -> None:
+        """
+        This sets the version of build (standard/editable) that is being run.
+        """
+        self.__version = version
 
     @abstractmethod
     def update(self, metadata: dict) -> None:

--- a/src/hatch/utils/dep.py
+++ b/src/hatch/utils/dep.py
@@ -58,7 +58,8 @@ def get_project_dependencies_complex(
         from packaging.requirements import Requirement
 
         with environment.root.as_cwd(), environment.build_environment(environment.metadata.build.requires):
-            command = ['python', '-u', '-W', 'ignore', '-m', 'hatchling', 'metadata', '--compact']
+            command = ['python', '-u', '-W', 'ignore', '-m', 'hatchling', 'metadata', '--compact',
+                       "--version", "editable" if environment.dev_mode else "standard"]
             output = environment.platform.check_command_output(
                 command,
                 # Only capture stdout


### PR DESCRIPTION
This is a very draft proposal on how to fix https://github.com/pypa/hatch/issues/1348 and https://github.com/pypa/hatch/issues/1349 - more
to see if this is a good direction. It should likely be split to
two PRs (and of course tests and docs are needed):

* extending custom metadata plugin to allow passing version through
  hook's version property to distinguish standard and editable builds
  (also including extending the hatchling CLIs.

* adding version to CLI where hatch queries hatchling to include standard/
  editable version when querying for available dependencies.

Not all changes have been yet applied, this is more to check if
this is the right direction.
