### PR TITLE
fix: prefer `python3` over `python` when discovering the interpreter

### DIFF
--- a/src/hatch/env/plugin/interface.py
+++ b/src/hatch/env/plugin/interface.py
@@ -169,10 +169,11 @@ class EnvironmentInterface(ABC):
         if system_python == 'self':
             system_python = sys.executable
 
+        # Prefer `python3` over `python` in a system context. See PEP-394 for details.
         system_python = (
             system_python
-            or self.platform.modules.shutil.which('python')
             or self.platform.modules.shutil.which('python3')
+            or self.platform.modules.shutil.which('python')
             or sys.executable
         )
         if not isabs(system_python):
@@ -768,7 +769,18 @@ class EnvironmentInterface(ABC):
         A convenience method for constructing a [`pip install`](https://pip.pypa.io/en/stable/cli/pip_install/)
         command with the given verbosity. The default verbosity is set to one less than Hatch's verbosity.
         """
-        command = ['python', '-u', '-m', 'pip', 'install', '--disable-pip-version-check', '--no-python-version-warning']
+        # TODO: we should better use either `self.system_python` (in a system context) or `python` (in a virtual environment).
+        # Since we are called from `hatch.env.virtual` and `hatch.env.system`, we need to handle both contexts.
+        # According to PEP-394, `python3` should be a safe choice under all circumstances.
+        command = [
+            'python3',
+            '-u',
+            '-m',
+            'pip',
+            'install',
+            '--disable-pip-version-check',
+            '--no-python-version-warning',
+        ]
 
         # Default to -1 verbosity
         add_verbosity_flag(command, self.verbosity, adjustment=-1)

--- a/src/hatch/utils/env.py
+++ b/src/hatch/utils/env.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 
 class PythonInfo:
-    def __init__(self, platform: Platform, executable: str = 'python') -> None:
+    def __init__(self, platform: Platform, executable: str = 'python3') -> None:
         self.platform = platform
         self.executable = executable
 


### PR DESCRIPTION
Previously hatch used `python` as the default name of the interpreter. This was not in line with PEP-394 [1], since `python` is still allowed to point to a Python 2.x interpreter.
PEP-394 recommends to use `python3` in a system context and `python` in the context of a virtual environment.

This change should not affect existing setups, since `python3` is expected to exist under all circumstances (according to PEP-394).

The change will relieve users from the burden of adding `python = /usr/bin/python3` to their environment configuration for hatch in order to support setups, where a Python 2.x interpreter is reachable via `python` (as specified in PEP-394).

The other occurrences of `python` within hatch's code seem to be used within virtual environments (i.e. `python` is suitable here).

See #583

See #1820

[1] https://peps.python.org/pep-0394/