### PR TITLE
Add notes about the use of UV in hatch-test

### DIFF
--- a/docs/how-to/environment/dependency-resolution.md
+++ b/docs/how-to/environment/dependency-resolution.md
@@ -12,9 +12,15 @@ PIP_INDEX_URL = "https://token:{env:GITLAB_API_TOKEN}@gitlab.com/api/v4/groups/<
 PIP_EXTRA_INDEX_URL = "https://token:{env:GITLAB_API_TOKEN}@gitlab.com/api/v4/groups/<group2_path>/-/packages/pypi/simple/ https://pypi.org/simple/"
 ```
 
+Note that Hatch's *internal* environments, such as the `hatch-test`
+matrix used by the [`test` command](../../../cli/reference/#hatch-test),
+now use `uv`.  Therefore if you wish change their dependency
+resolution behaviour, you will need to also set the corresponding
+environment variables, as described below.
+
 ## UV
 
-If you're [using UV](select-installer.md), a different set of [environment variables](https://github.com/astral-sh/uv/tree/0.1.35#environment-variables) are available to configure its behavior. The previous example would look like this instead:
+ you're [using UV](select-installer.md), a different set of [environment variables](https://github.com/astral-sh/uv/tree/0.1.35#environment-variables) are available to configure its behavior. The previous example would look like this instead:
 
 ```toml config-example
 [tool.hatch.envs.default.env-vars]

--- a/src/hatch/cli/test/__init__.py
+++ b/src/hatch/cli/test/__init__.py
@@ -71,6 +71,12 @@ def test(
         The inclusion option is treated as an intersection while the exclusion option is treated as a
         union i.e. an environment must match all of the included variables to be selected while matching
         any of the excluded variables will prevent selection.
+    \b
+    !!! tip
+        The `hatch-test` matrix [uses UV](../../how-to/environment/select-installer) as its installer by
+        default.  If you wish to control dependency resolution for your tests (to use a custom or extra
+        PyPI index for instance), you must [set its specific environment
+        variables](../../how-to/environment/dependency-resolution#UV)
     """
     app: Application = ctx.obj
 


### PR DESCRIPTION
As mentioned in #1767 it isn't immediately obvious to the user of `hatch test` that it uses `uv` rather than the default `pip`, and in the case where you'd like to configure dependency resolution for the test enviroment (such as to download CPU-only versions of pytorch...) it's necessary to know this in order to get the right environment variables.

This adds a note to the dependency resolution page mentioning that `uv` is used for internal environments as well as a tip to the `hatch test` documentation mentioning how to configure its PyPI indexes.