### PR TITLE
Fix require-runtime-dependencies being ignored for build hooks

### DIFF
--- a/src/hatch/env/plugin/interface.py
+++ b/src/hatch/env/plugin/interface.py
@@ -356,6 +356,24 @@ class EnvironmentInterface(ABC):
 
         return local_dependencies_complex
 
+    def add_additional_dependencies(self, dependencies: Iterable[Dependency]) -> None:
+        """
+        Extend `additional_dependencies` and invalidate cached properties that depend on it.
+
+        Use this instead of mutating `additional_dependencies` directly when adding
+        dependencies after the environment may have already computed
+        `dependencies_complex` / `missing_dependencies` (e.g. after `prepare_environment`).
+        """
+        self.additional_dependencies.extend(dependencies)
+        for attr in (
+            "dependencies_complex",
+            "dependencies",
+            "all_dependencies_complex",
+            "all_dependencies",
+            "missing_dependencies",
+        ):
+            self.__dict__.pop(attr, None)
+
     @cached_property
     def dependencies_complex(self) -> list[Dependency]:
         from hatch.dep.core import Dependency

--- a/src/hatch/project/core.py
+++ b/src/hatch/project/core.py
@@ -295,7 +295,7 @@ class Project:
             if additional_dependencies:
                 from hatch.dep.core import Dependency
 
-                self.build_env.additional_dependencies.extend(map(Dependency, additional_dependencies))
+                self.build_env.add_additional_dependencies(map(Dependency, additional_dependencies))
                 with self.build_env.app_status_dependency_synchronization():
                     self.build_env.sync_dependencies()
 

--- a/tests/env/plugin/test_interface.py
+++ b/tests/env/plugin/test_interface.py
@@ -3,6 +3,7 @@ import re
 import pytest
 
 from hatch.config.constants import AppEnvVars
+from hatch.dep.core import Dependency
 from hatch.env.plugin.interface import EnvironmentInterface
 from hatch.project.core import Project
 from hatch.utils.structures import EnvVars
@@ -1843,6 +1844,46 @@ feature3 = ["pkg-feature-3{i}"]
         environment.additional_dependencies = ["extra-dep"]
         deps = environment.dependencies_complex
         assert any("extra-dep" in str(d) for d in deps)
+
+    def test_add_additional_dependencies_invalidates_caches(
+        self, temp_dir, isolated_data_dir, platform, temp_application
+    ):
+        """Extending additional_dependencies must invalidate the cached dependency views.
+
+        Otherwise the build env fails to install dynamic build-hook dependencies (e.g. those
+        pulled in by require-runtime-dependencies). Regression test for #2110.
+        """
+        pyproject = temp_dir / "pyproject.toml"
+        pyproject.write_text("""
+    [project]
+    name = "my-app"
+    version = "0.0.1"
+    """)
+
+        project = Project(temp_dir)
+        project.set_app(temp_application)
+        temp_application.project = project
+        environment = MockEnvironment(
+            temp_dir,
+            project.metadata,
+            "default",
+            project.config.envs["default"],
+            {},
+            isolated_data_dir,
+            isolated_data_dir,
+            platform,
+            0,
+            temp_application,
+        )
+
+        # Prime the caches with the empty additional_dependencies snapshot.
+        assert not any("extra-dep" in str(d) for d in environment.dependencies_complex)
+        assert not any("extra-dep" in str(d) for d in environment.all_dependencies_complex)
+
+        environment.add_additional_dependencies([Dependency("extra-dep")])
+
+        assert any("extra-dep" in str(d) for d in environment.dependencies_complex)
+        assert any("extra-dep" in str(d) for d in environment.all_dependencies_complex)
 
 
 class TestScripts:


### PR DESCRIPTION
PR #2073 (workspace support) introduced a separate `additional_dependencies` list on `EnvironmentInterface` and changed `prepare_build_environment` to extend that list with the dynamic build-hook dependencies discovered by `get_required_build_deps` (e.g. project runtime deps when a build hook sets `require-runtime-dependencies = true`).

Bug: by the time `prepare_build_environment` extends `additional_dependencies`, the cached property chain that consumes it: `dependencies_complex` -> `all_dependencies_complex` -> `missing_dependencies` has already been populated by the preceding `prepare_environment` call (via `dependency_hash()` and `dependencies_in_sync()`) with the *empty* `additional_dependencies` snapshot.

The second `sync_dependencies()` call then early-returns because the cached `missing_dependencies` reflects the pre-mutation deps which have just been installed — so the runtime deps never get installed and the build hook fails with `ModuleNotFoundError`.

Before PR #2073, this worked because the old code mutated the cached `dependencies` list in place and the old `sync_dependencies` reinstalled the entire list via pip — there was no cached `missing_dependencies` short-circuit.

Fix: add `EnvironmentInterface.add_additional_dependencies()` which extends `additional_dependencies` and invalidates the dependent cached properties (`dependencies_complex`, `dependencies`, `all_dependencies_complex`, `all_dependencies`, `missing_dependencies`). Update `prepare_build_environment` to use it.

Add a regression test that primes the cache before extending and asserts the new dep is visible.

Fixes: #2110