### PR TITLE
Update dependency-resolution.md - uv env vars

### DIFF
--- a/docs/how-to/environment/dependency-resolution.md
+++ b/docs/how-to/environment/dependency-resolution.md
@@ -18,8 +18,8 @@ If you're [using UV](select-installer.md), a different set of [environment varia
 
 ```toml config-example
 [tool.hatch.envs.default.env-vars]
-UV_EXTRA_INDEX_URL = "https://token:{env:GITLAB_API_TOKEN}@gitlab.com/api/v4/groups/<group1_path>/-/packages/pypi/simple/"
-UV_INDEX_URL = "https://token:{env:GITLAB_API_TOKEN}@gitlab.com/api/v4/groups/<group2_path>/-/packages/pypi/simple/ https://pypi.org/simple/"
+UV_INDEX = "https://token:{env:GITLAB_API_TOKEN}@gitlab.com/api/v4/groups/<group1_path>/-/packages/pypi/simple/ https://token:{env:GITLAB_API_TOKEN}@gitlab.com/api/v4/groups/<group2_path>/-/packages/pypi/simple/"
+UV_DEFAULT_INDEX = "https://pypi.org/simple/"
 ```
 
 !!! tip


### PR DESCRIPTION
Replace deprecated `uv` env vars and provide space-separated extra URLs to [`UV_INDEX`](https://docs.astral.sh/uv/configuration/environment/#uv_index) and a single default index to [`UV_DEFAULT_INDEX`](https://docs.astral.sh/uv/configuration/environment/#uv_default_index).