### PR TITLE
feat: add more settings in interactive mode

### DIFF
--- a/src/hatch/cli/new/__init__.py
+++ b/src/hatch/cli/new/__init__.py
@@ -70,6 +70,7 @@ def new(app, name, location, interactive, feature_cli, initialize, setuptools_op
 
     default_config = {
         'description': '',
+        'name': '',
         'dependencies': set(),
         'package_name': normalized_name.replace('-', '_'),
         'project_name': name,
@@ -79,7 +80,8 @@ def new(app, name, location, interactive, feature_cli, initialize, setuptools_op
 
     if interactive:
         default_config['description'] = app.prompt('Description', default='')
-
+        default_config['name'] = app.prompt('Author Name', default='U.N Owen')
+        
         app.display_info()
 
     if needs_config_update:

--- a/src/hatch/cli/new/__init__.py
+++ b/src/hatch/cli/new/__init__.py
@@ -71,6 +71,7 @@ def new(app, name, location, interactive, feature_cli, initialize, setuptools_op
     default_config = {
         'description': '',
         'name': '',
+        'email': '',
         'dependencies': set(),
         'package_name': normalized_name.replace('-', '_'),
         'project_name': name,
@@ -81,7 +82,8 @@ def new(app, name, location, interactive, feature_cli, initialize, setuptools_op
     if interactive:
         default_config['description'] = app.prompt('Description', default='')
         default_config['name'] = app.prompt('Author Name', default='U.N Owen')
-        
+        default_config['email'] = app.prompt('Author Email', default='void@some.where')
+
         app.display_info()
 
     if needs_config_update:


### PR DESCRIPTION
Closes #1655

Is this the correct way to update the config files? The author name and email field are come from template_config (https://github.com/pypa/hatch/blob/7c8dbbcf66299efe4039b9d7b1d02b17b707aab7/src/hatch/cli/new/__init__.py#L90C1-L90C61) should I update template_config instead of adding a field in the default config?
Also do you have any ideas how to create a license file based on user input?



