### PR TITLE
Pass config_settings from build frontend to builders

### DIFF
--- a/backend/src/hatchling/build.py
+++ b/backend/src/hatchling/build.py
@@ -14,39 +14,39 @@ __all__ = [
 __all__ += ["__all__"]
 
 
-def get_requires_for_build_sdist(config_settings: dict[str, Any] | None = None) -> list[str]:  # noqa: ARG001
+def get_requires_for_build_sdist(config_settings: dict[str, Any] | None = None) -> list[str]:
     """
     https://peps.python.org/pep-0517/#get-requires-for-build-sdist
     """
     from hatchling.builders.sdist import SdistBuilder
 
-    builder = SdistBuilder(os.getcwd())
+    builder = SdistBuilder(os.getcwd(), config_settings=config_settings)
     return builder.config.dependencies
 
 
-def build_sdist(sdist_directory: str, config_settings: dict[str, Any] | None = None) -> str:  # noqa: ARG001
+def build_sdist(sdist_directory: str, config_settings: dict[str, Any] | None = None) -> str:
     """
     https://peps.python.org/pep-0517/#build-sdist
     """
     from hatchling.builders.sdist import SdistBuilder
 
-    builder = SdistBuilder(os.getcwd())
+    builder = SdistBuilder(os.getcwd(), config_settings=config_settings)
     return os.path.basename(next(builder.build(directory=sdist_directory, versions=["standard"])))
 
 
-def get_requires_for_build_wheel(config_settings: dict[str, Any] | None = None) -> list[str]:  # noqa: ARG001
+def get_requires_for_build_wheel(config_settings: dict[str, Any] | None = None) -> list[str]:
     """
     https://peps.python.org/pep-0517/#get-requires-for-build-wheel
     """
     from hatchling.builders.wheel import WheelBuilder
 
-    builder = WheelBuilder(os.getcwd())
+    builder = WheelBuilder(os.getcwd(), config_settings=config_settings)
     return builder.config.dependencies
 
 
 def build_wheel(
     wheel_directory: str,
-    config_settings: dict[str, Any] | None = None,  # noqa: ARG001
+    config_settings: dict[str, Any] | None = None,
     metadata_directory: str | None = None,  # noqa: ARG001
 ) -> str:
     """
@@ -54,24 +54,24 @@ def build_wheel(
     """
     from hatchling.builders.wheel import WheelBuilder
 
-    builder = WheelBuilder(os.getcwd())
+    builder = WheelBuilder(os.getcwd(), config_settings=config_settings)
     return os.path.basename(next(builder.build(directory=wheel_directory, versions=["standard"])))
 
 
-def get_requires_for_build_editable(config_settings: dict[str, Any] | None = None) -> list[str]:  # noqa: ARG001
+def get_requires_for_build_editable(config_settings: dict[str, Any] | None = None) -> list[str]:
     """
     https://peps.python.org/pep-0660/#get-requires-for-build-editable
     """
     from hatchling.builders.constants import EDITABLES_REQUIREMENT
     from hatchling.builders.wheel import WheelBuilder
 
-    builder = WheelBuilder(os.getcwd())
+    builder = WheelBuilder(os.getcwd(), config_settings=config_settings)
     return [*builder.config.dependencies, EDITABLES_REQUIREMENT]
 
 
 def build_editable(
     wheel_directory: str,
-    config_settings: dict[str, Any] | None = None,  # noqa: ARG001
+    config_settings: dict[str, Any] | None = None,
     metadata_directory: str | None = None,  # noqa: ARG001
 ) -> str:
     """
@@ -79,7 +79,7 @@ def build_editable(
     """
     from hatchling.builders.wheel import WheelBuilder
 
-    builder = WheelBuilder(os.getcwd())
+    builder = WheelBuilder(os.getcwd(), config_settings=config_settings)
     return os.path.basename(next(builder.build(directory=wheel_directory, versions=["editable"])))
 
 
@@ -100,14 +100,14 @@ if "PIP_BUILD_TRACKER" not in os.environ:
 
     def prepare_metadata_for_build_wheel(
         metadata_directory: str,
-        config_settings: dict[str, Any] | None = None,  # noqa: ARG001
+        config_settings: dict[str, Any] | None = None,
     ) -> str:
         """
         https://peps.python.org/pep-0517/#prepare-metadata-for-build-wheel
         """
         from hatchling.builders.wheel import WheelBuilder
 
-        builder = WheelBuilder(os.getcwd())
+        builder = WheelBuilder(os.getcwd(), config_settings=config_settings)
 
         directory = os.path.join(metadata_directory, f"{builder.artifact_project_id}.dist-info")
         if not os.path.isdir(directory):
@@ -120,7 +120,7 @@ if "PIP_BUILD_TRACKER" not in os.environ:
 
     def prepare_metadata_for_build_editable(
         metadata_directory: str,
-        config_settings: dict[str, Any] | None = None,  # noqa: ARG001
+        config_settings: dict[str, Any] | None = None,
     ) -> str:
         """
         https://peps.python.org/pep-0660/#prepare-metadata-for-build-editable
@@ -128,7 +128,7 @@ if "PIP_BUILD_TRACKER" not in os.environ:
         from hatchling.builders.constants import EDITABLES_REQUIREMENT
         from hatchling.builders.wheel import WheelBuilder
 
-        builder = WheelBuilder(os.getcwd())
+        builder = WheelBuilder(os.getcwd(), config_settings=config_settings)
 
         directory = os.path.join(metadata_directory, f"{builder.artifact_project_id}.dist-info")
         if not os.path.isdir(directory):

--- a/backend/src/hatchling/builders/hooks/plugin/interface.py
+++ b/backend/src/hatchling/builders/hooks/plugin/interface.py
@@ -45,6 +45,7 @@ class BuildHookInterface(Generic[BuilderConfigBound]):  # no cov
         metadata: ProjectMetadata,
         directory: str,
         target_name: str,
+        config_settings: dict[str, Any] | None,
         app: Application | None = None,
     ) -> None:
         self.__root = root
@@ -53,6 +54,7 @@ class BuildHookInterface(Generic[BuilderConfigBound]):  # no cov
         self.__metadata = metadata
         self.__directory = directory
         self.__target_name = target_name
+        self.__config_settings = config_settings
         self.__app = app
 
     @property
@@ -90,6 +92,13 @@ class BuildHookInterface(Generic[BuilderConfigBound]):  # no cov
     def metadata(self) -> ProjectMetadata:
         # Undocumented for now
         return self.__metadata
+
+    @property
+    def config_settings(self) -> dict[str, Any] | None:
+        """
+        Configuration settings from the build frontend, if supported.
+        """
+        return self.__config_settings
 
     @property
     def build_config(self) -> BuilderConfigBound:

--- a/backend/src/hatchling/builders/plugin/interface.py
+++ b/backend/src/hatchling/builders/plugin/interface.py
@@ -62,12 +62,14 @@ class BuilderInterface(ABC, Generic[BuilderConfigBound, PluginManagerBound]):
         config: dict[str, Any] | None = None,
         metadata: ProjectMetadata | None = None,
         app: Application | None = None,
+        config_settings: dict[str, Any] | None = None,
     ) -> None:
         self.__root = root
         self.__plugin_manager = cast(PluginManagerBound, plugin_manager)
         self.__raw_config = config
         self.__metadata = metadata
         self.__app = app
+        self.__config_settings = config_settings
         self.__config = cast(BuilderConfigBound, None)
         self.__project_config: dict[str, Any] | None = None
         self.__hatch_config: dict[str, Any] | None = None
@@ -307,6 +309,13 @@ class BuilderInterface(ABC, Generic[BuilderConfigBound, PluginManagerBound]):
             self.__app = cast(Application, Application().get_safe_application())
 
         return self.__app
+
+    @property
+    def config_settings(self) -> dict[str, Any] | None:
+        """
+        Configuration settings from the build frontend, if supported.
+        """
+        return self.__config_settings
 
     @property
     def raw_config(self) -> dict[str, Any]:

--- a/backend/src/hatchling/builders/plugin/interface.py
+++ b/backend/src/hatchling/builders/plugin/interface.py
@@ -294,7 +294,7 @@ class BuilderInterface(ABC, Generic[BuilderConfigBound, PluginManagerBound]):
         if self.__metadata is None:
             from hatchling.metadata.core import ProjectMetadata
 
-            self.__metadata = ProjectMetadata(self.root, self.plugin_manager, self.__raw_config)
+            self.__metadata = ProjectMetadata(self.root, self.plugin_manager, self.__raw_config, self.config_settings)
 
         return self.__metadata
 
@@ -397,7 +397,14 @@ class BuilderInterface(ABC, Generic[BuilderConfigBound, PluginManagerBound]):
                 raise UnknownPluginError(message)
 
             configured_build_hooks[hook_name] = build_hook(
-                self.root, config, self.config, self.metadata, directory, self.PLUGIN_NAME, self.app
+                self.root,
+                config,
+                self.config,
+                self.metadata,
+                directory,
+                self.PLUGIN_NAME,
+                self.config_settings,
+                self.app,
             )
 
         return configured_build_hooks

--- a/backend/src/hatchling/metadata/core.py
+++ b/backend/src/hatchling/metadata/core.py
@@ -42,10 +42,12 @@ class ProjectMetadata(Generic[PluginManagerBound]):
         root: str,
         plugin_manager: PluginManagerBound | None,
         config: dict[str, Any] | None = None,
+        config_settings: dict[str, Any] | None = None,
     ) -> None:
         self.root = root
         self.plugin_manager = plugin_manager
         self._config = config
+        self.config_settings = config_settings
 
         self._context: Context | None = None
         self._build: BuildMetadata | None = None
@@ -235,7 +237,7 @@ class ProjectMetadata(Generic[PluginManagerBound]):
                 hatch_config = hatch_config.copy()
                 hatch_config.update(config)
 
-            self._hatch = HatchMetadata(self.root, hatch_config, self.plugin_manager)
+            self._hatch = HatchMetadata(self.root, hatch_config, self.plugin_manager, self.config_settings)
 
         return self._hatch
 
@@ -1371,10 +1373,17 @@ class CoreMetadata:
 
 
 class HatchMetadata(Generic[PluginManagerBound]):
-    def __init__(self, root: str, config: dict[str, dict[str, Any]], plugin_manager: PluginManagerBound) -> None:
+    def __init__(
+        self,
+        root: str,
+        config: dict[str, dict[str, Any]],
+        plugin_manager: PluginManagerBound,
+        config_settings: dict[str, Any] | None,
+    ) -> None:
         self.root = root
         self.config = config
         self.plugin_manager = plugin_manager
+        self.config_settings = config_settings
 
         self._metadata: HatchMetadataSettings | None = None
         self._build_config: dict[str, Any] | None = None
@@ -1389,7 +1398,9 @@ class HatchMetadata(Generic[PluginManagerBound]):
                 message = "Field `tool.hatch.metadata` must be a table"
                 raise TypeError(message)
 
-            self._metadata = HatchMetadataSettings(self.root, metadata_config, self.plugin_manager)
+            self._metadata = HatchMetadataSettings(
+                self.root, metadata_config, self.plugin_manager, self.config_settings
+            )
 
         return self._metadata
 
@@ -1525,10 +1536,17 @@ class HatchVersionConfig(Generic[PluginManagerBound]):
 
 
 class HatchMetadataSettings(Generic[PluginManagerBound]):
-    def __init__(self, root: str, config: dict[str, Any], plugin_manager: PluginManagerBound) -> None:
+    def __init__(
+        self,
+        root: str,
+        config: dict[str, Any],
+        plugin_manager: PluginManagerBound,
+        config_settings: dict[str, Any] | None,
+    ) -> None:
         self.root = root
         self.config = config
         self.plugin_manager = plugin_manager
+        self.config_settings = config_settings
 
         self._allow_direct_references: bool | None = None
         self._allow_ambiguous_features: bool | None = None
@@ -1586,7 +1604,7 @@ class HatchMetadataSettings(Generic[PluginManagerBound]):
                     message = f"Unknown metadata hook: {hook_name}"
                     raise UnknownPluginError(message)
 
-                configured_hooks[hook_name] = metadata_hook(self.root, config)
+                configured_hooks[hook_name] = metadata_hook(self.root, config, self.config_settings)
 
             self._hooks = configured_hooks
 

--- a/backend/src/hatchling/metadata/plugin/interface.py
+++ b/backend/src/hatchling/metadata/plugin/interface.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import Any
 
 
 class MetadataHookInterface(ABC):  # no cov
@@ -31,9 +32,10 @@ class MetadataHookInterface(ABC):  # no cov
     PLUGIN_NAME = ""
     """The name used for selection."""
 
-    def __init__(self, root: str, config: dict) -> None:
+    def __init__(self, root: str, config: dict, config_settings: dict[str, Any] | None) -> None:
         self.__root = root
         self.__config = config
+        self.__config_settings = config_settings
 
     @property
     def root(self) -> str:
@@ -52,6 +54,13 @@ class MetadataHookInterface(ABC):  # no cov
         ```
         """
         return self.__config
+
+    @property
+    def config_settings(self) -> dict[str, Any] | None:
+        """
+        Configuration settings from the build frontend, if supported.
+        """
+        return self.__config_settings
 
     @abstractmethod
     def update(self, metadata: dict) -> None:

--- a/tests/backend/builders/hooks/test_custom.py
+++ b/tests/backend/builders/hooks/test_custom.py
@@ -10,21 +10,21 @@ def test_no_path(isolation):
     config = {"path": ""}
 
     with pytest.raises(ValueError, match="Option `path` for build hook `custom` must not be empty if defined"):
-        CustomBuildHook(str(isolation), config, None, None, "", "")
+        CustomBuildHook(str(isolation), config, None, None, "", "", None)
 
 
 def test_path_not_string(isolation):
     config = {"path": 3}
 
     with pytest.raises(TypeError, match="Option `path` for build hook `custom` must be a string"):
-        CustomBuildHook(str(isolation), config, None, None, "", "")
+        CustomBuildHook(str(isolation), config, None, None, "", "", None)
 
 
 def test_nonexistent(isolation):
     config = {"path": "test.py"}
 
     with pytest.raises(OSError, match="Build script does not exist: test.py"):
-        CustomBuildHook(str(isolation), config, None, None, "", "")
+        CustomBuildHook(str(isolation), config, None, None, "", "", None)
 
 
 def test_default(temp_dir, helpers):
@@ -44,7 +44,7 @@ def test_default(temp_dir, helpers):
     )
 
     with temp_dir.as_cwd():
