### PR TITLE
fix: `require-runtime-dependencies` not installed in build environment

### DIFF
--- a/src/hatch/env/plugin/interface.py
+++ b/src/hatch/env/plugin/interface.py
@@ -356,7 +356,7 @@ class EnvironmentInterface(ABC):
 
         return local_dependencies_complex
 
-    @cached_property
+    @property
     def dependencies_complex(self) -> list[Dependency]:
         from hatch.dep.core import Dependency
 
@@ -410,7 +410,7 @@ class EnvironmentInterface(ABC):
         """
         return [str(dependency) for dependency in self.dependencies_complex]
 
-    @cached_property
+    @property
     def all_dependencies_complex(self) -> list[Dependency]:
         from hatch.dep.core import Dependency
 

--- a/src/hatch/env/virtual.py
+++ b/src/hatch/env/virtual.py
@@ -138,7 +138,7 @@ class VirtualEnvironment(EnvironmentInterface):
 
         return InstalledDistributions(sys_path=self.virtual_env.sys_path, environment=self.virtual_env.environment)
 
-    @cached_property
+    @property
     def missing_dependencies(self) -> list[Dependency]:
         return self.distributions.missing_dependencies(self.all_dependencies_complex)
 

--- a/tests/cli/build/test_build.py
+++ b/tests/cli/build/test_build.py
@@ -1354,6 +1354,61 @@ def test_build_dependencies(hatch, temp_dir, helpers):
     )
 
 
+@pytest.mark.allow_backend_process
+@pytest.mark.requires_internet
+def test_require_runtime_dependencies(hatch, temp_dir, helpers):
+    """Test that require-runtime-dependencies installs runtime deps in the build env.
+
+    Regression test for https://github.com/pypa/hatch/issues/2110 where
+    prepare_build_environment's @cached_property on a few fields prevented 
+    runtime deps from being installed.
+    """
+    project_name = "My.App"
+
+    with temp_dir.as_cwd():
+        result = hatch("new", project_name)
+        assert result.exit_code == 0, result.output
+
+    project_path = temp_dir / "my-app"
+    data_path = temp_dir / "data"
+    data_path.mkdir()
+
+    # Custom build hook that imports a runtime dependency
+    build_script = project_path / DEFAULT_BUILD_SCRIPT
+    build_script.write_text(
+        helpers.dedent(
+            """
+            from typing import Any
+            from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+            class CustomBuildHook(BuildHookInterface):
+                PLUGIN_NAME = "custom"
+
+                def initialize(self, version: str, build_data: dict[str, Any]) -> None:
+                    import binary
+            """
+        )
+    )
+
+    project = Project(project_path)
+    config = dict(project.raw_config)
+    config["project"]["dependencies"] = ["binary"]
+    config["tool"]["hatch"]["build"] = {
+        "hooks": {
+            "custom": {
+                "path": DEFAULT_BUILD_SCRIPT,
+                "require-runtime-dependencies": True,
+            }
+        },
+    }
+    project.save_config(config)
+
+    with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
+        result = hatch("build", "-t", "wheel")
+
+    assert result.exit_code == 0, result.output
+
+
 def test_plugin_dependencies_unmet(hatch, temp_dir, helpers, mock_plugin_installation):
     project_name = "My.App"
 


### PR DESCRIPTION
# Summary

Addressing https://github.com/pypa/hatch/issues/2110.

Mentioned in the issue, https://github.com/pypa/hatch/pull/2073 changed `prepare_build_environment` such that:
1. `prepare_environment` syncs the build env, caching `dependencies_complex`, `all_dependencies_complex`, and `missing_dependencies` via `@cached_property`.
2. Queries hatchling for additional runtime deps and appends them to `additional_dependencies`
3. Calls `sync_dependencies` again but the cached properties from step 1 still have empty `additional_dependencies` so runtime deps are never installed.

This PR replaces `@cached_property` with `@property` for those fields. Alternatively, we could manually evict the fields after mutating `additional_dependencies`. However, I personally feel the latter is too ad-hoc and bypasses a more serious issue (caching properties that depend on mutable state).

# Test Plan

Disclaimer: I used Claude Code for these. TDD:

* Added a new integration test.
* Repro steps in the issue.