### PR TITLE
Fix hook deps not being installed

### DIFF
--- a/src/hatch/project/core.py
+++ b/src/hatch/project/core.py
@@ -294,10 +294,12 @@ class Project:
                 from hatch.dep.core import Dependency
 
                 self.build_env.additional_dependencies.extend(map(Dependency, additional_dependencies))
-                with self.build_env.app_status_dependency_synchronization():
-                    self.build_env.sync_dependencies()
 
             self.prepare_environment(self.build_env, keep_env=keep_env)
+
+            if additional_dependencies:
+                with self.build_env.app_status_dependency_synchronization():
+                    self.build_env.sync_dependencies()
 
     def get_dependencies(self) -> tuple[list[str], dict[str, list[str]]]:
         dynamic_fields = {"dependencies", "optional-dependencies"}

--- a/src/hatch/project/core.py
+++ b/src/hatch/project/core.py
@@ -272,8 +272,6 @@ class Project:
                 except Exception as e:  # noqa: BLE001
                     self.app.abort(f"Environment `{self.build_env.name}` is incompatible: {e}")
 
-            self.prepare_environment(self.build_env, keep_env=keep_env)
-
             additional_dependencies: list[str] = []
             with self.app.status("Inspecting build dependencies"):
                 if build_backend != BUILD_BACKEND:
@@ -298,6 +296,8 @@ class Project:
                 self.build_env.additional_dependencies.extend(map(Dependency, additional_dependencies))
                 with self.build_env.app_status_dependency_synchronization():
                     self.build_env.sync_dependencies()
+
+            self.prepare_environment(self.build_env, keep_env=keep_env)
 
     def get_dependencies(self) -> tuple[list[str], dict[str, list[str]]]:
         dynamic_fields = {"dependencies", "optional-dependencies"}

