### PR TITLE
Prevent matching bogus parent gitignores

### DIFF
--- a/backend/src/hatchling/builders/config.py
+++ b/backend/src/hatchling/builders/config.py
@@ -883,6 +883,11 @@ class BuilderConfig:
                     if glob_mode:
                         patterns.append(line)
 
+        # validate project root is not excluded by vcs
+        exclude_spec = pathspec.GitIgnoreSpec.from_lines(patterns)
+        if exclude_spec.match_file(self.root):
+            return []
+
         return patterns
 
     def normalize_build_directory(self, build_directory: str) -> str:

--- a/backend/src/hatchling/builders/config.py
+++ b/backend/src/hatchling/builders/config.py
@@ -788,7 +788,7 @@ class BuilderConfig:
         # validate project root is not excluded by vcs
         exclude_spec = pathspec.GitIgnoreSpec.from_lines(patterns)
         if exclude_spec.match_file(self.root):
-            return []
+            return patterns
 
         return patterns
 


### PR DESCRIPTION
If our project root directory is matched by an exclude pattern we should assume the pattern is invalid as our project root is likely in an ignored build directory of another project.

Should fix: #1641

This is essentially a port of the same technique I [used to fix a similar poetry core bug](https://github.com/python-poetry/poetry-core/pull/611).