### PR TITLE
Mark Application.abort() as NoReturn

### DIFF
--- a/backend/src/hatchling/bridge/app.py
+++ b/backend/src/hatchling/bridge/app.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
-from typing import Any
+from typing import Any, NoReturn
 
 
 class Application:
@@ -80,7 +80,7 @@ class Application:
         if self.__verbosity >= 0:
             _display(f'[{message}]')
 
-    def abort(self, message: str = '', code: int = 1, **kwargs: Any) -> None:  # noqa: ARG002
+    def abort(self, message: str = '', code: int = 1, **kwargs: Any) -> NoReturn:  # noqa: ARG002
         """
         Terminate the program with the given return code.
         """


### PR DESCRIPTION
Otherwise, type checkers (like PyRight) require an `assert False` after `self.app.abort()` in build hooks.

`NoReturn` was added to [typing](https://docs.python.org/3/library/typing.html#typing.NoReturn) in Python 3.6.2.