### PR TITLE
fix: normalize feature names for underscore/hyphen equivalence

### DIFF
--- a/src/hatch/project/core.py
+++ b/src/hatch/project/core.py
@@ -293,8 +293,15 @@ class Project:
     def get_dependencies(self) -> tuple[list[str], dict[str, list[str]]]:
         dynamic_fields = {"dependencies", "optional-dependencies"}
         if not dynamic_fields.intersection(self.metadata.dynamic):
+            from hatch.utils.metadata import normalize_project_name
+
             dependencies: list[str] = self.metadata.core_raw_metadata.get("dependencies", [])
-            features: dict[str, list[str]] = self.metadata.core_raw_metadata.get("optional-dependencies", {})
+            raw_features: dict[str, list[str]] = self.metadata.core_raw_metadata.get("optional-dependencies", {})
+            # Normalize feature keys (PEP 685: underscores -> hyphens) for consistent lookup
+            features = {
+                normalize_project_name(name) if not self.metadata.hatch.metadata.allow_ambiguous_features else name: deps
+                for name, deps in raw_features.items()
+            }
             return dependencies, features
 
         from hatch.project.constants import BUILD_BACKEND


### PR DESCRIPTION
## Summary
- Normalize feature names consistently so `foo_bar` and `foo-bar` are treated as equivalent
- Fixes feature lookup failure when optional-dependencies uses underscores

## Root Cause
PEP 685 requires normalizing extras by replacing underscores with hyphens, but when returning static optional-dependencies from `get_dependencies()`, the raw keys from pyproject.toml were used. The `features` config is normalized before lookup, causing `foo_bar` in optional-dependencies to not match `foo-bar` in the features list.

## Fix
Normalize the feature keys in `get_dependencies()` when returning static optional-dependencies, using the same `normalize_project_name` function and respecting `allow_ambiguous_features`.

## Testing
- Verified fix addresses reported scenario (foo_bar in optional-dependencies, foo_bar in features)
- Change is minimal and follows existing code patterns

Fixes #2166

Made with [Cursor](https://cursor.com)