-        hook = CustomBuildHook(str(temp_dir), config, None, None, "", "")
+        hook = CustomBuildHook(str(temp_dir), config, None, None, "", "", None)
 
     assert hook.foo() == ("custom", str(temp_dir))
 
@@ -67,7 +67,7 @@ def test_explicit_path(temp_dir, helpers):
     )
 
     with temp_dir.as_cwd():
-        hook = CustomBuildHook(str(temp_dir), config, None, None, "", "")
+        hook = CustomBuildHook(str(temp_dir), config, None, None, "", "", None)
 
     assert hook.foo() == ("custom", str(temp_dir))
 
@@ -100,4 +100,4 @@ def test_no_subclass(temp_dir, helpers):
         ),
         temp_dir.as_cwd(),
     ):
-        CustomBuildHook(str(temp_dir), config, None, None, "", "")
+        CustomBuildHook(str(temp_dir), config, None, None, "", "", None)

--- a/tests/backend/builders/hooks/test_version.py
+++ b/tests/backend/builders/hooks/test_version.py
@@ -9,20 +9,20 @@ from hatchling.utils.constants import DEFAULT_BUILD_SCRIPT
 class TestConfigPath:
     def test_correct(self, isolation):
         config = {"path": "foo/bar.py"}
-        hook = VersionBuildHook(str(isolation), config, None, None, "", "")
+        hook = VersionBuildHook(str(isolation), config, None, None, "", "", None)
 
         assert hook.config_path == hook.config_path == "foo/bar.py"
 
     def test_missing(self, isolation):
         config = {"path": ""}
