### PR TITLE
Remove redundant licence definition

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -8,7 +8,6 @@ name = "hatchling"
 dynamic = ["version"]
 description = "Modern, extensible Python build backend"
 readme = "README.md"
-license = "MIT"
 requires-python = ">=3.8"
 keywords = [
   "build",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ build-backend = "hatchling.build"
 name = "hatch"
 description = "Modern, extensible Python project management"
 readme = "README.md"
-license = "MIT"
 requires-python = ">=3.8"
 keywords = [
   "build",


### PR DESCRIPTION
Drop the licence key, keep the licence classifier.

From the [Python Packaging User Guide](https://packaging.python.org/):
> ### `license`
> 
> This can take two forms. You can put your license in a file, typically `LICENSE` or `LICENSE.txt`, and link that file here:
> ```toml
> [project]
> license = {file = "LICENSE"}
> ```
> or you can write the name of the license:
> ```toml
> [project]
> license = {text = "MIT License"}
> ```
> If you are using a standard, well-known license, it is not necessary to use this field. Instead, you should use one of the [classifiers](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#classifiers) starting with `License ::`.