### PR TITLE
fix(docs): correct syntax for group inclusion in advanced configuration

### DIFF
--- a/docs/config/environment/advanced.md
+++ b/docs/config/environment/advanced.md
@@ -144,8 +144,8 @@ lint = [
 ]
 # Groups can include other groups
 dev = [
-  {"include-group": "test"},
-  {"include-group": "lint"},
+  {include-group = "test"},
+  {include-group = "lint"},
   "pre-commit",
 ]
 


### PR DESCRIPTION
While updating my project I notice this error flagged by my IDE. Here is uv documentation which shows this format as well. https://docs.astral.sh/uv/concepts/projects/dependencies/#nesting-groups