### PR TITLE
Fix internal tests invoked from zsh shell

### DIFF
--- a/src/hatch/cli/application.py
+++ b/src/hatch/cli/application.py
@@ -11,7 +11,6 @@ from hatch.project.core import Project
 from hatch.utils.fs import Path
 from hatch.utils.platform import Platform
 from hatch.utils.runner import ExecutionContext
-from hatch.utils.shells import detect_shell
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -296,6 +295,8 @@ class Application(Terminal):
 
     @cached_property
     def shell_data(self) -> tuple[str, str]:
+        from hatch.utils.shells import detect_shell
+
         return detect_shell(self.platform)
 
     @cached_property

--- a/src/hatch/cli/application.py
+++ b/src/hatch/cli/application.py
@@ -11,6 +11,7 @@ from hatch.project.core import Project
 from hatch.utils.fs import Path
 from hatch.utils.platform import Platform
 from hatch.utils.runner import ExecutionContext
+from hatch.utils.shells import detect_shell
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -295,13 +296,7 @@ class Application(Terminal):
 
     @cached_property
     def shell_data(self) -> tuple[str, str]:
-        import shellingham
-
-        try:
-            return shellingham.detect_shell()
-        except shellingham.ShellDetectionFailure:
-            path = self.platform.default_shell
-            return Path(path).stem, path
+        return detect_shell(self.platform)
 
     @cached_property
     def env_metadata(self) -> EnvironmentMetadata:

--- a/src/hatch/cli/python/install.py
+++ b/src/hatch/cli/python/install.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 
 import click
 
+from hatch.utils.shells import get_shell_names
+
 if TYPE_CHECKING:
     from hatch.cli.application import Application
 
@@ -41,10 +43,7 @@ def install(app: Application, *, names: tuple[str, ...], private: bool, update: 
     from hatch.python.distributions import ORDERED_DISTRIBUTIONS
     from hatch.python.resolve import get_distribution
 
-    shells = []
-    if not private and not app.platform.windows:
-        shell_name, _ = app.shell_data
-        shells.append(shell_name)
+    shells = get_shell_names(app.shell_data, app.platform, private=private)
 
     manager = app.get_python_manager(directory)
     installed = manager.get_installed()

--- a/src/hatch/cli/python/install.py
+++ b/src/hatch/cli/python/install.py
@@ -4,8 +4,6 @@ from typing import TYPE_CHECKING
 
 import click
 
-from hatch.utils.shells import get_shell_names
-
 if TYPE_CHECKING:
     from hatch.cli.application import Application
 
@@ -43,7 +41,10 @@ def install(app: Application, *, names: tuple[str, ...], private: bool, update: 
     from hatch.python.distributions import ORDERED_DISTRIBUTIONS
     from hatch.python.resolve import get_distribution
 
-    shells = get_shell_names(app.shell_data, app.platform, private=private)
+    shells = []
+    if not private and not app.platform.windows:
+        shell_name, _ = app.shell_data
+        shells.append(shell_name)
 
     manager = app.get_python_manager(directory)
     installed = manager.get_installed()

--- a/src/hatch/utils/shells.py
+++ b/src/hatch/utils/shells.py
@@ -8,16 +8,12 @@ from hatch.utils.fs import Path
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
     from types import FrameType
-    from typing import TypeAlias
 
     from hatch.env.plugin.interface import EnvironmentInterface
     from hatch.utils.platform import Platform
 
 
-Shell: TypeAlias = tuple[str, str]
-
-
-def detect_shell(platform: Platform) -> Shell:
+def detect_shell(platform: Platform) -> tuple[str, str]:
     import shellingham
 
     try:
@@ -25,13 +21,6 @@ def detect_shell(platform: Platform) -> Shell:
     except shellingham.ShellDetectionFailure:
         path = platform.default_shell
         return Path(path).stem, path
-
-
-def get_shell_names(shell: Shell, platform: Platform, *, private: bool = False) -> list[str]:
-    shells = []
-    if not private and not platform.windows:
-        shells.append(shell[0])
-    return shells
 
 
 class ShellManager:

--- a/src/hatch/utils/shells.py
+++ b/src/hatch/utils/shells.py
@@ -3,12 +3,35 @@ from __future__ import annotations
 import sys
 from typing import TYPE_CHECKING
 
+from hatch.utils.fs import Path
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
     from types import FrameType
+    from typing import TypeAlias
 
     from hatch.env.plugin.interface import EnvironmentInterface
-    from hatch.utils.fs import Path
+    from hatch.utils.platform import Platform
+
+
+Shell: TypeAlias = tuple[str, str]
+
+
+def detect_shell(platform: Platform) -> Shell:
+    import shellingham
+
+    try:
+        return shellingham.detect_shell()
+    except shellingham.ShellDetectionFailure:
+        path = platform.default_shell
+        return Path(path).stem, path
+
+
+def get_shell_names(shell: Shell, platform: Platform, *, private: bool = False) -> list[str]:
+    shells = []
+    if not private and not platform.windows:
+        shells.append(shell[0])
+    return shells
 
 
 class ShellManager:

--- a/tests/cli/python/conftest.py
+++ b/tests/cli/python/conftest.py
@@ -2,13 +2,12 @@ import secrets
 
 import pytest
 
-from hatch.utils.shells import detect_shell, get_shell_names
+from hatch.utils.shells import detect_shell
 
 
 @pytest.fixture(autouse=True)
 def default_shells(platform):
-    shell = detect_shell(platform)
-    return get_shell_names(shell, platform)
+    return [] if platform.windows else detect_shell(platform)[0]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/cli/python/conftest.py
+++ b/tests/cli/python/conftest.py
@@ -2,10 +2,13 @@ import secrets
 
 import pytest
 
+from hatch.utils.shells import detect_shell, get_shell_names
+
 
 @pytest.fixture(autouse=True)
 def default_shells(platform):
-    return [] if platform.windows else ['sh']
+    shell = detect_shell(platform)
+    return get_shell_names(shell, platform)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/cli/python/conftest.py
+++ b/tests/cli/python/conftest.py
@@ -7,7 +7,7 @@ from hatch.utils.shells import detect_shell
 
 @pytest.fixture(autouse=True)
 def default_shells(platform):
-    return [] if platform.windows else detect_shell(platform)[0]
+    return [] if platform.windows else [detect_shell(platform)[0]]
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Before this fix some of the internal hatch tests were failing when invoked from zsh shell. This change updates the test fixture to use the same shell detection mechanism as in the actual hatch code.

One of the test errors before the fix:

```
E       AssertionError: expected call not found.
E       Expected: append('/private/var/folders/q3/s01nm0vn50n3696zg_w711yr0000gn/T/tmpuovbeire/data/pythons/pypy3.9/pypy3.9-v6.3.15-macos_arm64/bin', shells=['sh'])
E         Actual: append('/private/var/folders/q3/s01nm0vn50n3696zg_w711yr0000gn/T/tmpuovbeire/data/pythons/pypy3.9/pypy3.9-v6.3.15-macos_arm64/bin', shells=['zsh'])
E
E       pytest introspection follows:
E
E       Kwargs:
E       assert {'shells': ['zsh']} == {'shells': ['sh']}
E
E         Differing items:
E         {'shells': ['zsh']} != {'shells': ['sh']}
E         Use -v to get more diff
```