--- a/tests/cli/build/test_build.py
+++ b/tests/cli/build/test_build.py
@@ -53,10 +53,10 @@ class TestOtherBackend:
         assert result.exit_code == 0, result.output
         assert result.output == helpers.dedent(
             f"""
+            Inspecting build dependencies
             Creating environment: hatch-build
             Checking dependencies
             Syncing dependencies
-            Inspecting build dependencies
             ──────────────────────────────────── sdist ─────────────────────────────────────
             {sdist_path.relative_to(path)}
             ──────────────────────────────────── wheel ─────────────────────────────────────
@@ -145,10 +145,10 @@ print("Hello World!")
         assert result.exit_code == 0, result.output
         assert result.output == helpers.dedent(
             f"""
+            Inspecting build dependencies
             Creating environment: hatch-build
             Checking dependencies
             Syncing dependencies
-            Inspecting build dependencies
             ──────────────────────────────────── sdist ─────────────────────────────────────
             {sdist_path.relative_to(path)}
             ──────────────────────────────────── wheel ─────────────────────────────────────
@@ -207,10 +207,10 @@ def test_no_compatibility_check_if_exists(hatch, temp_dir, helpers, mocker):
     assert result.exit_code == 0, result.output
     assert result.output == helpers.dedent(
         """
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         ──────────────────────────────────── sdist ─────────────────────────────────────
         ──────────────────────────────────── wheel ─────────────────────────────────────
         """
@@ -251,10 +251,10 @@ def test_unknown_targets(hatch, temp_dir, helpers):
     assert result.exit_code == 1, result.output
     assert result.output == helpers.dedent(
         """
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         ───────────────────────────────────── foo ──────────────────────────────────────
         Unknown build targets: foo
         """
@@ -277,10 +277,10 @@ def test_mutually_exclusive_hook_options(hatch, temp_dir, helpers):
     assert result.exit_code == 1, result.output
     assert result.output == helpers.dedent(
         """
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         ──────────────────────────────────── sdist ─────────────────────────────────────
         Cannot use both --hooks-only and --no-hooks together
         """
@@ -312,10 +312,10 @@ def test_default(hatch, temp_dir, helpers):
 
     assert result.output == helpers.dedent(
         f"""
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         ──────────────────────────────────── sdist ─────────────────────────────────────
         {sdist_path.relative_to(path)}
         ──────────────────────────────────── wheel ─────────────────────────────────────
@@ -348,10 +348,10 @@ def test_explicit_targets(hatch, temp_dir, helpers):
 
     assert result.output == helpers.dedent(
         f"""
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         ──────────────────────────────────── wheel ─────────────────────────────────────
         {wheel_path.relative_to(path)}
         """
@@ -383,10 +383,10 @@ def test_explicit_directory(hatch, temp_dir, helpers):
 
     assert result.output == helpers.dedent(
         f"""
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         ──────────────────────────────────── sdist ─────────────────────────────────────
         {sdist_path}
         ──────────────────────────────────── wheel ─────────────────────────────────────
@@ -420,10 +420,10 @@ def test_explicit_directory_env_var(hatch, temp_dir, helpers):
 
     assert result.output == helpers.dedent(
         f"""
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         ──────────────────────────────────── sdist ─────────────────────────────────────
         {sdist_path}
         ──────────────────────────────────── wheel ─────────────────────────────────────
@@ -762,10 +762,10 @@ def test_clean_hooks_after(hatch, temp_dir, helpers, config_file):
 
     assert result.output == helpers.dedent(
         f"""
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         ──────────────────────────────────── sdist ─────────────────────────────────────
         {sdist_path.relative_to(path)}
         ──────────────────────────────────── wheel ─────────────────────────────────────
@@ -828,10 +828,10 @@ def test_clean_hooks_after_env_var(hatch, temp_dir, helpers, config_file):
 
     assert result.output == helpers.dedent(
         f"""
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         ──────────────────────────────────── sdist ─────────────────────────────────────
         {sdist_path.relative_to(path)}
         ──────────────────────────────────── wheel ─────────────────────────────────────
@@ -955,10 +955,10 @@ def test_hooks_only(hatch, temp_dir, helpers, config_file):
     helpers.assert_output_match(
         result.output,
         r"""
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         cmd \[1\] \| python -u .+
         ──────────────────────────────────── wheel ─────────────────────────────────────
         cmd \[1\] \| python -u -m hatchling build --target wheel --hooks-only
@@ -1016,10 +1016,10 @@ def test_hooks_only_env_var(hatch, temp_dir, helpers, config_file):
     helpers.assert_output_match(
         result.output,
         r"""
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         cmd \[1\] \| python -u .+
         ──────────────────────────────────── wheel ─────────────────────────────────────
         cmd \[1\] \| python -u -m hatchling build --target wheel --hooks-only
@@ -1077,10 +1077,10 @@ def test_extensions_only(hatch, temp_dir, helpers, config_file):
     helpers.assert_output_match(
         result.output,
         r"""
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         cmd \[1\] \| python -u .+
         ──────────────────────────────────── wheel ─────────────────────────────────────
         cmd \[1\] \| python -u -m hatchling build --target wheel --hooks-only
@@ -1136,10 +1136,10 @@ def test_no_hooks(hatch, temp_dir, helpers):
 
     assert result.output == helpers.dedent(
         f"""
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         ──────────────────────────────────── wheel ─────────────────────────────────────
         {wheel_path.relative_to(path)}
         """
@@ -1192,10 +1192,10 @@ def test_no_hooks_env_var(hatch, temp_dir, helpers):
 
     assert result.output == helpers.dedent(
         f"""
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         ──────────────────────────────────── wheel ─────────────────────────────────────
         {wheel_path.relative_to(path)}
         """
@@ -1227,10 +1227,10 @@ def test_debug_verbosity(hatch, temp_dir, helpers):
     helpers.assert_output_match(
         result.output,
         rf"""
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         ──────────────────────────────────── wheel ─────────────────────────────────────
         cmd \[1\] \| python -u -m hatchling build --target wheel:standard
         Building `wheel` version `standard`
@@ -1283,10 +1283,10 @@ def test_shipped(hatch, temp_dir, helpers):
 
     assert result.output == helpers.dedent(
         """
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         ──────────────────────────────────── sdist ─────────────────────────────────────
         ──────────────────────────────────── wheel ─────────────────────────────────────
         """
@@ -1363,10 +1363,10 @@ def test_build_dependencies(hatch, temp_dir, helpers):
 
     assert result.output == helpers.dedent(
         """
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         Syncing dependencies
         ──────────────────────────────────── custom ────────────────────────────────────
         """
@@ -1409,10 +1409,10 @@ def test_plugin_dependencies_unmet(hatch, temp_dir, helpers, mock_plugin_install
     assert result.output == helpers.dedent(
         f"""
         Syncing environment plugin requirements
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         ──────────────────────────────────── sdist ─────────────────────────────────────
         {sdist_path.relative_to(path)}
         ──────────────────────────────────── wheel ─────────────────────────────────────

--- a/tests/cli/env/test_create.py
+++ b/tests/cli/env/test_create.py
@@ -1545,10 +1545,10 @@ def test_sync_dynamic_dependencies(hatch, helpers, temp_dir, platform, uv_on_pat
         Installing project in development mode
         Running post-installation commands
         Polling dependency state
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         Checking dependencies
         Syncing dependencies
         """

--- a/tests/cli/project/test_metadata.py
+++ b/tests/cli/project/test_metadata.py
@@ -43,10 +43,10 @@ def test_other_backend(hatch, temp_dir, helpers):
     assert result.exit_code == 0, result.output
     assert result.output == helpers.dedent(
         f"""
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         {{
             "name": "my-app",
             "version": "0.0.1",
@@ -110,10 +110,10 @@ def test_default_all(hatch, temp_dir, helpers):
     assert result.exit_code == 0, result.output
     assert result.output == helpers.dedent(
         f"""
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         {{
             "name": "my-app",
             "version": "0.0.1",
@@ -175,10 +175,10 @@ def test_field_readme(hatch, temp_dir):
     assert result.exit_code == 0, result.output
     assert result.output == (
         f"""\
+Inspecting build dependencies
 Creating environment: hatch-build
 Checking dependencies
 Syncing dependencies
-Inspecting build dependencies
 {(path / "README.txt").read_text()}
 """
     )
@@ -202,10 +202,10 @@ def test_field_string(hatch, temp_dir, helpers):
     assert result.exit_code == 0, result.output
     assert result.output == helpers.dedent(
         """
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         MIT
         """
     )
@@ -229,10 +229,10 @@ def test_field_complex(hatch, temp_dir, helpers):
     assert result.exit_code == 0, result.output
     assert result.output == helpers.dedent(
         """
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         {
             "Documentation": "https://github.com/Foo Bar/my-app#readme",
             "Issues": "https://github.com/Foo Bar/my-app/issues",
@@ -304,10 +304,10 @@ def test_plugin_dependencies_unmet(hatch, temp_dir, helpers, mock_plugin_install
     assert result.output == helpers.dedent(
         f"""
         Syncing environment plugin requirements
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         {{
             "name": "my-app",
             "version": "0.0.1",
@@ -371,10 +371,10 @@ def test_build_dependencies_unmet(hatch, temp_dir, helpers):
     assert result.exit_code == 0, result.output
     assert result.output == helpers.dedent(
         """
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         Syncing dependencies
         MIT
         """
@@ -405,10 +405,10 @@ def test_no_compatibility_check_if_exists(hatch, temp_dir, helpers, mocker):
     assert result.exit_code == 0, result.output
     assert result.output == helpers.dedent(
         """
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         MIT
         """
     )

--- a/tests/cli/version/test_version.py
+++ b/tests/cli/version/test_version.py
@@ -63,10 +63,10 @@ def test_other_backend_show(hatch, temp_dir, helpers):
     assert result.exit_code == 0, result.output
     assert result.output == helpers.dedent(
         """
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         9000.42
         """
     )
@@ -147,10 +147,10 @@ def test_show_dynamic(hatch, helpers, temp_dir):
     assert result.exit_code == 0, result.output
     assert result.output == helpers.dedent(
         """
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         0.0.1
         """
     )
@@ -185,10 +185,10 @@ def test_plugin_dependencies_unmet(hatch, helpers, temp_dir, mock_plugin_install
     assert result.output == helpers.dedent(
         """
         Syncing environment plugin requirements
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         0.0.1
         """
     )
@@ -218,10 +218,10 @@ def test_no_compatibility_check_if_exists(hatch, helpers, temp_dir, mocker):
     assert result.exit_code == 0, result.output
     assert result.output == helpers.dedent(
         """
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         0.0.1
         """
     )
@@ -257,10 +257,10 @@ def test_set_dynamic(hatch, helpers, temp_dir):
     assert result.exit_code == 0, result.output
     assert result.output == helpers.dedent(
         """
+        Inspecting build dependencies
         Creating environment: hatch-build
         Checking dependencies
         Syncing dependencies
-        Inspecting build dependencies
         Old: 0.0.1
         New: 0.1.0rc0
         """


### PR DESCRIPTION
Fixes #2139
Fixes #2110
Superseeds & closes #2206

I didn't notice #2206 had been raised until after I had finished manually debugging myself, but thought I might as well open my own PR. This is an alternate fix to #2206 that retains the performance benefits of using `cached_property`.

The issue was that `additional_dependencies` hadn't been found yet when `prepare_environment` was called, so they didn't end up in the cached `all_dependencies_complex`. I fixed the issue by moving the `prepare_environment` call to after `additional_dependencies` is set.

I would greatly appreciate it if this is merged & released soon, as I'm sure many others would be too, as this is blocking me from upgating beyond hatch 1.15.1 (and by extension, beyond virtualenv 20.39.1).

I'd appreciate guidance creating tests if they're desired. I'm not sure what the best way to go about it is - the other PR linked seems to do it a bit roundabout by creating temp dirs

(No AI was used with this PR)