-        hook = VersionBuildHook(str(isolation), config, None, None, "", "")
+        hook = VersionBuildHook(str(isolation), config, None, None, "", "", None)
 
         with pytest.raises(ValueError, match="Option `path` for build hook `version` is required"):
             _ = hook.config_path
 
     def test_not_string(self, isolation):
         config = {"path": 9000}
-        hook = VersionBuildHook(str(isolation), config, None, None, "", "")
+        hook = VersionBuildHook(str(isolation), config, None, None, "", "", None)
 
         with pytest.raises(TypeError, match="Option `path` for build hook `version` must be a string"):
             _ = hook.config_path
@@ -31,13 +31,13 @@ class TestConfigPath:
 class TestConfigTemplate:
     def test_correct(self, isolation):
         config = {"template": "foo"}
-        hook = VersionBuildHook(str(isolation), config, None, None, "", "")
+        hook = VersionBuildHook(str(isolation), config, None, None, "", "", None)
 
         assert hook.config_template == hook.config_template == "foo"
 
     def test_not_string(self, isolation):
         config = {"template": 9000}
-        hook = VersionBuildHook(str(isolation), config, None, None, "", "")
+        hook = VersionBuildHook(str(isolation), config, None, None, "", "", None)
 
         with pytest.raises(TypeError, match="Option `template` for build hook `version` must be a string"):
             _ = hook.config_template
