### PR TITLE
Fix syntax highlighting contrast for the `config show` command

### DIFF
--- a/docs/history/hatch.md
+++ b/docs/history/hatch.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - The `fmt` command no longer hides the commands that are being executed
 - Add default timeout for network requests, useful when installing Python distributions
+- Fix syntax highlighting contrast for the `config show` command
 
 ## [1.11.1](https://github.com/pypa/hatch/releases/tag/hatch-v1.11.1) - 2024-05-23 ## {: #hatch-v1.11.1 }
 

--- a/src/hatch/cli/config/__init__.py
+++ b/src/hatch/cli/config/__init__.py
@@ -30,10 +30,8 @@ def show(app, all_keys):
     if not app.config_file.path.is_file():  # no cov
         app.display_critical('No config file found! Please try `hatch config restore`.')
     else:
-        from rich.syntax import Syntax
-
         text = app.config_file.read() if all_keys else app.config_file.read_scrubbed()
-        app.output(Syntax(text.rstrip(), 'toml', background_color='default'))
+        app.display_syntax(text.rstrip(), 'toml')
 
 
 @config.command(short_help='Update the config file with any new fields')

--- a/src/hatch/cli/terminal.py
+++ b/src/hatch/cli/terminal.py
@@ -134,6 +134,9 @@ class BorrowedStatus(TerminalStatus):
 
 class Terminal:
     def __init__(self, *, verbosity: int, enable_color: bool | None, interactive: bool | None):
+        # Force consistent output for test assertions
+        self.testing = 'HATCH_SELF_TESTING' in os.environ
+
         self.verbosity = verbosity
         self.console = Console(
             force_terminal=enable_color,
@@ -142,8 +145,7 @@ class Terminal:
             markup=False,
             emoji=False,
             highlight=False,
-            # Force consistent output for test assertions
-            legacy_windows=False if 'HATCH_SELF_TESTING' in os.environ else None,
+            legacy_windows=False if self.testing else None,
         )
 
         # Set defaults so we can pretty print before loading user config
@@ -275,6 +277,12 @@ class Terminal:
 
     def display_header(self, title=''):
         self.console.rule(Text(title, self._style_level_success))
+
+    def display_syntax(self, *args, **kwargs):
+        from rich.syntax import Syntax
+
+        kwargs.setdefault('background_color', 'default' if self.testing else None)
+        self.output(Syntax(*args, **kwargs))
 
     def display_markdown(self, text, **kwargs):  # no cov
         from rich.markdown import Markdown


### PR DESCRIPTION
Resolves https://github.com/pypa/hatch/issues/1465