### PR TITLE
fix(env/virtual): clean up project_name dir on env removal

### DIFF
--- a/src/hatch/env/virtual.py
+++ b/src/hatch/env/virtual.py
@@ -189,6 +189,17 @@ class VirtualEnvironment(EnvironmentInterface):
             if not entries or (entries == [".gitignore"] and self.root in self.storage_path.parents):
                 self.storage_path.remove()
 
+                # Also clean up the parent project_name directory if it is now empty
+                # (e.g. `<data_dir>/env/virtual/<project_name>/<project_id>` -> remove `<project_name>`)
+                storage_parent = self.storage_path.parent
+                if (
+                    storage_parent != self.data_directory
+                    and storage_parent != self.platform.home / ".virtualenvs"
+                    and storage_parent.is_dir()
+                    and not any(storage_parent.iterdir())
+                ):
+                    storage_parent.remove()
+
     def exists(self):
         return self.virtual_env.exists()
 

--- a/tests/cli/env/test_prune.py
+++ b/tests/cli/env/test_prune.py
@@ -89,6 +89,8 @@ def test_all(hatch, helpers, temp_dir_data, config_file):
     )
 
     assert not storage_path.is_dir()
+    # Issue #737: the project_name directory should also be cleaned up
+    assert not project_data_path.is_dir()
 
 
 def test_incompatible_ok(hatch, helpers, temp_dir_data, config_file):


### PR DESCRIPTION
Closes #737

<!-- Drafted by an agent run; please review carefully before merging. -->

## Repo
pypa/hatch

## Issue
https://github.com/pypa/hatch/issues/737

## Root cause
`VirtualEnvironment.remove()` in `src/hatch/env/virtual.py` cleans up the per-project `storage_path` (`<data_dir>/env/virtual/<project_name>/<project_id>`) when it becomes empty, but never removes the enclosing `<project_name>` directory. After `hatch env prune` removes every environment, that empty `<project_name>` dir is left orphaned under `LOCALAPPDATA\hatch\env\virtual\` (or the equivalent data dir).

## Fix
After successfully removing `storage_path`, also remove its parent `<project_name>` directory if it is now empty and is not itself the data root or `~/.virtualenvs`.

## Regression test
`tests/cli/env/test_prune.py::test_all` — added an assertion that `project_data_path` (the `<project_name>` dir, e.g. `data/env/virtual/my-app`) no longer exists after `hatch env prune`.

## Risk
low

## Verification
Ran `pytest tests/cli/env/test_prune.py tests/cli/env/test_remove.py tests/cli/env/test_create.py` in a fresh venv with the package installed editable: 52 passed, 1 unrelated failure (`test_new_selected_python` fails due to missing managed Python interpreter in the sandbox, not touched by this change). Confirmed the new assertion fails on the original code and passes after the fix.
