### PR TITLE
Improve license and license-files docs

### DIFF
--- a/docs/config/metadata.md
+++ b/docs/config/metadata.md
@@ -99,25 +99,18 @@ requires-python = ">=3.8"
 
 ## License
 
-For more information, see [PEP 639][].
+For more information, see [PEP 639][]. `license` must be a valid SPDX license expression,
+`license-files` a list of glob patterns which match license files. If not specified,
+`license-files` will default to `['LICEN[CS]E*', 'COPYING*', 'NOTICE*', 'AUTHORS*']`.
 
 === ":octicons-file-code-16: pyproject.toml"
 
-    === "SPDX expression"
-
-        ```toml
-        [project]
-        ...
-        license = "Apache-2.0 OR MIT"
-        ```
-
-    === "Files"
-
-        ```toml
-        [project]
-        ...
-        license-files = ["LICENSES/*"]
-        ```
+    ```toml
+    [project]
+    ...
+    license = "Apache-2.0 OR MIT"
+    license-files = ["LICENSES/*"]
+    ```
 
 ## Ownership
 


### PR DESCRIPTION
Mention the default globs for `license-files`.
https://github.com/pypa/hatch/blob/72d57279ac8fa58b1981734b58d55cf607e84656/backend/src/hatchling/metadata/core.py#L748-L749