### PR TITLE
Use compression.zstd/backports.zstd instead of zstandard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
   "userpath~=1.7",
   "uv>=0.5.23",
   "virtualenv>=20.26.6",
-  "zstandard<1",
+  "backports.zstd; python_version<'3.14'",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
In particular zstandard does not ships with all
the wheels of backports.zstd, and remove one
dependency on 3.14+.

Drawback might be some platforms may not package backports.zstd yet

Closes #2077

I can also do the same but conditionally using zstandard instead of `backports.zstd`.

It's also unclear to me where this codepath is tested (if tested).