### PR TITLE
Fix compatibility with virtualenv 21.0.0

### DIFF
--- a/src/hatch/env/virtual.py
+++ b/src/hatch/env/virtual.py
@@ -382,7 +382,7 @@ class VirtualEnvironment(EnvironmentInterface):
         try:
             propose_interpreters = virtualenv_discovery.propose_interpreters
         except AttributeError:
-            from python_discovery._discovery import propose_interpreters
+            from python_discovery._discovery import propose_interpreters  # noqa: PLC2701
 
         def _patched_propose_interpreters(*args, **kwargs):
             for interpreter, impl_must_match in propose_interpreters(*args, **kwargs):


### PR DESCRIPTION
A few hours ago, `virtualenv` 21.0.0 was released, and it extracted the Python discovery logic
into a standalone `python-discovery` package ([pypa/virtualenv#3070](https://github.com/pypa/virtualenv/pull/3070)). As part of this refactoring, `propose_interpreters` is no longer exported from `virtualenv.discovery.builtin`, causing hatch to fail with: 

```
Environment `my-env-name` is incompatible: module 'virtualenv.discovery.builtin' has no attribute 'propose_interpreters'
```

This PR adds a fallback import from `python_discovery._discovery` (which is installed as a dependency of virtualenv >=21).

The related issue is #2193.

I've tested this locally and it resolved the issue for me. 

This is my first contribution to hatch, so I'm happy to adjust the approach if maintainers prefer a different direction!