### PR TITLE
Added new template parameters for new projects

### DIFF
--- a/src/hatch/config/model.py
+++ b/src/hatch/config/model.py
@@ -455,6 +455,8 @@ class TemplateConfig(LazilyParsedConfig):
         self._field_email = FIELD_TO_PARSE
         self._field_licenses = FIELD_TO_PARSE
         self._field_plugins = FIELD_TO_PARSE
+        self._field_github_org = FIELD_TO_PARSE
+        self._field_copyright_holder = FIELD_TO_PARSE
 
     @property
     def name(self):
@@ -563,6 +565,62 @@ class TemplateConfig(LazilyParsedConfig):
     def plugins(self, value):
         self.raw_data["plugins"] = value
         self._field_plugins = FIELD_TO_PARSE
+
+    @property
+    def github_org(self):
+        if self._field_github_org is FIELD_TO_PARSE:
+            if "github-org" in self.raw_data:
+                github_org = self.raw_data["github-org"]
+                if not isinstance(github_org, str):
+                    self.raise_error("must be a string")
+
+                self._field_github_org = github_org
+            else:
+                github_org = os.environ.get("GITHUB_ORG")
+                if github_org is None:
+                    import shutil
+
+                    if shutil.which("gh") is None:
+                        # Revert to provided name if not found
+                        github_org = self.name
+                    else:
+                        import subprocess
+
+                        try:
+                            github_org = subprocess.check_output(
+                                ["gh", "api", "user", "--jq", ".login"],  # noqa: S607
+                                text=True,
+                            ).strip()
+                        except Exception:  # noqa: BLE001
+                            github_org = repr(self.name)[1:-1]
+                self._field_github_org = self.raw_data["github-org"] = github_org
+
+        return self._field_github_org
+
+    @github_org.setter
+    def github_org(self, value):
+        self.raw_data["github-org"] = value
+        self._field_github_org = FIELD_TO_PARSE
+
+    @property
+    def copyright_holder(self):
+        if self._field_copyright_holder is FIELD_TO_PARSE:
+            if "copyright-holder" in self.raw_data:
+                copyright_holder = self.raw_data["copyright-holder"]
+                if not isinstance(copyright_holder, str):
+                    self.raise_error("must be a string")
+
+                self._field_copyright_holder = copyright_holder
+            else:
+                copyright_holder = f"{self.name} <{self.email}>"
+                self._field_copyright_holder = self.raw_data["copyright-holder"] = copyright_holder
+
+        return self._field_copyright_holder
+
+    @copyright_holder.setter
+    def copyright_holder(self, value):
+        self.raw_data["copyright-holder"] = value
+        self._field_copyright_holder = FIELD_TO_PARSE
 
 
 class LicensesConfig(LazilyParsedConfig):

--- a/src/hatch/template/default.py
+++ b/src/hatch/template/default.py
@@ -57,7 +57,7 @@ class DefaultTemplate(TemplateInterface):
             ""
             if not config["licenses"]["headers"]
             else f"""\
-# SPDX-FileCopyrightText: {self.creation_time.year}-present {config["name"]} <{config["email"]}>
+# SPDX-FileCopyrightText: {self.creation_time.year}-present {config["copyright-holder"]}
 #
 # SPDX-License-Identifier: {config["license_expression"]}
 """
@@ -121,9 +121,9 @@ class DefaultTemplate(TemplateInterface):
 def get_license_text(config, license_id, license_text, creation_time):
     if license_id == "MIT":
         license_text = license_text.replace("<year>", f"{creation_time.year}-present", 1)
-        license_text = license_text.replace("<copyright holders>", f"{config['name']} <{config['email']}>", 1)
+        license_text = license_text.replace("<copyright holders>", config["copyright-holder"], 1)
     elif license_id == "BSD-3-Clause":
         license_text = license_text.replace("<year>", f"{creation_time.year}-present", 1)
-        license_text = license_text.replace("<owner>", f"{config['name']} <{config['email']}>", 1)
+        license_text = license_text.replace("<owner>", config["copyright-holder"], 1)
 
     return f"{license_text.rstrip()}\n"

--- a/src/hatch/template/files_default.py
+++ b/src/hatch/template/files_default.py
@@ -110,16 +110,15 @@ path = "{package_metadata_file_path}"{tests_section}
 
     def __init__(self, template_config: dict, plugin_config: dict):
         template_config = dict(template_config)
