### PR TITLE
Get rid of last occurrences of `coding: utf-8`

### DIFF
--- a/backend/src/hatchling/builders/sdist.py
+++ b/backend/src/hatchling/builders/sdist.py
@@ -215,7 +215,7 @@ class SdistBuilder(BuilderInterface):
         )
 
     def construct_setup_py_file(self, packages: list[str], extra_dependencies: tuple[()] = ()) -> str:
-        contents = '# -*- coding: utf-8 -*-\nfrom setuptools import setup\n\n'
+        contents = 'from setuptools import setup\n\n'
 
         contents += 'setup(\n'
 

--- a/release/windows/make_scripts_portable.py
+++ b/release/windows/make_scripts_portable.py
@@ -14,7 +14,6 @@ from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo
 LAUNCHERS_URL = 'https://raw.githubusercontent.com/astral-sh/uv/main/crates/uv-trampoline/trampolines'
 SCRIPT_TEMPLATE = """\
 #!{executable}
-# -*- coding: utf-8 -*-
 import re
 import sys
 from {module} import {import_name}

--- a/tests/backend/builders/test_sdist.py
+++ b/tests/backend/builders/test_sdist.py
@@ -109,7 +109,6 @@ class TestConstructSetupPyFile:
 
         assert builder.construct_setup_py_file([]) == helpers.dedent(
             """
-            # -*- coding: utf-8 -*-
             from setuptools import setup
 
             setup(
@@ -125,7 +124,6 @@ class TestConstructSetupPyFile:
 
         assert builder.construct_setup_py_file(['my_app', os.path.join('my_app', 'pkg')]) == helpers.dedent(
             """
-            # -*- coding: utf-8 -*-
             from setuptools import setup
 
             setup(
@@ -145,7 +143,6 @@ class TestConstructSetupPyFile:
 
         assert builder.construct_setup_py_file(['my_app', os.path.join('my_app', 'pkg')]) == helpers.dedent(
             """
-            # -*- coding: utf-8 -*-
             from setuptools import setup
 
             setup(
@@ -172,7 +169,6 @@ class TestConstructSetupPyFile:
 
         assert builder.construct_setup_py_file(['my_app', os.path.join('my_app', 'pkg')]) == helpers.dedent(
             """
-            # -*- coding: utf-8 -*-
             from setuptools import setup
 
             setup(
@@ -193,7 +189,6 @@ class TestConstructSetupPyFile:
 
         assert builder.construct_setup_py_file(['my_app', os.path.join('my_app', 'pkg')]) == helpers.dedent(
             """
-            # -*- coding: utf-8 -*-
             from setuptools import setup
 
             setup(
@@ -214,7 +209,6 @@ class TestConstructSetupPyFile:
 
         assert builder.construct_setup_py_file(['my_app', os.path.join('my_app', 'pkg')]) == helpers.dedent(
             """
-            # -*- coding: utf-8 -*-
             from setuptools import setup
 
             setup(
@@ -237,7 +231,6 @@ class TestConstructSetupPyFile:
 
         assert builder.construct_setup_py_file(['my_app', os.path.join('my_app', 'pkg')]) == helpers.dedent(
             """
-            # -*- coding: utf-8 -*-
             from setuptools import setup
 
             setup(
@@ -258,7 +251,6 @@ class TestConstructSetupPyFile:
 
         assert builder.construct_setup_py_file(['my_app', os.path.join('my_app', 'pkg')]) == helpers.dedent(
             """
-            # -*- coding: utf-8 -*-
             from setuptools import setup
 
             setup(
@@ -279,7 +271,6 @@ class TestConstructSetupPyFile:
 
         assert builder.construct_setup_py_file(['my_app', os.path.join('my_app', 'pkg')]) == helpers.dedent(
             """
-            # -*- coding: utf-8 -*-
             from setuptools import setup
 
             setup(
@@ -300,7 +291,6 @@ class TestConstructSetupPyFile:
 
         assert builder.construct_setup_py_file(['my_app', os.path.join('my_app', 'pkg')]) == helpers.dedent(
             """
-            # -*- coding: utf-8 -*-
             from setuptools import setup
 
             setup(
@@ -323,7 +313,6 @@ class TestConstructSetupPyFile:
 
         assert builder.construct_setup_py_file(['my_app', os.path.join('my_app', 'pkg')]) == helpers.dedent(
             """
-            # -*- coding: utf-8 -*-
             from setuptools import setup
 
             setup(
@@ -344,7 +333,6 @@ class TestConstructSetupPyFile:
 
         assert builder.construct_setup_py_file(['my_app', os.path.join('my_app', 'pkg')]) == helpers.dedent(
             """
-            # -*- coding: utf-8 -*-
             from setuptools import setup
 
             setup(
@@ -369,7 +357,6 @@ class TestConstructSetupPyFile:
 
         assert builder.construct_setup_py_file(['my_app', os.path.join('my_app', 'pkg')]) == helpers.dedent(
             """
-            # -*- coding: utf-8 -*-
             from setuptools import setup
 
             setup(
@@ -393,7 +380,6 @@ class TestConstructSetupPyFile:
 
         assert builder.construct_setup_py_file(['my_app', os.path.join('my_app', 'pkg')]) == helpers.dedent(
             """
-            # -*- coding: utf-8 -*-
             from setuptools import setup
 
             setup(
@@ -417,7 +403,6 @@ class TestConstructSetupPyFile:
 
         assert builder.construct_setup_py_file(['my_app', os.path.join('my_app', 'pkg')], ['baz==3']) == helpers.dedent(
             """
-            # -*- coding: utf-8 -*-
             from setuptools import setup
 
             setup(
@@ -451,7 +436,6 @@ class TestConstructSetupPyFile:
 
         assert builder.construct_setup_py_file(['my_app', os.path.join('my_app', 'pkg')]) == helpers.dedent(
             """
-            # -*- coding: utf-8 -*-
             from setuptools import setup
 
             setup(
@@ -481,7 +465,6 @@ class TestConstructSetupPyFile:
 
         assert builder.construct_setup_py_file(['my_app', os.path.join('my_app', 'pkg')]) == helpers.dedent(
             """
-            # -*- coding: utf-8 -*-
             from setuptools import setup
 
             setup(
@@ -509,7 +492,6 @@ class TestConstructSetupPyFile:
 
         assert builder.construct_setup_py_file(['my_app', os.path.join('my_app', 'pkg')]) == helpers.dedent(
             """
-            # -*- coding: utf-8 -*-
             from setuptools import setup
 
             setup(
@@ -544,7 +526,6 @@ class TestConstructSetupPyFile:
 
         assert builder.construct_setup_py_file(['my_app', os.path.join('my_app', 'pkg')]) == helpers.dedent(
             """
-            # -*- coding: utf-8 -*-
             from setuptools import setup
 
             setup(
@@ -599,7 +580,6 @@ class TestConstructSetupPyFile:
 
         assert builder.construct_setup_py_file(['my_app', os.path.join('my_app', 'pkg')]) == helpers.dedent(
             """
-            # -*- coding: utf-8 -*-
             from setuptools import setup
 
             setup(

--- a/tests/helpers/templates/sdist/standard_default_support_legacy.py
+++ b/tests/helpers/templates/sdist/standard_default_support_legacy.py
@@ -22,7 +22,6 @@ License-File: LICENSE.txt
         File(
             Path(relative_root, 'setup.py'),
             f"""\
-# -*- coding: utf-8 -*-
 from setuptools import setup
 
 setup(


### PR DESCRIPTION
Am I correct that Python 2 is totally out of the picture when using current versions of hatch, which means `coding: utf-8` comments have become useless?