@@ -46,13 +46,13 @@ class TestConfigTemplate:
 class TestConfigPattern:
     def test_correct(self, isolation):
         config = {"pattern": "foo"}
-        hook = VersionBuildHook(str(isolation), config, None, None, "", "")
+        hook = VersionBuildHook(str(isolation), config, None, None, "", "", None)
 
         assert hook.config_pattern == hook.config_pattern == "foo"
 
     def test_not_string(self, isolation):
         config = {"pattern": 9000}
-        hook = VersionBuildHook(str(isolation), config, None, None, "", "")
+        hook = VersionBuildHook(str(isolation), config, None, None, "", "", None)
 
         with pytest.raises(TypeError, match="Option `pattern` for build hook `version` must be a string"):
             _ = hook.config_pattern
@@ -84,7 +84,7 @@ class TestTemplate:
         )
 
         build_data = {"artifacts": []}
-        hook = VersionBuildHook(str(temp_dir), config, None, metadata, "", "")
+        hook = VersionBuildHook(str(temp_dir), config, None, metadata, "", "", None)
         hook.initialize([], build_data)
 
         expected_file = temp_dir / "baz.py"
@@ -124,7 +124,7 @@ class TestTemplate:
         )
 
         build_data = {"artifacts": []}
-        hook = VersionBuildHook(str(temp_dir), config, None, metadata, "", "")
+        hook = VersionBuildHook(str(temp_dir), config, None, metadata, "", "", None)
         hook.initialize([], build_data)
 
         expected_file = temp_dir / "bar" / "baz.py"
