### PR TITLE
Limit locating ignore files to both kind of repositories

### DIFF
--- a/backend/src/hatchling/builders/config.py
+++ b/backend/src/hatchling/builders/config.py
@@ -752,11 +752,11 @@ class BuilderConfig:
     def vcs_exclusion_files(self) -> dict[str, list[str]]:
         exclusion_files: dict[str, list[str]] = {"git": [], "hg": []}
 
-        local_gitignore = locate_file(self.root, ".gitignore", boundary=".git")
+        local_gitignore = locate_file(self.root, ".gitignore", boundaries=[".git", ".hg"])
         if local_gitignore is not None:
             exclusion_files["git"].append(local_gitignore)
 
-        local_hgignore = locate_file(self.root, ".hgignore", boundary=".hg")
+        local_hgignore = locate_file(self.root, ".hgignore", boundaries=[".git", ".hg"])
         if local_hgignore is not None:
             exclusion_files["hg"].append(local_hgignore)
 

--- a/backend/src/hatchling/utils/fs.py
+++ b/backend/src/hatchling/utils/fs.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import os
 
 
-def locate_file(root: str, file_name: str, *, boundary: str | None = None) -> str | None:
+def locate_file(root: str, file_name: str, *, boundaries: list[str] | None = None) -> str | None:
     while True:
         file_path = os.path.join(root, file_name)
         if os.path.isfile(file_path):
             return file_path
 
-        if boundary is not None and os.path.exists(os.path.join(root, boundary)):
+        if boundaries is not None and any(os.path.exists(os.path.join(root, boundary)) for boundary in boundaries):
             return None
 
         new_root = os.path.dirname(root)


### PR DESCRIPTION
I have a general `.gitignore` in my home directory but when I build a package from a mercurial repository (with only an `.hgignore` file) this `.gitignore` file is used while it is not part of the repository.
So I think the boundaries should apply to both type of repository.