### PR TITLE
Fix CI error

### DIFF
--- a/backend/src/hatchling/builders/hooks/plugin/hooks.py
+++ b/backend/src/hatchling/builders/hooks/plugin/hooks.py
@@ -12,4 +12,4 @@ if typing.TYPE_CHECKING:
 
 @hookimpl
 def hatch_register_build_hook() -> list[type[BuildHookInterface]]:
-    return [CustomBuildHook, VersionBuildHook]  # type: ignore[list-item]
+    return [CustomBuildHook, VersionBuildHook]

--- a/src/hatch/env/collectors/plugin/hooks.py
+++ b/src/hatch/env/collectors/plugin/hooks.py
@@ -12,4 +12,4 @@ if TYPE_CHECKING:
 
 @hookimpl
 def hatch_register_environment_collector() -> list[type[EnvironmentCollectorInterface]]:
-    return [CustomEnvironmentCollector, DefaultEnvironmentCollector]  # type: ignore[list-item]
+    return [CustomEnvironmentCollector, DefaultEnvironmentCollector]


### PR DESCRIPTION
```
src/hatch/env/collectors/plugin/hooks.py:15: error: Unused "type: ignore" comment  [unused-ignore]
        return [CustomEnvironmentCollector, DefaultEnvironmentCollector]  ...
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~...
backend/src/hatchling/builders/hooks/plugin/hooks.py:15: error: Unused "type: ignore" comment  [unused-ignore]
        return [CustomBuildHook, VersionBuildHook]  # type: ignore[list-it...
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```