@@ -164,7 +164,7 @@ class TestTemplate:
         )
 
         build_data = {"artifacts": []}
-        hook = VersionBuildHook(str(temp_dir), config, None, metadata, "", "")
+        hook = VersionBuildHook(str(temp_dir), config, None, metadata, "", "", None)
         hook.initialize([], build_data)
 
         expected_file = temp_dir / "baz.py"
@@ -211,7 +211,7 @@ class TestPattern:
         )
 
         build_data = {"artifacts": []}
-        hook = VersionBuildHook(str(temp_dir), config, None, metadata, "", "")
+        hook = VersionBuildHook(str(temp_dir), config, None, metadata, "", "", None)
         hook.initialize([], build_data)
 
         assert version_file.read_text() == helpers.dedent(
@@ -254,7 +254,7 @@ class TestPattern:
         )
 
         build_data = {"artifacts": []}
-        hook = VersionBuildHook(str(temp_dir), config, None, metadata, "", "")
+        hook = VersionBuildHook(str(temp_dir), config, None, metadata, "", "", None)
         hook.initialize([], build_data)
 
         assert version_file.read_text() == helpers.dedent(

--- a/tests/backend/builders/plugin/test_interface.py
+++ b/tests/backend/builders/plugin/test_interface.py
@@ -387,3 +387,17 @@ class TestDirectoryRecursion:
                 (str(temp_dir / "external2.txt"), f"nested{path_sep}target1.txt"),
                 (str(temp_dir / "external1.txt"), f"nested{path_sep}target2.txt"),
             ]
+
+
+class TestConfigSettings:
+    def test_no_config(self, isolation):
+        builder = MockBuilder(str(isolation))
+
+        assert builder.config_settings is None
+
+    def test_with_config(self, isolation):
+        config_settings = {"foo": "bar"}
+        builder = MockBuilder(str(isolation), config_settings=config_settings)
+
+        assert builder.config_settings is config_settings
+        assert builder.config_settings["foo"] == "bar"

--- a/tests/backend/builders/test_sdist.py
+++ b/tests/backend/builders/test_sdist.py
@@ -1543,3 +1543,55 @@ class TestBuildStandard:
         # we assert that at minimum 644 is set, based on the platform (e.g.)
         # windows it may be higher
         assert file_stat.st_mode & 0o644
+
+    def test_config_settings(self, hatch, helpers, temp_dir, config_file):
+        config_file.model.template.plugins["default"]["src-layout"] = False
+        config_file.save()
+
+        project_name = "My.App"
+
+        with temp_dir.as_cwd():
+            result = hatch("new", project_name)
+
+        assert result.exit_code == 0, result.output
+
+        project_path = temp_dir / "my-app"
+
+        config_settings = {"foo": "bar", "hooks": []}
+
+        build_script = project_path / DEFAULT_BUILD_SCRIPT
+        build_script.write_text(
+            helpers.dedent(
+                """
+                from hatchling.metadata.plugin.interface import MetadataHookInterface
+                from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+                class CustomMetadataBuilder(MetadataHookInterface):
+                    def update(self, metadata):
+                        assert self.config_settings == {"foo": "bar", "hooks": []}
+                        self.config_settings["hooks"].append("metadata")
+
+                class CustomHook(BuildHookInterface):
+                    def initialize(self, version, build_data):
+                        assert self.config_settings == {"foo": "bar", "hooks": ["metadata"]}
+                        self.config_settings["hooks"].append("build")
+                """
+            )
+        )
+
+        config = {
+            "project": {"name": project_name, "dynamic": ["version"]},
+            "tool": {
+                "hatch": {
+                    "version": {"path": "my_app/__about__.py"},
+                    "metadata": {"hooks": {"custom": {}}},
+                    "build": {"targets": {"sdist": {"hooks": {"custom": {}}}}},
+                },
+            },
+        }
+        builder = SdistBuilder(str(project_path), config=config, config_settings=config_settings)
+
+        with project_path.as_cwd():
+            list(builder.build(hooks_only=True))
+
+        assert config_settings["hooks"] == ["metadata", "build"]

--- a/tests/backend/builders/test_wheel.py
+++ b/tests/backend/builders/test_wheel.py
@@ -3997,3 +3997,55 @@ class TestSBOMFiles:
             ],
         )
         helpers.assert_files(extraction_directory, expected_files)
