### PR TITLE
Return empty list if project root is ignored

### DIFF
--- a/backend/src/hatchling/builders/config.py
+++ b/backend/src/hatchling/builders/config.py
@@ -788,7 +788,7 @@ class BuilderConfig:
         # validate project root is not excluded by vcs
         exclude_spec = pathspec.GitIgnoreSpec.from_lines(patterns)
         if exclude_spec.match_file(self.root):
-            return patterns
+            return []
 
         return patterns
 


### PR DESCRIPTION
We need to return an empty list in the event the project root is ignored by a pattern as the project root being ignored means the ignore patterns are not valid for the project.

This got broken when merging #1643.