### PR TITLE
fix(wheel): treat shared-scripts/shared-data/extra-metadata as selection signals

### DIFF
--- a/backend/src/hatchling/builders/wheel.py
+++ b/backend/src/hatchling/builders/wheel.py
@@ -238,7 +238,19 @@ class WheelBuilderConfig(BuilderConfig):
                 return FileSelectionOptions([], exclude, [namespace], [])
             project_names.add(project_name)
 
-        if self.bypass_selection or self.build_artifact_spec is not None or self.get_force_include():
+        # Treat any out-of-tree contribution to the wheel — force-include map, build artifacts,
+        # shared-data, shared-scripts, extra-metadata — as an explicit signal that the user
+        # intentionally omitted in-tree file selection. Without this, supplying only
+        # `shared-scripts` (and friends) raises a confusing "no files to ship" error even
+        # though the wheel will not actually be empty. See issue #1973.
+        if (
+            self.bypass_selection
+            or self.build_artifact_spec is not None
+            or self.get_force_include()
+            or self.shared_data
+            or self.shared_scripts
+            or self.extra_metadata
+        ):
             self.set_exclude_all()
             return FileSelectionOptions([], exclude, [], [])
 

--- a/docs/history/hatchling.md
+++ b/docs/history/hatchling.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Support PEP 794 (core metadata `Import-Name` and `Import-Namespace` fields and version 2.5)
 
+***Fixed:***
+
+- Wheel builder now treats `shared-scripts`, `shared-data`, and `extra-metadata` as valid file selection signals, matching the existing behavior for `force-include` and `bypass-selection`. Previously, configuring only one of these without an explicit `include`/`packages`/`only-include` raised a misleading "no files to ship" error.
+
 ## [1.29.0](https://github.com/pypa/hatch/releases/tag/hatchling-v1.29.0) - 2026-02-21 ## {: #hatchling-v1.29.0 }
 
 ***Fixed:***

--- a/tests/backend/builders/test_wheel.py
+++ b/tests/backend/builders/test_wheel.py
@@ -241,6 +241,67 @@ class TestDefaultFileSelection:
             assert builder.config.default_packages() == []
             assert builder.config.default_only_include() == []
 
+    def test_shared_scripts_option_considered_selection(self, temp_dir):
+        # Regression test for https://github.com/pypa/hatch/issues/1973: configuring only
+        # `shared-scripts` (no `include`/`packages`) should be a sufficient selection
+        # signal — there's nothing in-tree to ship but the wheel will contain the scripts.
+        scripts_dir = temp_dir / "bin"
+        scripts_dir.ensure_dir_exists()
+        config = {
+            "project": {"name": "my-app", "version": "0.0.1"},
+            "tool": {
+                "hatch": {
+                    "build": {"targets": {"wheel": {"shared-scripts": {str(scripts_dir): "/myapp/"}}}}
+                }
+            },
+        }
+        builder = WheelBuilder(str(temp_dir), config=config)
+
+        assert builder.config.default_include() == []
+        assert builder.config.default_exclude() == []
+        assert builder.config.default_packages() == []
+        assert builder.config.default_only_include() == []
+
+    def test_shared_data_option_considered_selection(self, temp_dir):
+        # Same rationale as shared-scripts (issue #1973): shared-data alone should be a
+        # valid configuration without needing `bypass-selection = true`.
+        data_dir = temp_dir / "data"
+        data_dir.ensure_dir_exists()
+        config = {
+            "project": {"name": "my-app", "version": "0.0.1"},
+            "tool": {
+                "hatch": {
+                    "build": {"targets": {"wheel": {"shared-data": {str(data_dir): "/myapp/"}}}}
+                }
+            },
+        }
+        builder = WheelBuilder(str(temp_dir), config=config)
+
+        assert builder.config.default_include() == []
+        assert builder.config.default_exclude() == []
+        assert builder.config.default_packages() == []
+        assert builder.config.default_only_include() == []
+
+    def test_extra_metadata_option_considered_selection(self, temp_dir):
+        # Same rationale as shared-scripts (issue #1973): extra-metadata alone should be
+        # a valid configuration without needing `bypass-selection = true`.
+        meta_dir = temp_dir / "meta"
+        meta_dir.ensure_dir_exists()
+        config = {
+            "project": {"name": "my-app", "version": "0.0.1"},
+            "tool": {
+                "hatch": {
+                    "build": {"targets": {"wheel": {"extra-metadata": {str(meta_dir): "/myapp/"}}}}
+                }
+            },
+        }
+        builder = WheelBuilder(str(temp_dir), config=config)
+
+        assert builder.config.default_include() == []
+        assert builder.config.default_exclude() == []
+        assert builder.config.default_packages() == []
+        assert builder.config.default_only_include() == []
+
     def test_unnormalized_name_with_unnormalized_directory(self, temp_dir):
         config = {"project": {"name": "MyApp", "version": "0.0.1"}}
         builder = WheelBuilder(str(temp_dir), config=config)


