### PR TITLE
chore: List `extra-dependencies` as regular deps in `env show --json`

### DIFF
--- a/src/hatch/cli/env/show.py
+++ b/src/hatch/cli/env/show.py
@@ -50,7 +50,10 @@ def show(
 
                 extra_dependencies = environment.environment_dependencies[num_dependencies:]
                 if extra_dependencies:
-                    new_config['extra-dependencies'] = extra_dependencies
+                    if dependencies:
+                        new_config['dependencies'].extend(extra_dependencies)
+                    else:
+                        new_config['dependencies'] = extra_dependencies
 
                 if environment.pre_install_commands:
                     new_config['pre-install-commands'] = list(


### PR DESCRIPTION
# Summary

`extra-dependencies` are listed in the dependencies column in `env show` thanks to https://github.com/pypa/hatch/pull/377 . However, it's not the case for when `--json` is present and they're still listed as `extra-dependencies`. I personally feel it's slightly more intuitive to keep them consistent plus it hides implementation details since `extra-` is just syntactic sugar per se. 

I didn't file an issue since it's pretty straightforward to patch up. Also I understand that [Hyrum's Law](https://www.hyrumslaw.com/) might apply to some of the consumers so happy to discuss the trade-offs.

# Test Plan

CI.