### PR TITLE
Add pixi to excluded directories

### DIFF
--- a/backend/src/hatchling/builders/constants.py
+++ b/backend/src/hatchling/builders/constants.py
@@ -21,6 +21,8 @@ EXCLUDED_DIRECTORIES = frozenset((
     '.pytest_cache',
     # Mypy
     '.mypy_cache',
+    # pixi
+    '.pixi',
 ))
 EXCLUDED_FILES = frozenset((
     # https://en.wikipedia.org/wiki/.DS_Store


### PR DESCRIPTION
[Pixi](https://pixi.sh) is a recent tool that manages project-specific Conda environments. The environments are created in a cache directory named `.pixi/` under the project root. They should never be included in a Python distribution. For additional discussion, see
<https://github.com/prefix-dev/pixi/issues/2115#issuecomment-2379136870>