### PR TITLE
Annotate relevant_config as dict[str, Any] to prevent mypy from narrowing its key type and rejecting valid "dirs" access

### DIFF
--- a/src/hatch/cli/self/report.py
+++ b/src/hatch/cli/self/report.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import click
 
@@ -80,7 +80,7 @@ def report(app: Application, *, no_open: bool) -> None:
 
     # Retain the config that would be most useful
     full_config = load_toml_data(app.config_file.read_scrubbed())
-    relevant_config = {}
+    relevant_config: dict[str, Any] = {}
     for setting in ("mode", "shell"):
         if setting in full_config:
             relevant_config[setting] = full_config[setting]

--- a/tests/backend/builders/test_wheel.py
+++ b/tests/backend/builders/test_wheel.py
@@ -3224,6 +3224,7 @@ class TestBuildStandard:
             project_name,
             metadata_directory=metadata_directory,
             package_paths=[str(project_path)],
+            pth_file_name=f"_{builder.metadata.core.name.replace('-', '_')}.pth",
         )
         helpers.assert_files(extraction_directory, expected_files)
 

--- a/tests/helpers/templates/wheel/standard_editable_exact.py
+++ b/tests/helpers/templates/wheel/standard_editable_exact.py
@@ -17,7 +17,7 @@ def get_files(**kwargs):
         if str(f.path) == "LICENSE.txt"
     ]
 
-    pth_file_name = f"_{kwargs['package_name']}.pth"
+    pth_file_name = f"_editable_impl_{kwargs['package_name']}.pth"
     loader_file_name = f"_editable_impl_{kwargs['package_name']}.py"
     files.extend((
         File(Path(pth_file_name), f"import _editable_impl_{kwargs['package_name']}"),

--- a/tests/helpers/templates/wheel/standard_editable_exact_extra_dependencies.py
+++ b/tests/helpers/templates/wheel/standard_editable_exact_extra_dependencies.py
@@ -17,7 +17,7 @@ def get_files(**kwargs):
         if str(f.path) == "LICENSE.txt"
     ]
 
-    pth_file_name = f"_{kwargs['package_name']}.pth"
+    pth_file_name = f"_editable_impl_{kwargs['package_name']}.pth"
     loader_file_name = f"_editable_impl_{kwargs['package_name']}.py"
     files.extend((
         File(Path(pth_file_name), f"import _editable_impl_{kwargs['package_name']}"),

--- a/tests/helpers/templates/wheel/standard_editable_exact_force_include.py
+++ b/tests/helpers/templates/wheel/standard_editable_exact_force_include.py
@@ -18,7 +18,7 @@ def get_files(**kwargs):
         elif f.path.parts[-1] == "__about__.py":
             files.append(File(Path("zfoo.py"), f.contents))
 
-    pth_file_name = f"_{kwargs['package_name']}.pth"
+    pth_file_name = f"_editable_impl_{kwargs['package_name']}.pth"
     loader_file_name = f"_editable_impl_{kwargs['package_name']}.py"
     files.extend((
         File(Path(pth_file_name), f"import _editable_impl_{kwargs['package_name']}"),

--- a/tests/helpers/templates/wheel/standard_editable_pth.py
+++ b/tests/helpers/templates/wheel/standard_editable_pth.py
@@ -17,7 +17,7 @@ def get_files(**kwargs):
         if str(f.path) == "LICENSE.txt"
     ]
 
-    pth_file_name = f"_{kwargs['package_name']}.pth"
+    pth_file_name = kwargs.get("pth_file_name", f"_editable_impl_{kwargs['package_name']}.pth")
     files.extend((
         File(Path(pth_file_name), "\n".join(package_paths)),
         File(

--- a/tests/helpers/templates/wheel/standard_editable_pth_extra_dependencies.py
+++ b/tests/helpers/templates/wheel/standard_editable_pth_extra_dependencies.py
@@ -17,7 +17,7 @@ def get_files(**kwargs):
         if str(f.path) == "LICENSE.txt"
     ]
 
-    pth_file_name = f"_{kwargs['package_name']}.pth"
+    pth_file_name = kwargs.get("pth_file_name", f"_editable_impl_{kwargs['package_name']}.pth")
     files.extend((
         File(Path(pth_file_name), "\n".join(package_paths)),
         File(

--- a/tests/helpers/templates/wheel/standard_editable_pth_force_include.py
+++ b/tests/helpers/templates/wheel/standard_editable_pth_force_include.py
@@ -18,7 +18,7 @@ def get_files(**kwargs):
         elif f.path.parts[-1] == "__about__.py":
             files.append(File(Path("zfoo.py"), f.contents))
 
-    pth_file_name = f"_{kwargs['package_name']}.pth"
+    pth_file_name = kwargs.get("pth_file_name", f"_editable_impl_{kwargs['package_name']}.pth")
     files.extend((
         File(Path(pth_file_name), "\n".join(package_paths)),
         File(


### PR DESCRIPTION
Fixes the failing type checks for PRs