+
+    def test_config_settings(self, hatch, helpers, temp_dir, config_file):
+        config_file.model.template.plugins["default"]["src-layout"] = False
+        config_file.save()
+
+        project_name = "My.App"
+
+        with temp_dir.as_cwd():
+            result = hatch("new", project_name)
+
+        assert result.exit_code == 0, result.output
+
+        project_path = temp_dir / "my-app"
+
+        config_settings = {"foo": "bar", "hooks": []}
+
+        build_script = project_path / DEFAULT_BUILD_SCRIPT
+        build_script.write_text(
+            helpers.dedent(
+                """
+                from hatchling.metadata.plugin.interface import MetadataHookInterface
+                from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+                class CustomMetadataBuilder(MetadataHookInterface):
+                    def update(self, metadata):
+                        assert self.config_settings == {"foo": "bar", "hooks": []}
+                        self.config_settings["hooks"].append("metadata")
+
+                class CustomHook(BuildHookInterface):
+                    def initialize(self, version, build_data):
+                        assert self.config_settings == {"foo": "bar", "hooks": ["metadata"]}
+                        self.config_settings["hooks"].append("build")
+                """
+            )
+        )
+
+        config = {
+            "project": {"name": project_name, "dynamic": ["version"]},
+            "tool": {
+                "hatch": {
+                    "version": {"path": "my_app/__about__.py"},
+                    "metadata": {"hooks": {"custom": {}}},
+                    "build": {"targets": {"wheel": {"hooks": {"custom": {}}}}},
+                },
+            },
+        }
+        builder = WheelBuilder(str(project_path), config=config, config_settings=config_settings)
+
+        with project_path.as_cwd():
+            list(builder.build(hooks_only=True))
+
+        assert config_settings["hooks"] == ["metadata", "build"]

--- a/tests/backend/metadata/test_custom_hook.py
+++ b/tests/backend/metadata/test_custom_hook.py
@@ -10,21 +10,21 @@ def test_no_path(isolation):
     config = {"path": ""}
 
     with pytest.raises(ValueError, match="Option `path` for metadata hook `custom` must not be empty if defined"):
-        CustomMetadataHook(str(isolation), config)
+        CustomMetadataHook(str(isolation), config, None)
 
 
 def test_path_not_string(isolation):
     config = {"path": 3}
 
     with pytest.raises(TypeError, match="Option `path` for metadata hook `custom` must be a string"):
-        CustomMetadataHook(str(isolation), config)
+        CustomMetadataHook(str(isolation), config, None)
 
 
 def test_nonexistent(isolation):
     config = {"path": "test.py"}
 
     with pytest.raises(OSError, match="Build script does not exist: test.py"):
-        CustomMetadataHook(str(isolation), config)
+        CustomMetadataHook(str(isolation), config, None)
 
 
 def test_default(temp_dir, helpers):
@@ -47,7 +47,7 @@ def test_default(temp_dir, helpers):
     )
 
     with temp_dir.as_cwd():
-        hook = CustomMetadataHook(str(temp_dir), config)
+        hook = CustomMetadataHook(str(temp_dir), config, None)
 
     assert hook.foo() == ("custom", str(temp_dir))
 
@@ -73,7 +73,7 @@ def test_explicit_path(temp_dir, helpers):
     )
 
     with temp_dir.as_cwd():
-        hook = CustomMetadataHook(str(temp_dir), config)
+        hook = CustomMetadataHook(str(temp_dir), config, None)
 
     assert hook.foo() == ("custom", str(temp_dir))
 
@@ -106,4 +106,4 @@ def test_no_subclass(temp_dir, helpers):
         ),
         temp_dir.as_cwd(),
     ):
-        CustomMetadataHook(str(temp_dir), config)
+        CustomMetadataHook(str(temp_dir), config, None)

--- a/tests/backend/metadata/test_hatch.py
+++ b/tests/backend/metadata/test_hatch.py
@@ -9,20 +9,20 @@ from hatchling.version.source.regex import RegexSource
 class TestBuildConfig:
     def test_default(self, isolation):
         config = {}
-        metadata = HatchMetadata(str(isolation), config, None)
+        metadata = HatchMetadata(str(isolation), config, None, None)
 
         assert metadata.build_config == metadata.build_config == {}
 
     def test_not_table(self, isolation):
         config = {"build": 0}
-        metadata = HatchMetadata(str(isolation), config, None)
+        metadata = HatchMetadata(str(isolation), config, None, None)
 
         with pytest.raises(TypeError, match="Field `tool.hatch.build` must be a table"):
             _ = metadata.build_config
 
     def test_correct(self, isolation):
         config = {"build": {"reproducible": True}}
-        metadata = HatchMetadata(str(isolation), config, None)
+        metadata = HatchMetadata(str(isolation), config, None, None)
 
         assert metadata.build_config == metadata.build_config == {"reproducible": True}
 