-        template_config["name"] = repr(template_config["name"])[1:-1]
 
         project_url_data = ""
         project_urls = (
             plugin_config["project_urls"]
             if "project_urls" in plugin_config
             else {
-                "Documentation": "https://github.com/{name}/{project_name_normalized}#readme",
-                "Issues": "https://github.com/{name}/{project_name_normalized}/issues",
-                "Source": "https://github.com/{name}/{project_name_normalized}",
+                "Documentation": "https://github.com/{github-org}/{project_name_normalized}#readme",
+                "Issues": "https://github.com/{github-org}/{project_name_normalized}/issues",
+                "Source": "https://github.com/{github-org}/{project_name_normalized}",
             }
         )
         if project_urls:

--- a/src/hatch/template/files_default.py
+++ b/src/hatch/template/files_default.py
@@ -111,6 +111,10 @@ path = "{package_metadata_file_path}"{tests_section}
     def __init__(self, template_config: dict, plugin_config: dict):
         template_config = dict(template_config)
 
+        # Default github organization name to user's name if not set or blank.
+        if not template_config.get("github-org", None):
+            template_config["github-org"] = repr(template_config["name"])[1:-1]
+
         project_url_data = ""
         project_urls = (
             plugin_config["project_urls"]

--- a/tests/cli/config/test_show.py
+++ b/tests/cli/config/test_show.py
@@ -1,3 +1,6 @@
+from unittest.mock import MagicMock, patch
+
+
 def test_default_scrubbed(hatch, config_file, helpers, default_cache_dir, default_data_dir):
     config_file.model.project = "foo"
     config_file.model.publish["index"]["auth"] = "bar"
@@ -28,6 +31,8 @@ def test_default_scrubbed(hatch, config_file, helpers, default_cache_dir, defaul
         [template]
         name = "Foo Bar"
         email = "foo@bar.baz"
+        github-org = "Foo Bar"
+        copyright-holder = "Foo Bar <foo@bar.baz>"
 
         [template.licenses]
         headers = true
@@ -52,6 +57,7 @@ def test_default_scrubbed(hatch, config_file, helpers, default_cache_dir, defaul
     )
 
 
+@patch("shutil.which", MagicMock(return_value=None))  # Disables attempting to fetch github org from gh cli tool
 def test_reveal(hatch, config_file, helpers, default_cache_dir, default_data_dir):
     config_file.model.project = "foo"
     config_file.model.publish["index"]["auth"] = "bar"
@@ -86,6 +92,8 @@ def test_reveal(hatch, config_file, helpers, default_cache_dir, default_data_dir
         [template]
         name = "Foo Bar"
         email = "foo@bar.baz"
+        github-org = "Foo Bar"
+        copyright-holder = "Foo Bar <foo@bar.baz>"
 
         [template.licenses]
         headers = true

--- a/tests/cli/new/test_new.py
+++ b/tests/cli/new/test_new.py
@@ -229,9 +229,9 @@ def test_licenses_empty(hatch, helpers, config_file, temp_dir):
 def test_projects_urls_space_in_label(hatch, helpers, config_file, temp_dir):
     project_name = "My.App"
     config_file.model.template.plugins["default"]["project_urls"] = {
-        "Documentation": "https://github.com/{name}/{project_name_normalized}#readme",
-        "Source": "https://github.com/{name}/{project_name_normalized}",
-        "Bug Tracker": "https://github.com/{name}/{project_name_normalized}/issues",
+        "Documentation": "https://github.com/{github-org}/{project_name_normalized}#readme",
+        "Source": "https://github.com/{github-org}/{project_name_normalized}",
+        "Bug Tracker": "https://github.com/{github-org}/{project_name_normalized}/issues",
     }
     config_file.save()
 

--- a/tests/config/test_model.py
+++ b/tests/config/test_model.py
@@ -25,6 +25,8 @@ def test_default(default_cache_dir, default_data_dir):
         "template": {
             "name": "Foo Bar",
             "email": "foo@bar.baz",
+            "github-org": "Foo Bar",
+            "copyright-holder": "Foo Bar <foo@bar.baz>",
             "licenses": {"default": ["MIT"], "headers": True},
             "plugins": {"default": {"ci": False, "src-layout": True, "tests": True}},
         },
@@ -1118,6 +1120,46 @@ class TestTemplate:
             ),
         ):
             _ = config.template.plugins
+
+    def test_github_org(self):
+        config = RootConfig({"template": {"github-org": "foobarbaz"}})
+
+        assert config.template.github_org == "foobarbaz"
+        assert config.raw_data == {"template": {"github-org": "foobarbaz"}}
+
+    def test_github_org_default(self):
+        config = RootConfig({"template": {"name": "Foo Bar"}})
+
+        assert config.template.github_org == "Foo Bar"
+        assert config.raw_data == {"template": {"github-org": "Foo Bar", "name": "Foo Bar"}}
+
+    def test_github_org_default_env_var(self):
+        import os
+
+        os.environ["GITHUB_ORG"] = "foobarbaz"
+        config = RootConfig({})
+
+        assert config.template.github_org == "foobarbaz"
+        assert config.raw_data == {"template": {"github-org": "foobarbaz"}}
+        os.environ.pop("GITHUB_ORG")
+
+    @pytest.mark.usefixtures("use_gh")
+    def test_github_org_default_gh(self):
+        config = RootConfig({})
+
+        assert config.template.github_org == "gh-foobarbaz"
+        assert config.raw_data == {"template": {"github-org": "gh-foobarbaz"}}
+
+    def test_copyright_holder(self):
+        config = RootConfig({"template": {"copyright-holder": "Foobar Inc."}})
+
+        assert config.template.copyright_holder == "Foobar Inc."
+        assert config.raw_data == {"template": {"copyright-holder": "Foobar Inc."}}
+
+    def test_copyright_default_holder(self):
+        config = RootConfig({"template": {"name": "Foo Bar", "email": "foo@bar.com"}})
+
+        assert config.template.copyright_holder == "Foo Bar <foo@bar.com>"
 
 
 class TestTerminal:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,6 +109,26 @@ def isolation(uv_on_path) -> Generator[Path, None, None]:
             yield d
 
 
+@pytest.fixture(scope="session", autouse=True)
+def bypass_gh():
+    with temp_directory() as d:
+        gh_file = d / "gh"
+        gh_file.write_text("#!/bin/sh\nexit 1")
+        gh_file.chmod(0o755)
+        path = os.environ["PATH"]
+        os.environ["PATH"] = f"{d.absolute()}:{path}"
+        yield gh_file
+        os.environ["PATH"] = path
+
+
+@pytest.fixture
+def use_gh(bypass_gh):
+    orig_content = bypass_gh.read_text()
+    bypass_gh.write_text("#!/bin/sh\necho gh-foobarbaz\nexit 0")
+    yield bypass_gh
+    bypass_gh.write_text(orig_content)
+
+
 @pytest.fixture(scope="session")
 def isolated_data_dir() -> Path:
     return Path(os.environ[ConfigEnvVars.DATA])

--- a/tests/helpers/helpers.py
+++ b/tests/helpers/helpers.py
@@ -112,6 +112,8 @@ def get_template_files(template_name, project_name, **kwargs):
     config = RootConfig({})
     kwargs.setdefault("author", config.template.name)
     kwargs.setdefault("email", config.template.email)
+    kwargs.setdefault("copyright-holder", config.template.copyright_holder)
+    kwargs.setdefault("github-org", config.template.github_org)
     kwargs.setdefault("year", str(datetime.now(timezone.utc).year))
 
     return __load_template_module(template_name)(**kwargs)

--- a/tests/helpers/templates/new/basic.py
+++ b/tests/helpers/templates/new/basic.py
@@ -15,7 +15,7 @@ def get_files(**kwargs):
         File(
             Path("src", kwargs["package_name"], "__init__.py"),
             f"""\
-# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["author"]} <{kwargs["email"]}>
+# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["copyright-holder"]}
 #
 # SPDX-License-Identifier: MIT
 """,
@@ -23,7 +23,7 @@ def get_files(**kwargs):
         File(
             Path("src", kwargs["package_name"], "__about__.py"),
             f"""\
-# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["author"]} <{kwargs["email"]}>
+# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["copyright-holder"]}
 #
 # SPDX-License-Identifier: MIT
 __version__ = "0.0.1"
@@ -87,9 +87,9 @@ classifiers = [
 dependencies = []
 
 [project.urls]
-Documentation = "https://github.com/{kwargs["author"]}/{kwargs["project_name_normalized"]}#readme"
-Issues = "https://github.com/{kwargs["author"]}/{kwargs["project_name_normalized"]}/issues"
-Source = "https://github.com/{kwargs["author"]}/{kwargs["project_name_normalized"]}"
+Documentation = "https://github.com/{kwargs["github-org"]}/{kwargs["project_name_normalized"]}#readme"
+Issues = "https://github.com/{kwargs["github-org"]}/{kwargs["project_name_normalized"]}/issues"
+Source = "https://github.com/{kwargs["github-org"]}/{kwargs["project_name_normalized"]}"
 
 [tool.hatch.version]
 path = "src/{kwargs["package_name"]}/__about__.py"

--- a/tests/helpers/templates/new/default.py
+++ b/tests/helpers/templates/new/default.py
@@ -17,7 +17,7 @@ def get_files(**kwargs):
         File(
             Path("src", kwargs["package_name"], "__init__.py"),
             f"""\
-# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["author"]} <{kwargs["email"]}>
+# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["copyright-holder"]}
 #
 # SPDX-License-Identifier: MIT
 """,
@@ -25,7 +25,7 @@ def get_files(**kwargs):
         File(
             Path("src", kwargs["package_name"], "__about__.py"),
             f"""\
-# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["author"]} <{kwargs["email"]}>
+# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["copyright-holder"]}
 #
 # SPDX-License-Identifier: MIT
 __version__ = "0.0.1"
@@ -34,7 +34,7 @@ __version__ = "0.0.1"
         File(
             Path("tests", "__init__.py"),
             f"""\
-# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["author"]} <{kwargs["email"]}>
+# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["copyright-holder"]}
 #
 # SPDX-License-Identifier: MIT
 """,
@@ -97,9 +97,9 @@ classifiers = [
 dependencies = []
 
 [project.urls]
-Documentation = "https://github.com/{kwargs["author"]}/{kwargs["project_name_normalized"]}#readme"
-Issues = "https://github.com/{kwargs["author"]}/{kwargs["project_name_normalized"]}/issues"
-Source = "https://github.com/{kwargs["author"]}/{kwargs["project_name_normalized"]}"
+Documentation = "https://github.com/{kwargs["github-org"]}/{kwargs["project_name_normalized"]}#readme"
+Issues = "https://github.com/{kwargs["github-org"]}/{kwargs["project_name_normalized"]}/issues"
+Source = "https://github.com/{kwargs["github-org"]}/{kwargs["project_name_normalized"]}"
 
 [tool.hatch.version]
 path = "src/{kwargs["package_name"]}/__about__.py"

--- a/tests/helpers/templates/new/feature_cli.py
+++ b/tests/helpers/templates/new/feature_cli.py
@@ -15,7 +15,7 @@ def get_files(**kwargs):
         File(
             Path("src", kwargs["package_name"], "__init__.py"),
             f"""\
-# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["author"]} <{kwargs["email"]}>
+# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["copyright-holder"]}
 #
 # SPDX-License-Identifier: MIT
 """,
@@ -23,7 +23,7 @@ def get_files(**kwargs):
         File(
             Path("src", kwargs["package_name"], "__about__.py"),
             f"""\
-# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["author"]} <{kwargs["email"]}>
+# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["copyright-holder"]}
 #
 # SPDX-License-Identifier: MIT
 __version__ = "0.0.1"
@@ -32,7 +32,7 @@ __version__ = "0.0.1"
         File(
             Path("src", kwargs["package_name"], "__main__.py"),
             f"""\
-# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["author"]} <{kwargs["email"]}>
+# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["copyright-holder"]}
 #
 # SPDX-License-Identifier: MIT
 import sys
@@ -46,7 +46,7 @@ if __name__ == "__main__":
         File(
             Path("src", kwargs["package_name"], "cli", "__init__.py"),
             f"""\
-# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["author"]} <{kwargs["email"]}>
+# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["copyright-holder"]}
 #
 # SPDX-License-Identifier: MIT
 import click
@@ -63,7 +63,7 @@ def {kwargs["package_name"]}():
         File(
             Path("tests", "__init__.py"),
             f"""\
-# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["author"]} <{kwargs["email"]}>
+# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["copyright-holder"]}
 #
 # SPDX-License-Identifier: MIT
 """,
@@ -128,9 +128,9 @@ dependencies = [
 ]
 
 [project.urls]
-Documentation = "https://github.com/{kwargs["author"]}/{kwargs["project_name_normalized"]}#readme"
-Issues = "https://github.com/{kwargs["author"]}/{kwargs["project_name_normalized"]}/issues"
-Source = "https://github.com/{kwargs["author"]}/{kwargs["project_name_normalized"]}"
+Documentation = "https://github.com/{kwargs["github-org"]}/{kwargs["project_name_normalized"]}#readme"
+Issues = "https://github.com/{kwargs["github-org"]}/{kwargs["project_name_normalized"]}/issues"
+Source = "https://github.com/{kwargs["github-org"]}/{kwargs["project_name_normalized"]}"
 
 [project.scripts]
 {kwargs["project_name_normalized"]} = "{kwargs["package_name"]}.cli:{kwargs["package_name"]}"

--- a/tests/helpers/templates/new/feature_no_src_layout.py
+++ b/tests/helpers/templates/new/feature_no_src_layout.py
@@ -17,7 +17,7 @@ def get_files(**kwargs):
         File(
             Path(kwargs["package_name"], "__init__.py"),
             f"""\
-# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["author"]} <{kwargs["email"]}>
+# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["copyright-holder"]}
 #
 # SPDX-License-Identifier: MIT
 """,
@@ -25,7 +25,7 @@ def get_files(**kwargs):
         File(
             Path(kwargs["package_name"], "__about__.py"),
             f"""\
-# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["author"]} <{kwargs["email"]}>
+# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["copyright-holder"]}
 #
 # SPDX-License-Identifier: MIT
 __version__ = "0.0.1"
@@ -34,7 +34,7 @@ __version__ = "0.0.1"
         File(
             Path("tests", "__init__.py"),
             f"""\
-# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["author"]} <{kwargs["email"]}>
+# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["copyright-holder"]}
 #
 # SPDX-License-Identifier: MIT
 """,
@@ -97,9 +97,9 @@ classifiers = [
 dependencies = []
 
 [project.urls]
-Documentation = "https://github.com/{kwargs["author"]}/{kwargs["project_name_normalized"]}#readme"
-Issues = "https://github.com/{kwargs["author"]}/{kwargs["project_name_normalized"]}/issues"
-Source = "https://github.com/{kwargs["author"]}/{kwargs["project_name_normalized"]}"
+Documentation = "https://github.com/{kwargs["github-org"]}/{kwargs["project_name_normalized"]}#readme"
+Issues = "https://github.com/{kwargs["github-org"]}/{kwargs["project_name_normalized"]}/issues"
+Source = "https://github.com/{kwargs["github-org"]}/{kwargs["project_name_normalized"]}"
 
 [tool.hatch.version]
 path = "{kwargs["package_name"]}/__about__.py"

--- a/tests/helpers/templates/new/licenses_empty.py
+++ b/tests/helpers/templates/new/licenses_empty.py
@@ -60,9 +60,9 @@ classifiers = [
 dependencies = []
 
 [project.urls]
-Documentation = "https://github.com/{kwargs["author"]}/{kwargs["project_name_normalized"]}#readme"
-Issues = "https://github.com/{kwargs["author"]}/{kwargs["project_name_normalized"]}/issues"
-Source = "https://github.com/{kwargs["author"]}/{kwargs["project_name_normalized"]}"
+Documentation = "https://github.com/{kwargs["github-org"]}/{kwargs["project_name_normalized"]}#readme"
+Issues = "https://github.com/{kwargs["github-org"]}/{kwargs["project_name_normalized"]}/issues"
+Source = "https://github.com/{kwargs["github-org"]}/{kwargs["project_name_normalized"]}"
 
 [tool.hatch.version]
 path = "src/{kwargs["package_name"]}/__about__.py"

--- a/tests/helpers/templates/new/licenses_multiple.py
+++ b/tests/helpers/templates/new/licenses_multiple.py
@@ -16,7 +16,7 @@ def get_files(**kwargs):
         File(
             Path("src", kwargs["package_name"], "__init__.py"),
             f"""\
-# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["author"]} <{kwargs["email"]}>
+# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["copyright-holder"]}
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 """,
@@ -24,7 +24,7 @@ def get_files(**kwargs):
         File(
             Path("src", kwargs["package_name"], "__about__.py"),
             f"""\
-# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["author"]} <{kwargs["email"]}>
+# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["copyright-holder"]}
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 __version__ = "0.0.1"
@@ -33,7 +33,7 @@ __version__ = "0.0.1"
         File(
             Path("tests", "__init__.py"),
             f"""\
-# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["author"]} <{kwargs["email"]}>
+# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["copyright-holder"]}
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 """,
@@ -100,9 +100,9 @@ classifiers = [
 dependencies = []
 
 [project.urls]
-Documentation = "https://github.com/{kwargs["author"]}/{kwargs["project_name_normalized"]}#readme"
-Issues = "https://github.com/{kwargs["author"]}/{kwargs["project_name_normalized"]}/issues"
-Source = "https://github.com/{kwargs["author"]}/{kwargs["project_name_normalized"]}"
+Documentation = "https://github.com/{kwargs["github-org"]}/{kwargs["project_name_normalized"]}#readme"
+Issues = "https://github.com/{kwargs["github-org"]}/{kwargs["project_name_normalized"]}/issues"
+Source = "https://github.com/{kwargs["github-org"]}/{kwargs["project_name_normalized"]}"
 
 [tool.hatch.version]
 path = "src/{kwargs["package_name"]}/__about__.py"

--- a/tests/helpers/templates/new/projects_urls_empty.py
+++ b/tests/helpers/templates/new/projects_urls_empty.py
@@ -15,7 +15,7 @@ def get_files(**kwargs):
         File(
             Path("src", kwargs["package_name"], "__init__.py"),
             f"""\
-# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["author"]} <{kwargs["email"]}>
+# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["copyright-holder"]}
 #
 # SPDX-License-Identifier: MIT
 """,
@@ -23,7 +23,7 @@ def get_files(**kwargs):
         File(
             Path("src", kwargs["package_name"], "__about__.py"),
             f"""\
-# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["author"]} <{kwargs["email"]}>
+# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["copyright-holder"]}
 #
 # SPDX-License-Identifier: MIT
 __version__ = "0.0.1"
@@ -32,7 +32,7 @@ __version__ = "0.0.1"
         File(
             Path("tests", "__init__.py"),
             f"""\
-# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["author"]} <{kwargs["email"]}>
+# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["copyright-holder"]}
 #
 # SPDX-License-Identifier: MIT
 """,

--- a/tests/helpers/templates/new/projects_urls_space_in_label.py
+++ b/tests/helpers/templates/new/projects_urls_space_in_label.py
@@ -15,7 +15,7 @@ def get_files(**kwargs):
         File(
             Path("src", kwargs["package_name"], "__init__.py"),
             f"""\
-# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["author"]} <{kwargs["email"]}>
+# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["copyright-holder"]}
 #
 # SPDX-License-Identifier: MIT
 """,
@@ -23,7 +23,7 @@ def get_files(**kwargs):
         File(
             Path("src", kwargs["package_name"], "__about__.py"),
             f"""\
-# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["author"]} <{kwargs["email"]}>
+# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["copyright-holder"]}
 #
 # SPDX-License-Identifier: MIT
 __version__ = "0.0.1"
@@ -32,7 +32,7 @@ __version__ = "0.0.1"
         File(
             Path("tests", "__init__.py"),
             f"""\
-# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["author"]} <{kwargs["email"]}>
+# SPDX-FileCopyrightText: {kwargs["year"]}-present {kwargs["copyright-holder"]}
 #
 # SPDX-License-Identifier: MIT
 """,
@@ -95,9 +95,9 @@ classifiers = [
 dependencies = []
 
 [project.urls]
-Documentation = "https://github.com/{kwargs["author"]}/{kwargs["project_name_normalized"]}#readme"
-Source = "https://github.com/{kwargs["author"]}/{kwargs["project_name_normalized"]}"
-"Bug Tracker" = "https://github.com/{kwargs["author"]}/{kwargs["project_name_normalized"]}/issues"
+Documentation = "https://github.com/{kwargs["github-org"]}/{kwargs["project_name_normalized"]}#readme"
+Source = "https://github.com/{kwargs["github-org"]}/{kwargs["project_name_normalized"]}"
+"Bug Tracker" = "https://github.com/{kwargs["github-org"]}/{kwargs["project_name_normalized"]}/issues"
 
 [tool.hatch.version]
 path = "src/{kwargs["package_name"]}/__about__.py"


### PR DESCRIPTION
Two updates to facilitate using hatch and hatch cli when working within an orginization rather than as a sole-developer.

* Added "github-org" field to template section of config

    Allows control of "organization" portion of auto-generated project
    urls.

    Fetched from `gh` github cli command if it is installed and
    configured. Defaults to name

* Added "copyright-holder" field to template section of config

    Overrides copyright holder wording, allowing for automatic setting
    of copyright in cases when the creator is working for an
    organization.

    Defaults to previous value ('{name} <{email}>') if not set.

* Updated tests to reflect change.

* Added new tests to cover new template params and default values.