### PR TITLE
Fix: Set default of None for @click.option("--filter", ...)

### DIFF
--- a/src/hatch/cli/env/run.py
+++ b/src/hatch/cli/env/run.py
@@ -25,7 +25,7 @@ def filter_environments(environments, filter_data):
 @click.option('--env', '-e', 'env_names', multiple=True, help='The environments to target')
 @click.option('--include', '-i', 'included_variable_specs', multiple=True, help='The matrix variables to include')
 @click.option('--exclude', '-x', 'excluded_variable_specs', multiple=True, help='The matrix variables to exclude')
-@click.option('--filter', '-f', 'filter_json', help='The JSON data used to select environments')
+@click.option('--filter', '-f', 'filter_json', default=None, help='The JSON data used to select environments')
 @click.option(
     '--force-continue', is_flag=True, help='Run every command and if there were any errors exit with the first code'
 )


### PR DESCRIPTION
# Summary

With release of click `v8.3.0`, the click module is leaking `click.core.UNSET` where previously `None` was returned.

This is causing the filter option on the run command to fail.

Favoring explicit over implicit, we can avoid that issue without pinning back the click library.

## Alternative

- #2051 Pins the version of `click`.

# Fixes

fixes #2050 