### PR DESCRIPTION
## Summary

Configuring only `shared-scripts` (or `shared-data`, or `extra-metadata`) on a wheel target — without `include`/`packages`/`only-include` — raises a misleading "Unable to determine which files to ship" `ValueError` even though the resulting wheel will not be empty. Extend the existing selection-signal guard in `WheelBuilderConfig.default_file_selection_options` to cover these three options, matching the existing behavior for `force-include`/`bypass-selection`/build artifacts.

Closes #1973.

## Why

The current guard (`backend/src/hatchling/builders/wheel.py:241`) already considers `bypass-selection`, `build_artifact_spec`, and `get_force_include()` as explicit selection signals — when any of them is present, the builder accepts that there is nothing in-tree to package and proceeds. But `shared-scripts`, `shared-data`, and `extra-metadata` are equally valid out-of-tree contributions to the wheel, and forgetting to also list a project package or set `bypass-selection = true` produces a confusing error that doesn't mention them. The reporter of #1973 noted that `force-include` works fine in the same situation while `shared-scripts` does not.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# 0. Set up a venv with the local checkout
python -m venv /tmp/hatch-1973 && /tmp/hatch-1973/bin/pip install -q -e . -e ./backend pytest pytest-mock

# BEFORE — on master, the three new tests fail with the misleading ValueError
git checkout master
/tmp/hatch-1973/bin/python -m pytest tests/backend/builders/test_wheel.py -k \
  "test_shared_scripts_option_considered_selection or test_shared_data_option_considered_selection or test_extra_metadata_option_considered_selection" \
  -p no:cacheprovider 2>&1 | tail -5
# Expected: 3 failed (or "0 selected" because the tests don't exist yet on master).
# To prove the underlying bug on master, the equivalent reproducer is below.
git checkout master -- backend/src/hatchling/builders/wheel.py
git checkout fix/1973-shared-scripts-empty-include -- tests/backend/builders/test_wheel.py
/tmp/hatch-1973/bin/python -m pytest tests/backend/builders/test_wheel.py::TestDefaultFileSelection::test_shared_scripts_option_considered_selection -p no:cacheprovider 2>&1 | tail -5
# Expected: FAILED with "Unable to determine which files to ship"
git checkout HEAD -- backend/src/hatchling/builders/wheel.py tests/backend/builders/test_wheel.py

# AFTER — on this branch, all three tests pass
git checkout fix/1973-shared-scripts-empty-include
/tmp/hatch-1973/bin/python -m pytest tests/backend/builders/test_wheel.py::TestDefaultFileSelection -p no:cacheprovider 2>&1 | tail -5
# Expected: 15 passed
```

## What I ran locally

- `pytest tests/backend/builders/test_wheel.py::TestDefaultFileSelection -p no:cacheprovider` → **15 passed** on this branch.
- Same selection on master with the new tests grafted in → 3 failed (the regression tests).
- Verified the existing `test_bypass_selection_option`, `test_force_include_option_considered_selection`, `test_force_include_build_data_considered_selection`, and `test_artifacts_build_data_considered_selection` still pass — the new guard is strictly additive.

## Edge cases

| Scenario | BEFORE | AFTER |
|---|---|---|
| Only `shared-scripts` configured, no `include` | `ValueError` | wheel built, scripts copied |
| Only `shared-data` configured, no `include` | `ValueError` | wheel built, data copied |
| Only `extra-metadata` configured, no `include` | `ValueError` | wheel built, metadata copied |
| `shared-scripts` + a package directory present | wheel built normally | unchanged (selection is still picked up) |
| Nothing configured, no in-tree directory | `ValueError` (same message) | unchanged — the error still fires when truly nothing is selected |
| `bypass-selection = true` (existing workaround) | wheel built | unchanged |

## Code comment

The new condition has a short comment in `wheel.py` explaining the rationale and pointing back to this issue, so a future reviewer reading the diff cold doesn't have to re-derive why these three properties belong in the guard.

---

🤖 *AI disclosure: this PR was prepared with assistance from Claude (Anthropic) under the supervision of @jbbqqf, who reviewed the diff, ran the tests, and verified the BEFORE/AFTER behavior before opening it.*