### PR TITLE
Use a consistent style for CLI help

### DIFF
--- a/src/hatch/cli/__init__.py
+++ b/src/hatch/cli/__init__.py
@@ -141,7 +141,7 @@ def hatch(ctx: click.Context, env_name, project, verbose, quiet, color, interact
             )
 
     if not ctx.invoked_subcommand:
-        app.display_info(ctx.get_help())
+        click.echo(ctx.get_help())
         return
 
     # Persist app data for sub-commands

--- a/src/hatch/cli/run/__init__.py
+++ b/src/hatch/cli/run/__init__.py
@@ -61,7 +61,7 @@ def run(ctx: click.Context, args: tuple[str, ...]):
 
     first_arg = args[0]
     if first_arg in {'-h', '--help'}:
-        app.display_info(ctx.get_help())
+        click.echo(ctx.get_help())
         return
 
     from hatch.utils.fs import Path


### PR DESCRIPTION
All help output is handled by click except for `hatch` and `hatch run -h`. These get the help text and display it with `app.display_info`, which makes the entire help output bold. Switch to using `click.echo` instead to be consistent with the help output of all the other commands.