@@ -30,20 +30,20 @@ class TestBuildConfig:
 class TestBuildTargets:
     def test_default(self, isolation):
         config = {}
-        metadata = HatchMetadata(str(isolation), config, None)
+        metadata = HatchMetadata(str(isolation), config, None, None)
 
         assert metadata.build_targets == metadata.build_targets == {}
 
     def test_not_table(self, isolation):
         config = {"build": {"targets": 0}}
-        metadata = HatchMetadata(str(isolation), config, None)
+        metadata = HatchMetadata(str(isolation), config, None, None)
 
         with pytest.raises(TypeError, match="Field `tool.hatch.build.targets` must be a table"):
             _ = metadata.build_targets
 
     def test_correct(self, isolation):
         config = {"build": {"targets": {"wheel": {"versions": ["standard"]}}}}
-        metadata = HatchMetadata(str(isolation), config, None)
+        metadata = HatchMetadata(str(isolation), config, None, None)
 
         assert metadata.build_targets == metadata.build_targets == {"wheel": {"versions": ["standard"]}}
 
@@ -53,19 +53,19 @@ class TestVersionSourceName:
         with pytest.raises(
             ValueError, match="The `source` option under the `tool.hatch.version` table must not be empty if defined"
         ):
-            _ = HatchMetadata(isolation, {"version": {"source": ""}}, None).version.source_name
+            _ = HatchMetadata(isolation, {"version": {"source": ""}}, None, None).version.source_name
 
     def test_not_table(self, isolation):
         with pytest.raises(TypeError, match="Field `tool.hatch.version.source` must be a string"):
-            _ = HatchMetadata(isolation, {"version": {"source": 9000}}, None).version.source_name
+            _ = HatchMetadata(isolation, {"version": {"source": 9000}}, None, None).version.source_name
 
     def test_correct(self, isolation):
-        metadata = HatchMetadata(isolation, {"version": {"source": "foo"}}, None)
+        metadata = HatchMetadata(isolation, {"version": {"source": "foo"}}, None, None)
 
         assert metadata.version.source_name == metadata.version.source_name == "foo"
 
     def test_default(self, isolation):
-        metadata = HatchMetadata(isolation, {"version": {}}, None)
+        metadata = HatchMetadata(isolation, {"version": {}}, None, None)
 
         assert metadata.version.source_name == metadata.version.source_name == "regex"
 
@@ -75,19 +75,19 @@ class TestVersionSchemeName:
         with pytest.raises(
             ValueError, match="The `scheme` option under the `tool.hatch.version` table must not be empty if defined"
         ):
-            _ = HatchMetadata(isolation, {"version": {"scheme": ""}}, None).version.scheme_name
+            _ = HatchMetadata(isolation, {"version": {"scheme": ""}}, None, None).version.scheme_name
 
     def test_not_table(self, isolation):
         with pytest.raises(TypeError, match="Field `tool.hatch.version.scheme` must be a string"):
-            _ = HatchMetadata(isolation, {"version": {"scheme": 9000}}, None).version.scheme_name
+            _ = HatchMetadata(isolation, {"version": {"scheme": 9000}}, None, None).version.scheme_name
 
     def test_correct(self, isolation):
-        metadata = HatchMetadata(isolation, {"version": {"scheme": "foo"}}, None)
+        metadata = HatchMetadata(isolation, {"version": {"scheme": "foo"}}, None, None)
 
         assert metadata.version.scheme_name == metadata.version.scheme_name == "foo"
 
     def test_default(self, isolation):
-        metadata = HatchMetadata(isolation, {"version": {}}, None)
+        metadata = HatchMetadata(isolation, {"version": {}}, None, None)
 
         assert metadata.version.scheme_name == metadata.version.scheme_name == "standard"
 
@@ -95,10 +95,10 @@ class TestVersionSchemeName:
 class TestVersionSource:
     def test_unknown(self, isolation):
         with pytest.raises(ValueError, match="Unknown version source: foo"):
-            _ = HatchMetadata(isolation, {"version": {"source": "foo"}}, PluginManager()).version.source
+            _ = HatchMetadata(isolation, {"version": {"source": "foo"}}, PluginManager(), None).version.source
 
     def test_cached(self, isolation):
-        metadata = HatchMetadata(isolation, {"version": {}}, PluginManager())
+        metadata = HatchMetadata(isolation, {"version": {}}, PluginManager(), None)
 
         assert metadata.version.source is metadata.version.source
         assert isinstance(metadata.version.source, RegexSource)
@@ -107,10 +107,10 @@ class TestVersionSource:
 class TestVersionScheme:
     def test_unknown(self, isolation):
         with pytest.raises(ValueError, match="Unknown version scheme: foo"):
