### PR TITLE
Exclude .git file from SDist builds for git worktree support

### DIFF
--- a/backend/src/hatchling/builders/constants.py
+++ b/backend/src/hatchling/builders/constants.py
@@ -27,6 +27,8 @@ EXCLUDED_DIRECTORIES = frozenset((
 EXCLUDED_FILES = frozenset((
     # https://en.wikipedia.org/wiki/.DS_Store
     ".DS_Store",
+    # When using git worktrees, .git is a file rather than a directory
+    ".git",
 ))
 
 


### PR DESCRIPTION
When using git worktrees, `.git` is a regular file (not a directory) containing a `gitdir:` reference. This file was incorrectly included in SDist archives because it was only excluded as a directory via `EXCLUDED_DIRECTORIES`, not as a file via `EXCLUDED_FILES`.

This PR adds `.git` to `EXCLUDED_FILES` to handle the worktree case. In normal repositories where `.git` is a directory, this change is a no-op since `os.walk` only returns files in the files list.

Fixes #2253