### PR TITLE
Add a helpful snippet for using Hatch from Emacs

### DIFF
--- a/docs/how-to/integrate/emacs.md
+++ b/docs/how-to/integrate/emacs.md
@@ -1,0 +1,26 @@
+# How to use Hatch environments from Emacs
+
+-----
+
+The [pyvenv](https://github.com/jorgenschaefer/pyvenv) package is
+frequently used to manage virtual environments in Emacs (with
+[elpy](https://github.com/jorgenschaefer/elpy) for instance).  To make
+it easier to use with Hatch, you can add the following function to
+your `.emacs` to add the command `hatch-activate`, which works like
+`pyvenv-activate` but activates the default environment for the
+current directory:
+
+```lisp
+(require 'subr-x)
+(require 'pyvenv)
+(defun hatch-activate (directory)
+  "Activate the default hatch virtual environment for DIRECTORY"
+  (interactive (list (read-directory-name "Activate for project: ")))
+  (let ((expdir (expand-file-name directory))
+        (default-directory directory))
+    (let ((hatch-env
+           (string-trim
+            (shell-command-to-string "hatch env find"))))
+      (pyvenv-activate hatch-env)
+    )))
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -123,6 +123,7 @@ nav:
       - Report issues: how-to/meta/report-issues.md
     - Integrate:
       - Visual Studio Code: how-to/integrate/vscode.md
+      - Emacs: how-to/integrate/emacs.md
     - Run:
       - Python scripts: how-to/run/python-scripts.md
     - Config:


### PR DESCRIPTION
My sense is that `pyvenv` is still pretty widely used despite being apparently unmaintained.  So here's a helpful function for using it (since it is unlikely to get added to `pyvenv` itself).

If someone knows an alternative it would be cool to support Hatch directly in it too!