### PR TITLE
Fix failing test due to unsorted iterdir

### DIFF
--- a/tests/cli/env/test_create.py
+++ b/tests/cli/env/test_create.py
@@ -1560,12 +1560,10 @@ def test_sync_dynamic_dependencies(hatch, helpers, temp_dir, platform, uv_on_pat
     storage_path = storage_dirs[0]
     assert len(storage_path.name) == 8
 
-    env_dirs = list(storage_path.iterdir())
-    assert len(env_dirs) == 2
+    env_dirs = sorted(storage_path.iterdir())
+    assert [d.name for d in env_dirs] == ['hatch-build', 'test']
 
     env_path = env_dirs[1]
-
-    assert env_path.name == 'test'
 
     with UVVirtualEnv(env_path, platform):
         output = platform.run_command([uv_on_path, 'pip', 'freeze'], check=True, capture_output=True).stdout.decode(


### PR DESCRIPTION
The tests are failing on `main` with:

```python
         env_dirs = list(storage_path.iterdir())
        assert len(env_dirs) == 2
    
        env_path = env_dirs[1]
    
>       assert env_path.name == 'test'
E       AssertionError: assert 'hatch-build' == 'test'
E         
E         - test
E         + hatch-build

/home/runner/work/hatch/hatch/tests/cli/env/test_create.py:1568: AssertionError
```

Not sure what triggered this (perhaps something on the runner changed?), and I couldn't reproduce it locally, but the result of `list(storage_path.iterdir())` was returning `['test', 'hatch-build']` instead of `['hatch-build', 'test']`. Indeed, the docstring of `iterdir` states:

> The children are yielded in arbitrary order

so technically the sort is needed, even if it normally comes out in alphabetical order.