### PR TITLE
Ensure environment is initialized before locking

### DIFF
--- a/src/hatch/env/lock.py
+++ b/src/hatch/env/lock.py
@@ -153,6 +153,9 @@ def generate_lockfile(
     if state is None:
         return
 
+    if not environment.exists():
+        environment.create()
+
     locker_cls = get_locker_plugin_class(environment.app.project, environment)
     locker_cls.generate(
         environment,


### PR DESCRIPTION
**Summary:** This change fixes a small issue that the new `hatch env lock` command fails if the specific test environment is not initialized yet.

## Repro

With the latest hatch create a new project (`hatch new project`) then inside the project enable the setting to `lock-envs = true` under `tool.hatch`. Once this is ready run `hatch env lock`. Since most likely the user hasn't initialized and locally run all possible environment types (tests for all Python versions / type checks / static checks / ...) the command fails with this error:
```
│ <Path>/hatch/src/hatch/venv/core.py:31 in activate                                │
│                                                                                                  │
│    28 │   │   if old_path is None:                                                               │
│    29 │   │   │   os.environ["PATH"] = f"{self.executables_directory}{os.pathsep}{os.defpath}"   │
│    30 │   │   else:                                                                              │
│ ❱  31 │   │   │   os.environ["PATH"] = f"{self.executables_directory}{os.pathsep}{old_path}"     │
│    32 │   │                                                                                      │
│    33 │   │   for env_var in self.IGNORED_ENV_VARS:                                              │
│    34 │   │   │   self._env_vars_to_restore[env_var] = os.environ.pop(env_var, None)             │
│                                                                                                  │
│ <Path>/hatch/src/hatch/venv/core.py:91 in executables_directory                   │
│                                                                                                  │
│    88 │   │   │   │   │   raise OSError(msg)                                                     │
│    89 │   │   │   else:                                                                          │
│    90 │   │   │   │   msg = f"Unable to locate executables directory within: {self.directory}"   │
│ ❱  91 │   │   │   │   raise OSError(msg)                                                         │
│    92 │   │                                                                                      │
│    93 │   │   return self._executables_directory                                                 │
│    94                                                                                            │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
OSError: Unable to locate executables directory within: 
<Path>/types
```

After adding the step to create the environment, the lockfiles are all generated successfully.

## Changes

Simple check to validate whether the environment exists and create it if not is added.

## Test

Validated against the steps described in the repro section.