### PR TITLE
Fix failing tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
   "tomli-w>=1.0",
   "tomlkit>=0.11.1",
   "userpath~=1.7",
-  "uv>=0.1.35",
+  "uv>=0.5.23",
   "virtualenv>=20.26.6",
   "zstandard<1",
 ]

--- a/tests/cli/project/test_metadata.py
+++ b/tests/cli/project/test_metadata.py
@@ -28,7 +28,7 @@ def test_other_backend(hatch, temp_dir, helpers):
 
     project = Project(path)
     config = dict(project.raw_config)
-    config['build-system']['requires'] = ['flit-core']
+    config['build-system']['requires'] = ['flit-core==3.10.1']
     config['build-system']['build-backend'] = 'flit_core.buildapi'
     config['project']['version'] = '0.0.1'
     config['project']['dynamic'] = []

--- a/tests/dep/test_sync.py
+++ b/tests/dep/test_sync.py
@@ -92,7 +92,7 @@ def test_dependency_git_uv(platform, uv_on_path):
             check=True,
             capture_output=True,
         )
-        assert not dependencies_in_sync([Requirement('requests@git+https://github.com/psf/requests')], venv.sys_path)
+        assert dependencies_in_sync([Requirement('requests@git+https://github.com/psf/requests')], venv.sys_path)
 
 
 @pytest.mark.requires_internet
@@ -114,9 +114,7 @@ def test_dependency_git_revision_uv(platform, uv_on_path):
             check=True,
             capture_output=True,
         )
-        assert not dependencies_in_sync(
-            [Requirement('requests@git+https://github.com/psf/requests@main')], venv.sys_path
-        )
+        assert dependencies_in_sync([Requirement('requests@git+https://github.com/psf/requests@main')], venv.sys_path)
 
 
 @pytest.mark.requires_internet


### PR DESCRIPTION
Flit version 3.11 automatically includes license files in the metadata, even if they are not explicitly referenced in the pyproject.toml. Any file matching a license regex, such as the LICENSE.txt generated by hatch new, is included by default. This broke the result output assumption.

UV>=0.5.23 fixed https://github.com/astral-sh/uv/issues/3014