### PR TITLE
docs: fix broken "Switching to Hatch" link in community highlights

### DIFF
--- a/docs/community/highlights.md
+++ b/docs/community/highlights.md
@@ -10,4 +10,4 @@
 ## Adoption
 
 - Black - https://ichard26.github.io/blog/2022/10/black-22.10.0/#goodbye-python-36-and-hello-hatchling
-- "Switching to Hatch" - https://andrich.me/2023/08/switching-to-hatch/
+- "Switching to Hatch" - https://web.archive.org/web/20240123014819/https://andrich.me/2023/08/switching-to-hatch/

--- a/docs/history/hatch.md
+++ b/docs/history/hatch.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Fixed:***
+
+- Replace broken "Switching to Hatch" link in community highlights with a Wayback Machine archive URL (the original blog at `andrich.me` returns 404).
+
 ## [1.16.5](https://github.com/pypa/hatch/releases/tag/hatch-v1.16.5) - 2026-02-26 ## {: #hatch-v1.16.5 }
 
 ***Fixed:***


### PR DESCRIPTION
## Summary

The "Switching to Hatch" link in `docs/community/highlights.md` (https://andrich.me/2023/08/switching-to-hatch/) is dead — the domain redirects to `someonewho.codes` but the article itself returns 404. Replaces the link with a Wayback Machine snapshot from 2024-01-23 so readers can still reach the content.

Closes #1997.

## Why

A 404 in the official docs creates friction for new users browsing community resources. Wayback Machine is the conventional fallback for blog posts that disappear; the snapshot URL is stable and the content is intact.

## What changed

- `docs/community/highlights.md`: link target swapped to the Wayback Machine snapshot.
- `docs/history/hatch.md`: added a `Fixed` entry under `Unreleased`.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# BEFORE — on master, link returns 404
git checkout master -- docs/community/highlights.md
grep -n 'switching-to-hatch' docs/community/highlights.md
# Expected: shows https://andrich.me/2023/08/switching-to-hatch/
curl -sL -o /dev/null -w "BEFORE status: %{http_code}\n" \
  "$(grep -oE 'https://andrich\.me[^ )]+' docs/community/highlights.md)"
# Expected: BEFORE status: 404

# AFTER — on this branch, link returns 200
git checkout fix/1997-broken-switching-to-hatch-link -- docs/community/highlights.md
grep -n 'switching-to-hatch' docs/community/highlights.md
# Expected: shows https://web.archive.org/...
curl -sL -o /dev/null -w "AFTER  status: %{http_code}\n" \
  "$(grep -oE 'https://web\.archive\.org[^ )]+' docs/community/highlights.md)"
# Expected: AFTER  status: 200
```

## What I ran locally

- Verified the original URL returns 404 (`curl -sLI`).
- Verified the Wayback snapshot returns 200 and shows the original article body.
- This is a docs-only change; no test suite implications.

## Edge cases

| Scenario | Behavior |
|---|---|
| User clicks the link from rendered docs | Lands on the archived article (200) |
| Original blog comes back online | Wayback snapshot remains valid; can be reverted in a future PR |
| Reader copies the URL to share | Wayback URL is permanent and self-describing |

---

🤖 *AI disclosure: this PR was prepared with assistance from Claude (Anthropic) under the supervision of @jbbqqf, who reviewed the diff and the verification before opening it.*