### PR TITLE
Normalize local requirements when creating a wheel or sdist

### DIFF
--- a/backend/src/hatchling/builders/sdist.py
+++ b/backend/src/hatchling/builders/sdist.py
@@ -189,7 +189,9 @@ class SdistBuilder(BuilderInterface):
                     archive.addfile(tar_info)
 
             archive.create_file(
-                self.config.core_metadata_constructor(self.metadata, extra_dependencies=build_data['dependencies']),
+                self.config.core_metadata_constructor(self.metadata,
+                                                      extra_dependencies=build_data['dependencies'],
+                                                      normalize_requirement=self.releasable_requirement),
                 'PKG-INFO',
             )
 

--- a/backend/src/hatchling/builders/wheel.py
+++ b/backend/src/hatchling/builders/wheel.py
@@ -701,7 +701,9 @@ Root-Is-Purelib: {'true' if build_data['pure_python'] else 'false'}
         self, archive: WheelArchive, records: RecordFile, extra_dependencies: Sequence[str] = ()
     ) -> None:
         record = archive.write_metadata(
-            'METADATA', self.config.core_metadata_constructor(self.metadata, extra_dependencies=extra_dependencies)
+            'METADATA', self.config.core_metadata_constructor(self.metadata,
+                                                              extra_dependencies=extra_dependencies,
+                                                              normalize_requirement=self.releasable_requirement)
         )
         records.write(record)
 

--- a/backend/src/hatchling/metadata/spec.py
+++ b/backend/src/hatchling/metadata/spec.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Optional
+
+from packaging.requirements import Requirement
 
 if TYPE_CHECKING:
     from hatchling.metadata.core import ProjectMetadata
@@ -196,7 +198,8 @@ def project_metadata_from_core_metadata(core_metadata: str) -> dict[str, Any]:
     return metadata
 
 
-def construct_metadata_file_1_2(metadata: ProjectMetadata, extra_dependencies: tuple[str] | None = None) -> str:
+def construct_metadata_file_1_2(metadata: ProjectMetadata, extra_dependencies: tuple[str] | None = None,
+                                normalize_requirement: Optional[Callable[[Requirement], Requirement]] = None) -> str:
     """
     https://peps.python.org/pep-0345/
     """
@@ -244,8 +247,12 @@ def construct_metadata_file_1_2(metadata: ProjectMetadata, extra_dependencies: t
     if metadata.core.requires_python:
         metadata_file += f'Requires-Python: {metadata.core.requires_python}\n'
 
-    if metadata.core.dependencies:
-        for dependency in metadata.core.dependencies:
+    if metadata.core.dependencies_complex:
+        for dependency, req in metadata.core.dependencies_complex.items():
+            if normalize_requirement:
+                new_req = normalize_requirement(req)
+                if new_req is not req:
+                    dependency = str(new_req)
             metadata_file += f'Requires-Dist: {dependency}\n'
 
     if extra_dependencies:
@@ -255,7 +262,8 @@ def construct_metadata_file_1_2(metadata: ProjectMetadata, extra_dependencies: t
     return metadata_file
 
 
-def construct_metadata_file_2_1(metadata: ProjectMetadata, extra_dependencies: tuple[str] | None = None) -> str:
+def construct_metadata_file_2_1(metadata: ProjectMetadata, extra_dependencies: tuple[str] | None = None,
+                                normalize_requirement: Optional[Callable[[Requirement], Requirement]] = None) -> str:
     """
     https://peps.python.org/pep-0566/
     """
@@ -310,8 +318,12 @@ def construct_metadata_file_2_1(metadata: ProjectMetadata, extra_dependencies: t
     if metadata.core.requires_python:
         metadata_file += f'Requires-Python: {metadata.core.requires_python}\n'
 
-    if metadata.core.dependencies:
-        for dependency in metadata.core.dependencies:
+    if metadata.core.dependencies_complex:
+        for dependency, req in metadata.core.dependencies_complex.items():
+            if normalize_requirement:
+                new_req = normalize_requirement(req)
+                if new_req is not req:
+                    dependency = str(new_req)
             metadata_file += f'Requires-Dist: {dependency}\n'
 
     if extra_dependencies:
@@ -337,7 +349,8 @@ def construct_metadata_file_2_1(metadata: ProjectMetadata, extra_dependencies: t
     return metadata_file
 
 
-def construct_metadata_file_2_2(metadata: ProjectMetadata, extra_dependencies: tuple[str] | None = None) -> str:
+def construct_metadata_file_2_2(metadata: ProjectMetadata, extra_dependencies: tuple[str] | None = None,
+                                normalize_requirement: Optional[Callable[[Requirement], Requirement]] = None) -> str:
     """
     https://peps.python.org/pep-0643/
     """
@@ -401,8 +414,12 @@ def construct_metadata_file_2_2(metadata: ProjectMetadata, extra_dependencies: t
     if metadata.core.requires_python:
         metadata_file += f'Requires-Python: {metadata.core.requires_python}\n'
 
-    if metadata.core.dependencies:
-        for dependency in metadata.core.dependencies:
+    if metadata.core.dependencies_complex:
+        for dependency, req in metadata.core.dependencies_complex.items():
+            if normalize_requirement:
+                new_req = normalize_requirement(req)
+                if new_req is not req:
+                    dependency = str(new_req)
             metadata_file += f'Requires-Dist: {dependency}\n'
 
     if extra_dependencies:
@@ -428,7 +445,8 @@ def construct_metadata_file_2_2(metadata: ProjectMetadata, extra_dependencies: t
     return metadata_file
 
 
-def construct_metadata_file_2_3(metadata: ProjectMetadata, extra_dependencies: tuple[str] | None = None) -> str:
+def construct_metadata_file_2_3(metadata: ProjectMetadata, extra_dependencies: tuple[str] | None = None,
+                                normalize_requirement: Optional[Callable[[Requirement], Requirement]] = None) -> str:
     """
     https://peps.python.org/pep-0639/
     """
@@ -492,8 +510,12 @@ def construct_metadata_file_2_3(metadata: ProjectMetadata, extra_dependencies: t
     if metadata.core.requires_python:
         metadata_file += f'Requires-Python: {metadata.core.requires_python}\n'
 
-    if metadata.core.dependencies:
-        for dependency in metadata.core.dependencies:
+    if metadata.core.dependencies_complex:
+        for dependency, req in metadata.core.dependencies_complex.items():
+            if normalize_requirement:
+                new_req = normalize_requirement(req)
+                if new_req is not req:
+                    dependency = str(new_req)
             metadata_file += f'Requires-Dist: {dependency}\n'
 
     if extra_dependencies:


### PR DESCRIPTION
When building a wheel or a source distribution local source dependencies like `my_lib @ ../my_lib` will be converted to regular dependencies like `my_lib == 1.0.0`.

This would make it easier to release multiple inter-dependent libraries