### PR TITLE
docs: fix outdated `hatch run` commands

### DIFF
--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -23,13 +23,13 @@ git checkout -b add-my-contribution
 Run the test suite while developing:
 
 ```bash
-hatch run dev
+hatch test
 ```
 
 Run the test suite with coverage report:
 
 ```bash
-hatch run cov
+hatch test --cover
 ```
 
 Run the extended test suite with coverage:
@@ -43,13 +43,13 @@ hatch run full
 Run automated formatting:
 
 ```bash
-hatch run lint:fmt
+hatch fmt --formatter
 ```
 
 Run full linting and type checking:
 
 ```bash
-hatch run lint:all
+hatch fmt
 ```
 
 ## Docs


### PR DESCRIPTION
Fixes #1657

Equivalent to the `hatch run` commands, but `hatch run full` is implemented. I checked version 1.7.0 of Hatch and find out that `hatch run full` script runs `pytest --cov --cov-report={env:COVERAGE_REPORT:term-missing} --cov-config=pyproject.toml -n auto --reruns 5 --reruns-delay 3 -r aR {args:tests}` (https://github.com/pypa/hatch/blob/46a2118ba39c00ca102cf463bdc829301402d05b/hatch.toml#L20C1-L23C69). I didn't figure out what is the equivalent of the `hatch run full` script. Do you have any idea?

