### PR TITLE
Fix workspace option overrides

### DIFF
--- a/src/hatch/project/env.py
+++ b/src/hatch/project/env.py
@@ -312,22 +312,15 @@ def _apply_override_to_workspace(env_name, option, data, source, condition, cond
         raise TypeError(message)
 
     # Get or create workspace dict
-    if overwrite:
-        workspace = {}
-    else:
-        workspace = new_config.setdefault(option, {})
+    workspace = {} if overwrite else new_config.setdefault(option, {})
 
     for key, value in data.items():
-        if key in ("members", "exclude"):
+        if key in {"members", "exclude"}:
             # Delegate to array handler - pass workspace dict
-            _apply_override_to_array(
-                env_name, key, value, source, condition, condition_value, workspace, overwrite
-            )
+            _apply_override_to_array(env_name, key, value, source, condition, condition_value, workspace, overwrite)
         elif key == "parallel":
             # Delegate to boolean handler - pass workspace dict
-            _apply_override_to_boolean(
-                env_name, key, value, source, condition, condition_value, workspace, overwrite
-            )
+            _apply_override_to_boolean(env_name, key, value, source, condition, condition_value, workspace, overwrite)
         else:
             message = f"Unknown workspace option: {key}"
             raise ValueError(message)

--- a/tests/project/test_config.py
+++ b/tests/project/test_config.py
@@ -2574,15 +2574,14 @@ class TestEnvs:
     @pytest.mark.parametrize("option", WORKSPACE_OPTIONS)
     def test_overrides_matrix_workspace_invalid_type(self, isolation, option):
         with pytest.raises(
-                TypeError,
-                match=f"Field `tool.hatch.envs.foo.overrides.matrix.version.{option}` must be a table",
+            TypeError,
+            match=f"Field `tool.hatch.envs.foo.overrides.matrix.version.{option}` must be a table",
         ):
             _ = ProjectConfig(
                 isolation,
                 {
                     "envs": {
-                        "foo": {"matrix": [{"version": ["9000"]}],
-                                "overrides": {"matrix": {"version": {option: 9000}}}}
+                        "foo": {"matrix": [{"version": ["9000"]}], "overrides": {"matrix": {"version": {option: 9000}}}}
                     }
                 },
                 PluginManager(),

--- a/tests/workspaces/test_config.py
+++ b/tests/workspaces/test_config.py
@@ -751,7 +751,7 @@ docs = ["sphinx", "sphinx-rtd-theme"]
             result = hatch("env", "create", "test")
             assert result.exit_code == 0
 
-    def test_workspace_overrides_platform_conditional_members(self, temp_dir, hatch, platform):
+    def test_workspace_overrides_platform_conditional_members(self, temp_dir, hatch):
         """Test workspace members added conditionally via platform overrides."""
         workspace_root = temp_dir / "workspace"
         workspace_root.mkdir()


### PR DESCRIPTION
This contains the fixes for option overrides for workspaces. Adjusted tests because the workspace overrides do not fit nicely in the flat dict section. I am open to suggestions if you think there is a better way to handle this. 