### PR TITLE
fix: show what has changed when running hatch fmt

### DIFF
--- a/src/hatch/env/internal/static_analysis.py
+++ b/src/hatch/env/internal/static_analysis.py
@@ -12,7 +12,7 @@ def get_default_config() -> dict[str, Any]:
             'format-check': 'ruff format{env:HATCH_FMT_ARGS:} --check --diff {args:.}',
             'format-fix': 'ruff format{env:HATCH_FMT_ARGS:} {args:.}',
             'lint-check': 'ruff check{env:HATCH_FMT_ARGS:} {args:.}',
-            'lint-fix': 'ruff check{env:HATCH_FMT_ARGS:} --fix {args:.}',
+            'lint-fix': 'ruff check{env:HATCH_FMT_ARGS:} --fix --show-fixes {args:.}',
         },
     }
 


### PR DESCRIPTION
For some reason, Ruff just makes changes without telling the user why it's changing things by default. Adding `--show-fixes` prints a nice summary of what's changed.