### PR TITLE
Add hatch installation option with `uvx`

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -111,6 +111,14 @@ pip install hatch
 pipx install hatch
 ```
 
+## uvx
+
+Similar to [pipx](#pipx), [uvx](https://docs.astral.sh/uv/concepts/tools/) allows for the global installation of Python applications in isolated environments managed by [uv](https://docs.astral.sh/uv/).
+
+```
+uv tool install hatch@latest
+```
+
 ## Homebrew
 
 See the [formula](https://formulae.brew.sh/formula/hatch) for more details.


### PR DESCRIPTION
## Description

`uv` has grown to have a large community and rapid adoption. This PR introduces a minor patch to the install docs to inform users of an optional Hatch installation with `uv`. Users, or anyone managing isolated tools with `uv`, can now install Hatch in a persistent, isolated, globally available environment.

## Decisions
> This section outlines notable considerations for developers/maintainers.

- `uvx` (an _alias_ for `uv tool run <tool>`) executes tools in a **temporary**, cached virtual environment.
- `uv tool run <tool>` installs tools in a **persistent**, isolated, global environment, similar to [pipx](https://pipx.pypa.io/stable/). 

### Similar Workflow

| Action                        | `pipx` Command                  | `uv` Equivalent                   |
|------------------------------|----------------------------------|-----------------------------------|
| Install globally             | `pipx install black`            | `uv tool install black`           |
| Run once (ephemeral)         | `pipx run ruff`                 | `uvx ruff`                        |
| Run a specific version       | `pipx run ruff==0.4.0`          | `uvx ruff@0.4.0`                  |
| List installed tools         | `pipx list`                     | `uv tool list`                    |
| Upgrade a specific tool      | `pipx upgrade black`            | `uv tool upgrade black`           |
| Upgrade all tools            | `pipx upgrade --all`            | `uv tool upgrade --all`           |
| Uninstall a tool             | `pipx uninstall black`          | `uv tool uninstall black`         |

## References
- `uv` Tools [Concept](https://docs.astral.sh/uv/concepts/tools/)
- `uv` Tools [Guide and Usage](https://docs.astral.sh/uv/guides/tools/) 