### PR TITLE
CI: Add Python 3.13 test jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4
@@ -33,6 +33,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
 
     - name: Install UV
       run: curl -LsSf https://github.com/astral-sh/uv/releases/latest/download/uv-installer.sh | sh
@@ -114,7 +115,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4
@@ -123,6 +124,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
 
     - name: Install tools
       run: pip install --upgrade -r backend/tests/downstream/requirements.txt


### PR DESCRIPTION
Enable Python 3.13 testing in the GitHub Action workflows by adding 3.13 jobs to the test matrices.

Python 3.13 is now in [release candidate](https://www.python.org/downloads/release/python-3130rc1/) phase and ABI stable.