### PR TITLE
drop --no-python-version-warning from pip install

### DIFF
--- a/backend/tests/downstream/integrate.py
+++ b/backend/tests/downstream/integrate.py
@@ -140,7 +140,6 @@ def main():
             'download',
             '-q',
             '--disable-pip-version-check',
-            '--no-python-version-warning',
             '-d',
             links_dir,
             os.path.join(links_dir, os.listdir(links_dir)[0]),
@@ -230,7 +229,6 @@ def main():
                         'install',
                         '-q',
                         '--disable-pip-version-check',
-                        '--no-python-version-warning',
                         '--find-links',
                         links_dir,
                         '--no-deps',
@@ -243,7 +241,6 @@ def main():
                         'install',
                         '-q',
                         '--disable-pip-version-check',
-                        '--no-python-version-warning',
                         repo_dir,
                     ])
 

--- a/src/hatch/cli/application.py
+++ b/src/hatch/cli/application.py
@@ -162,7 +162,7 @@ class Application(Terminal):
 
             pip_command = [sys.executable, '-u', '-m', 'pip']
 
-        pip_command.extend(['install', '--disable-pip-version-check', '--no-python-version-warning'])
+        pip_command.extend(['install', '--disable-pip-version-check'])
 
         # Default to -1 verbosity
         add_verbosity_flag(pip_command, self.verbosity, adjustment=-1)

--- a/src/hatch/env/plugin/interface.py
+++ b/src/hatch/env/plugin/interface.py
@@ -768,7 +768,7 @@ class EnvironmentInterface(ABC):
         A convenience method for constructing a [`pip install`](https://pip.pypa.io/en/stable/cli/pip_install/)
         command with the given verbosity. The default verbosity is set to one less than Hatch's verbosity.
         """
-        command = ['python', '-u', '-m', 'pip', 'install', '--disable-pip-version-check', '--no-python-version-warning']
+        command = ['python', '-u', '-m', 'pip', 'install', '--disable-pip-version-check']
 
         # Default to -1 verbosity
         add_verbosity_flag(command, self.verbosity, adjustment=-1)

--- a/tests/helpers/helpers.py
+++ b/tests/helpers/helpers.py
@@ -55,7 +55,6 @@ def assert_plugin_installation(subprocess_run, dependencies: list[str], *, verbo
         'pip',
         'install',
         '--disable-pip-version-check',
-        '--no-python-version-warning',
     ]
     add_verbosity_flag(command, verbosity, adjustment=-1)
     command.extend(dependencies)


### PR DESCRIPTION
When using `hatch sell` with `pip` 25.0.1 at the first time, a deprecation warning is showed:

> $ hatch shell
> DEPRECATION: --no-python-version-warning is deprecated. pip 25.1 will
>  enforce this behaviour change. A possible replacement is to remove the
>  flag as it's a no-op. Discussion can be found at
>  https://github.com/pypa/pip/issues/13154
> You are about to enter a new shell, exit as you usually would e.g. by
>  typing `exit` or pressing `ctrl+d`...

Looking at https://github.com/pypa/pip/issues/13154 it said:

> The Python 2 days are behind us, thus we can kill off the
> --no-python-version-warning flag which disabled the
> "Python 2 is sunsetting support" warnings :)
>
> If you're using this flag, you can simply stop. It does nothing today.

So, lets remove it to not show the warning