### PR TITLE
fix: exclude Git worktree metadata files from sdists

### DIFF
--- a/backend/src/hatchling/builders/constants.py
+++ b/backend/src/hatchling/builders/constants.py
@@ -27,6 +27,8 @@ EXCLUDED_DIRECTORIES = frozenset((
 EXCLUDED_FILES = frozenset((
     # https://en.wikipedia.org/wiki/.DS_Store
     ".DS_Store",
+    # Git worktree metadata file
+    ".git",
 ))
 
 

--- a/tests/backend/builders/test_sdist.py
+++ b/tests/backend/builders/test_sdist.py
@@ -1336,9 +1336,8 @@ class TestBuildStandard:
 
         project_path = temp_dir / "my-app"
 
-        vcs_ignore_file = temp_dir / ".gitignore"
-        vcs_ignore_file.write_text("*.pyc\n*.so\n*.h\n")
-
+        (project_path / ".gitignore").write_text("*.pyc\n*.so\n*.h\n")
+        (project_path / ".git").write_text("gitdir: ../.git/worktrees/my-app\n")
         (project_path / "my_app" / "lib.so").touch()
         (project_path / "my_app" / "lib.h").touch()
 


### PR DESCRIPTION
Fixes #2253.

This updates Hatchling default file exclusions so a Git worktree metadata file named `.git` is treated like other VCS metadata and is not included in source distributions. The existing Git VCS exclusion test now covers a project-root `.git` file alongside `.gitignore` patterns.