### PR TITLE
Add codespell support (config, workflow to detect/not fix) 

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,3 +132,10 @@ exclude_lines = [
   "if __name__ == .__main__.:",
   "if TYPE_CHECKING:",
 ]
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*,*.svg,venv,*.css'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,5 +137,5 @@ exclude_lines = [
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
 skip = '.git*,*.svg,venv,*.css'
 check-hidden = true
-# ignore-regex = ''
+ignore-regex = '\baNULL\b'
 # ignore-words-list = ''


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .  It was already used but not automated for CI etc e.g. in
- #1479

and congrats as no new typos were found.

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

Feel free to close (I found no other similar PR in the past so suggested)