-            _ = HatchMetadata(isolation, {"version": {"scheme": "foo"}}, PluginManager()).version.scheme
+            _ = HatchMetadata(isolation, {"version": {"scheme": "foo"}}, PluginManager(), None).version.scheme
 
     def test_cached(self, isolation):
-        metadata = HatchMetadata(isolation, {"version": {}}, PluginManager())
+        metadata = HatchMetadata(isolation, {"version": {}}, PluginManager(), None)
 
         assert metadata.version.scheme is metadata.version.scheme
         assert isinstance(metadata.version.scheme, StandardScheme)
@@ -119,20 +119,20 @@ class TestVersionScheme:
 class TestMetadata:
     def test_default(self, isolation):
         config = {}
-        metadata = HatchMetadata(str(isolation), config, None)
+        metadata = HatchMetadata(str(isolation), config, None, None)
 
         assert metadata.metadata.config == metadata.metadata.config == {}
 
     def test_not_table(self, isolation):
         config = {"metadata": 0}
-        metadata = HatchMetadata(str(isolation), config, None)
+        metadata = HatchMetadata(str(isolation), config, None, None)
 
         with pytest.raises(TypeError, match="Field `tool.hatch.metadata` must be a table"):
             _ = metadata.metadata.config
 
     def test_correct(self, isolation):
         config = {"metadata": {"option": True}}
-        metadata = HatchMetadata(str(isolation), config, None)
+        metadata = HatchMetadata(str(isolation), config, None, None)
 
         assert metadata.metadata.config == metadata.metadata.config == {"option": True}
 
@@ -140,20 +140,20 @@ class TestMetadata:
 class TestMetadataAllowDirectReferences:
     def test_default(self, isolation):
         config = {}
-        metadata = HatchMetadata(str(isolation), config, None)
+        metadata = HatchMetadata(str(isolation), config, None, None)
 
         assert metadata.metadata.allow_direct_references is metadata.metadata.allow_direct_references is False
 
     def test_not_boolean(self, isolation):
         config = {"metadata": {"allow-direct-references": 9000}}
-        metadata = HatchMetadata(str(isolation), config, None)
+        metadata = HatchMetadata(str(isolation), config, None, None)
 
         with pytest.raises(TypeError, match="Field `tool.hatch.metadata.allow-direct-references` must be a boolean"):
             _ = metadata.metadata.allow_direct_references
 
     def test_correct(self, isolation):
         config = {"metadata": {"allow-direct-references": True}}
-        metadata = HatchMetadata(str(isolation), config, None)
+        metadata = HatchMetadata(str(isolation), config, None, None)
 
         assert metadata.metadata.allow_direct_references is True
 
@@ -161,19 +161,19 @@ class TestMetadataAllowDirectReferences:
 class TestMetadataAllowAmbiguousFeatures:
     def test_default(self, isolation):
         config = {}
-        metadata = HatchMetadata(str(isolation), config, None)
+        metadata = HatchMetadata(str(isolation), config, None, None)
 
         assert metadata.metadata.allow_ambiguous_features is metadata.metadata.allow_ambiguous_features is False
 
     def test_not_boolean(self, isolation):
         config = {"metadata": {"allow-ambiguous-features": 9000}}
-        metadata = HatchMetadata(str(isolation), config, None)
+        metadata = HatchMetadata(str(isolation), config, None, None)
 
         with pytest.raises(TypeError, match="Field `tool.hatch.metadata.allow-ambiguous-features` must be a boolean"):
             _ = metadata.metadata.allow_ambiguous_features
 
     def test_correct(self, isolation):
         config = {"metadata": {"allow-ambiguous-features": True}}
-        metadata = HatchMetadata(str(isolation), config, None)
+        metadata = HatchMetadata(str(isolation), config, None, None)
 
         assert metadata.metadata.allow_ambiguous_features is True


### PR DESCRIPTION
As a Python packager writing custom _hatchling_ build hooks (using _hatch_build.py_), I would like _hatchling_ to support passing `config_settings` from build frontends that support it to hatchling builders so that users can customize certain aspects of the build experience (i.e., build jobs, compiler choice, etc.) using the command-line options provided by build frontends.

PEP 517 defines a `config_settings` dictionary in the backend hooks specifications for passing configuration from build frontends. Many build frontends already support passing in `config_settings` using the _-C/--config-settings_ command-line option.

* **uv build**
* **pip install**
* **pip wheel**
* **pyproject-build** (from the _build_ package)

Currently, _hatchling_ does not pass `config_settings` on to builders. I finally realized that the reluctance to implement such a feature in _hatch_, as indicated by responses in #1072, stem from the ambiguity in how frontends should implement the feature. What I'm suggesting here is _not_ that we add support to the _hatch_ frontend, but that we provide the backend with settings from frontends that already support it.

See #1072

Please let me know if anything should be added to the documentation or if additional tests would be helpful.