### PR TITLE
Back-populate string `license` fields

### DIFF
--- a/backend/src/hatchling/metadata/spec.py
+++ b/backend/src/hatchling/metadata/spec.py
@@ -234,6 +234,8 @@ def construct_metadata_file_1_2(metadata: ProjectMetadata, extra_dependencies: t
                 metadata_file += f'{line}\n'
             else:
                 metadata_file += f'{indent}{line}\n'
+    elif metadata.core.license_expression:
+        metadata_file += f'License: {metadata.core.license_expression}\n'
 
     if metadata.core.keywords:
         metadata_file += f"Keywords: {','.join(metadata.core.keywords)}\n"
@@ -293,13 +295,8 @@ def construct_metadata_file_2_1(metadata: ProjectMetadata, extra_dependencies: t
                 metadata_file += f'{line}\n'
             else:
                 metadata_file += f'{indent}{line}\n'
-
-    if metadata.core.license_expression:
-        metadata_file += f'License-Expression: {metadata.core.license_expression}\n'
-
-    if metadata.core.license_files:
-        for license_file in metadata.core.license_files:
-            metadata_file += f'License-File: {license_file}\n'
+    elif metadata.core.license_expression:
+        metadata_file += f'License: {metadata.core.license_expression}\n'
 
     if metadata.core.keywords:
         metadata_file += f"Keywords: {','.join(metadata.core.keywords)}\n"
@@ -384,13 +381,8 @@ def construct_metadata_file_2_2(metadata: ProjectMetadata, extra_dependencies: t
                 metadata_file += f'{line}\n'
             else:
                 metadata_file += f'{indent}{line}\n'
-
-    if metadata.core.license_expression:
-        metadata_file += f'License-Expression: {metadata.core.license_expression}\n'
-
-    if metadata.core.license_files:
-        for license_file in metadata.core.license_files:
-            metadata_file += f'License-File: {license_file}\n'
+    elif metadata.core.license_expression:
+        metadata_file += f'License: {metadata.core.license_expression}\n'
 
     if metadata.core.keywords:
         metadata_file += f"Keywords: {','.join(metadata.core.keywords)}\n"
@@ -475,6 +467,8 @@ def construct_metadata_file_2_3(metadata: ProjectMetadata, extra_dependencies: t
                 metadata_file += f'{line}\n'
             else:
                 metadata_file += f'{indent}{line}\n'
+    elif metadata.core.license_expression:
+        metadata_file += f'License: {metadata.core.license_expression}\n'
 
     if metadata.core.keywords:
         metadata_file += f"Keywords: {','.join(metadata.core.keywords)}\n"

--- a/docs/history/hatchling.md
+++ b/docs/history/hatchling.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Fixed:***
+
+- Back-populate string `license` fields (`License-Expression`) for core metadata versions prior to 2.4
+- Remove the `License-Expression` and `License-Files` core metadata from version 2.2 that was missed in the previous minor release
+
 ## [1.26.1](https://github.com/pypa/hatch/releases/tag/hatchling-v1.26.1) - 2024-11-10 ## {: #hatchling-v1.26.1 }
 
 ***Fixed:***

--- a/tests/backend/metadata/test_spec.py
+++ b/tests/backend/metadata/test_spec.py
@@ -419,6 +419,22 @@ class TestCoreMetadataV12:
             """
         )
 
+    def test_license_expression(self, constructor, isolation, helpers):
+        metadata = ProjectMetadata(
+            str(isolation),
+            None,
+            {'project': {'name': 'My.App', 'version': '0.1.0', 'license': 'mit'}},
+        )
+
+        assert constructor(metadata) == helpers.dedent(
+            """
+            Metadata-Version: 1.2
+            Name: My.App
+            Version: 0.1.0
+            License: MIT
+            """
+        )
+
     def test_keywords_single(self, constructor, isolation, helpers):
         metadata = ProjectMetadata(
             str(isolation), None, {'project': {'name': 'My.App', 'version': '0.1.0', 'keywords': ['foo']}}
@@ -762,7 +778,7 @@ class TestCoreMetadataV21:
             Metadata-Version: 2.1
             Name: My.App
             Version: 0.1.0
-            License-Expression: MIT
+            License: MIT
             """
         )
 
@@ -961,7 +977,6 @@ class TestCoreMetadataV21:
             Maintainer-email: foo <bar@domain>
             License: foo
                     bar
-            License-File: LICENSE.txt
             Keywords: bar,foo
             Classifier: Programming Language :: Python :: 3.9
             Classifier: Programming Language :: Python :: 3.11
@@ -1202,7 +1217,7 @@ class TestCoreMetadataV22:
             Metadata-Version: 2.2
             Name: My.App
             Version: 0.1.0
-            License-Expression: MIT
+            License: MIT
             """
         )
 
@@ -1431,7 +1446,6 @@ class TestCoreMetadataV22:
             Maintainer-email: foo <bar@domain>
             License: foo
                     bar
-            License-File: LICENSE.txt
             Keywords: bar,foo
             Classifier: Programming Language :: Python :: 3.9
             Classifier: Programming Language :: Python :: 3.11
@@ -1657,6 +1671,22 @@ class TestCoreMetadataV23:
             Version: 0.1.0
             License: foo
                     bar
+            """
+        )
+
+    def test_license_expression(self, constructor, isolation, helpers):
+        metadata = ProjectMetadata(
+            str(isolation),
+            None,
+            {'project': {'name': 'My.App', 'version': '0.1.0', 'license': 'mit'}},
+        )
+
+        assert constructor(metadata) == helpers.dedent(
+            """
+            Metadata-Version: 2.3
+            Name: My.App
+            Version: 0.1.0
+            License: MIT
             """
         )
 


### PR DESCRIPTION
Resolves https://github.com/pypa/hatch/issues/1804#issuecomment-2469360000

Also resolves https://github.com/squidfunk/mkdocs-material/pull/7692#issuecomment-2467579900 because metadata hooks shouldn't be called when there is nothing dynamic and therefore the population from `PKG-INFO` was lossy