### PR TITLE
Pin click version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
   "Topic :: Software Development :: Build Tools",
 ]
 dependencies = [
-  "click==8.2.2",
+  "click==8.2.1",
   "hatchling>=1.24.2",
   "httpx>=0.22.0",
   "hyperlink>=21.0.0",


### PR DESCRIPTION
Click 8.3.0 includes breaking changes causing build failures in projects using Hatch. This commit pins the version to a version known to work with the current Hatch release.

#2050 