### PR TITLE
Use `include-hidden-files: true` to upload coverage artifacts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,7 @@ jobs:
     - name: Upload coverage data
       uses: actions/upload-artifact@v4
       with:
+        include-hidden-files: true
         name: coverage-${{ matrix.os }}-${{ matrix.python-version }}
         path: .coverage*
 


### PR DESCRIPTION
Version [v4.4.0](https://github.com/actions/upload-artifact/releases/tag/v4.4.0) of actions/upload-artifact broke uploading (silently) and combining coverage files.
