### PR TITLE
Add support for proxy environment variables in `publish`

### DIFF
--- a/docs/plugins/publisher/package-index.md
+++ b/docs/plugins/publisher/package-index.md
@@ -40,6 +40,11 @@ url = "https://test.pypi.org/legacy/"
 
 The `repo` and `repos` options have no effect.
 
+### Proxy support
+
+The publisher honors standard proxy environment variables, including
+`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and `NO_PROXY`.
+
 ### Confirmation prompt
 
 You can require a confirmation prompt or use of the `-y`/`--yes` flag by

--- a/src/hatch/index/core.py
+++ b/src/hatch/index/core.py
@@ -51,6 +51,7 @@ class PackageIndex:
     @cached_property
     def client(self) -> httpx.Client:
         import httpx
+        from httpx._utils import get_environment_proxies  # noqa: PLC2701
 
         from hatch.utils.network import DEFAULT_TIMEOUT
 
@@ -59,9 +60,20 @@ class PackageIndex:
             f"{sys.implementation.name}/{'.'.join(map(str, sys.version_info[:3]))} "
             f"HTTPX/{httpx.__version__}"
         )
+        proxy_map = get_environment_proxies()
+        mounts: dict[str, httpx.HTTPTransport | None] = {}
+        for pattern, proxy in proxy_map.items():
+            if proxy is None:
+                mounts[pattern] = None
+            else:
+                mounts[pattern] = httpx.HTTPTransport(
+                    retries=3, verify=self.__verify, cert=self.__cert, trust_env=True, proxy=proxy
+                )
+
         return httpx.Client(
             headers={"User-Agent": user_agent},
-            transport=httpx.HTTPTransport(retries=3, verify=self.__verify, cert=self.__cert),
+            transport=httpx.HTTPTransport(retries=3, verify=self.__verify, cert=self.__cert, trust_env=True),
+            mounts=mounts,
             timeout=DEFAULT_TIMEOUT,
         )
 

--- a/tests/index/test_core.py
+++ b/tests/index/test_core.py
@@ -1,6 +1,7 @@
 import platform
 import sys
 
+import httpcore
 import httpx
 import pytest
 
@@ -84,3 +85,35 @@ class TestUserAgent:
             f"Hatch/{__version__} {sys.implementation.name}/{platform.python_version()} HTTPX/{httpx.__version__}"
         )
         assert user_agent == expected
+
+
+class TestEnvProxy:
+    @pytest.mark.parametrize(
+        ("environment", "proxies"),
+        [
+            ({}, {}),
+            ({"HTTP_PROXY": "http://127.0.0.1"}, {"http://": "http://127.0.0.1"}),
+            (
+                {"https_proxy": "http://127.0.0.1", "HTTP_PROXY": "https://127.0.0.1"},
+                {"https://": "http://127.0.0.1", "http://": "https://127.0.0.1"},
+            ),
+            ({"all_proxy": "http://127.0.0.1"}, {"all://": "http://127.0.0.1"}),
+            ({"no_proxy": "127.0.0.1"}, {"all://127.0.0.1": None}),
+        ],
+    )
+    def test_environment_proxies(self, mocker, environment, proxies):
+        mocker.patch.dict("os.environ", environment, clear=True)
+
+        client = PackageIndex("https://foo.internal/a/b/").client
+        mounts = {pattern.pattern: transport for pattern, transport in client._mounts.items()}  # noqa: SLF001
+
+        assert mounts.keys() == proxies.keys()
+
+        for pattern, proxy in proxies.items():
+            transport = mounts[pattern]
+            if proxy is None:
+                assert transport is None
+            else:
+                assert isinstance(transport, httpx.HTTPTransport)
+                assert isinstance(transport._pool, httpcore.HTTPProxy)  # noqa: SLF001
+                assert transport._pool._proxy_url == httpcore.URL(proxy)  # noqa: SLF001


### PR DESCRIPTION
stumbled across this at work, fixes #1908 

---

- httpx does not honor proxy environment variables automatically when a custom transport is passed, like in this case
- we use `httpx._utils.get_environment_proxies`[0] to stay consistent with httpx behavior instead of reimplementing env var parsing ourselves

[0] https://github.com/encode/httpx/blob/b5addb64f0161ff6bfe94c124ef76f6a1fba5254/httpx/_utils.py#L30