### PR TITLE
Add User-Agent header with Hatch, Python and HTTPX versions

### DIFF
--- a/src/hatch/index/core.py
+++ b/src/hatch/index/core.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING
 
 import hyperlink
 
+from hatch._version import __version__
+
 if TYPE_CHECKING:
     import httpx
 
@@ -47,11 +49,19 @@ class PackageIndex:
 
     @cached_property
     def client(self) -> httpx.Client:
+        import platform
+
         import httpx
 
         from hatch.utils.network import DEFAULT_TIMEOUT
 
+        user_agent = (
+            f'Hatch/{__version__} '
+            f'{platform.python_implementation()}/{platform.python_version()} '
+            f'HTTPX/{httpx.__version__}'
+        )
         return httpx.Client(
+            headers={'User-Agent': user_agent},
             transport=httpx.HTTPTransport(retries=3, verify=self.__verify, cert=self.__cert),
             timeout=DEFAULT_TIMEOUT,
         )


### PR DESCRIPTION
Fixes https://github.com/pypa/hatch/issues/1816.

Add a User-Agent header such as:

`Hatch/1.12.1.dev42 CPython/3.12.7 HTTPX/0.27.2`
