### PR TITLE
WIP: Support default version for env version source

### DIFF
--- a/tests/backend/version/source/test_env.py
+++ b/tests/backend/version/source/test_env.py
@@ -27,8 +27,22 @@ def test_variable_not_available(isolation):
         source.get_version_data()
 
 
+def test_variable_not_available_with_default(isolation):
+    source = EnvSource(str(isolation), {'variable': 'ENV_VERSION', 'default': '0.0.0'})
+
+    with EnvVars(exclude=['ENV_VERSION']):
+        assert source.get_version_data()['version'] == '0.0.0'
+
+
 def test_variable_contains_version(isolation):
     source = EnvSource(str(isolation), {'variable': 'ENV_VERSION'})
+
+    with EnvVars({'ENV_VERSION': '0.0.1'}):
+        assert source.get_version_data()['version'] == '0.0.1'
+
+
+def test_variable_contains_version_with_default(isolation):
+    source = EnvSource(str(isolation), {'variable': 'ENV_VERSION', 'default': '0.0.0'})
 
     with EnvVars({'ENV_VERSION': '0.0.1'}):
         assert source.get_version_data()['version'] == '0.0.1'


### PR DESCRIPTION
Closes #1853

Added two tests for the `env` version source:
1. the environment variable is not set, but a default is configured
2. the environment variable is set and a default is configured