### PR TITLE
fix(hatch): incorrect content sent to stdout

### DIFF
--- a/src/hatch/cli/application.py
+++ b/src/hatch/cli/application.py
@@ -61,7 +61,7 @@ class Application(Terminal):
             should_display_command = not context.hide_commands and (self.verbose or len(resolved_commands) > 1)
             for i, raw_command in enumerate(resolved_commands, 1):
                 if should_display_command:
-                    self.display(f"{context.source} [{i}] | {raw_command}")
+                    self.display_info(f"{context.source} [{i}] | {raw_command}")
 
                 command = raw_command
                 continue_on_error = context.force_continue


### PR DESCRIPTION
I discovered an issue whereby some informational content was being sent to `stdout` instead of `stderr`. This creates a test to verify the issue, and fixes the issue itself.

Fixes: #2107