### PR TITLE
fix(hatchling): honor .git/info/exclude patterns in builder VCS exclusions

### DIFF
--- a/backend/src/hatchling/builders/config.py
+++ b/backend/src/hatchling/builders/config.py
@@ -756,6 +756,20 @@ class BuilderConfig:
         if local_gitignore is not None:
             exclusion_files["git"].append(local_gitignore)
 
+        # Git also honors patterns from .git/info/exclude (a per-clone, untracked
+        # equivalent of .gitignore — see https://git-scm.com/docs/gitignore). Without
+        # this, users adding patterns to .git/info/exclude (e.g. as a workaround for
+        # tooling that overwrites .gitignore — see issue #2204) silently see those
+        # patterns ignored by the sdist/wheel builder. The .git path may be a
+        # directory (regular clone) or a file (worktree / submodule pointing to
+        # ../.git/worktrees/<name>); we only honor the regular-clone case here, since
+        # worktree-private excludes live in a different file under the main repo.
+        local_git = os.path.join(self.root, ".git")
+        if os.path.isdir(local_git):
+            git_info_exclude = os.path.join(local_git, "info", "exclude")
+            if os.path.isfile(git_info_exclude):
+                exclusion_files["git"].append(git_info_exclude)
+
         local_hgignore = locate_file(self.root, ".hgignore", boundary=".hg")
         if local_hgignore is not None:
             exclusion_files["hg"].append(local_hgignore)

--- a/docs/history/hatchling.md
+++ b/docs/history/hatchling.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ***Added:***
 
 - Support PEP 794 (core metadata `Import-Name` and `Import-Namespace` fields and version 2.5)
+- Honor patterns in `.git/info/exclude` for the wheel and sdist builders, matching Git's own behavior. Useful when tooling overwrites a project's `.gitignore` or for per-clone exclusions that aren't tracked in version control.
 
 ## [1.29.0](https://github.com/pypa/hatch/releases/tag/hatchling-v1.29.0) - 2026-02-21 ## {: #hatchling-v1.29.0 }
 

--- a/tests/backend/builders/test_config.py
+++ b/tests/backend/builders/test_config.py
@@ -1874,6 +1874,52 @@ class TestPatternExclude:
             assert not builder.config.exclude_spec.match_file(f"bar{separator}file.py")
 
     @pytest.mark.parametrize("separator", ["/", "\\"])
+    def test_vcs_git_info_exclude(self, temp_dir, separator, platform):
+        # Regression test for https://github.com/pypa/hatch/issues/2204:
+        # patterns added to `.git/info/exclude` (per-clone, not tracked) should be
+        # honored alongside `.gitignore`, matching Git's own behavior.
+        if separator == "\\" and not platform.windows:
+            pytest.skip("Not running on Windows")
+
+        with temp_dir.as_cwd():
+            config = {"tool": {"hatch": {"build": {"exclude": ["foo"]}}}}
+            builder = MockBuilder(str(temp_dir), config=config)
+
+            git_dir = temp_dir / ".git"
+            git_dir.mkdir()
+            git_info_dir = git_dir / "info"
+            git_info_dir.mkdir()
+            (git_info_dir / "exclude").write_text("/bar\n*.pyc\n")
+
+            assert builder.config.exclude_spec.match_file(f"foo{separator}file.py")
+            assert builder.config.exclude_spec.match_file(f"bar{separator}file.py")
+            assert builder.config.exclude_spec.match_file(f"baz{separator}bar{separator}file.pyc")
+            assert not builder.config.exclude_spec.match_file(f"baz{separator}bar{separator}file.py")
+
+    @pytest.mark.parametrize("separator", ["/", "\\"])
+    def test_vcs_git_info_exclude_combined_with_gitignore(self, temp_dir, separator, platform):
+        # Regression test for https://github.com/pypa/hatch/issues/2204: patterns from
+        # .gitignore and .git/info/exclude should both apply (additive, not exclusive).
+        if separator == "\\" and not platform.windows:
+            pytest.skip("Not running on Windows")
+
+        with temp_dir.as_cwd():
+            config = {"tool": {"hatch": {"build": {}}}}
+            builder = MockBuilder(str(temp_dir), config=config)
+
+            (temp_dir / ".gitignore").write_text("*.pyc\n")
+            git_info_dir = temp_dir / ".git" / "info"
+            git_info_dir.mkdir(parents=True)
+            (git_info_dir / "exclude").write_text("*.so\n")
+
+            # .gitignore pattern still excluded
+            assert builder.config.exclude_spec.match_file(f"foo{separator}file.pyc")
+            # .git/info/exclude pattern also excluded
+            assert builder.config.exclude_spec.match_file(f"foo{separator}file.so")
+            # unmatched files still allowed
+            assert not builder.config.exclude_spec.match_file(f"foo{separator}file.py")
+
+    @pytest.mark.parametrize("separator", ["/", "\\"])
     def test_vcs_git_exclude_whitelisted_file(self, temp_dir, separator, platform):
         if separator == "\\" and not platform.windows:
             pytest.skip("Not running on Windows")


### PR DESCRIPTION
## Summary

Git itself honors patterns from three sources, in priority order: project `.gitignore`, `.git/info/exclude` (per-clone, untracked), and the user's global `core.excludesFile` (see https://git-scm.com/docs/gitignore). Hatchling's wheel/sdist builders only read `.gitignore`, silently dropping patterns added to `.git/info/exclude`. This PR teaches `BuilderConfig.vcs_exclusion_files` to also include `.git/info/exclude` when `.git` is a regular directory.

Closes #2204.

## Why

The reporter's concrete scenario: PyCharm injects various `venv*`/`.venv*` patterns into `.gitignore`, and they tried to use `.git/info/exclude` as a per-clone workaround. Hatchling silently shipped files they expected to be excluded. Matching Git's own pattern-source list closes the gap with the principle of least surprise.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# 0. Set up a venv with the local backend checkout
python -m venv /tmp/hatch-2204
/tmp/hatch-2204/bin/pip install -q -e . -e ./backend pytest pytest-mock pathspec

# BEFORE — on master, the regression tests fail
git checkout master -- backend/src/hatchling/builders/config.py
git checkout fix/2204-git-info-exclude -- tests/backend/builders/test_config.py
/tmp/hatch-2204/bin/python -m pytest \
  tests/backend/builders/test_config.py::TestPatternExclude::test_vcs_git_info_exclude \
  tests/backend/builders/test_config.py::TestPatternExclude::test_vcs_git_info_exclude_combined_with_gitignore \
  -p no:cacheprovider 2>&1 | tail -8
# Expected: 2 failed (.git/info/exclude patterns are silently ignored)

# AFTER — on this branch, all tests pass
git checkout fix/2204-git-info-exclude -- backend/src/hatchling/builders/config.py tests/backend/builders/test_config.py
/tmp/hatch-2204/bin/python -m pytest tests/backend/builders/test_config.py -p no:cacheprovider 2>&1 | tail -3
# Expected: 216 passed, 21 skipped
```

## What I ran locally

- `pytest tests/backend/builders/test_config.py` → **216 passed, 21 skipped** on this branch (skips are platform-gated Windows tests).
- The two new regression tests (`test_vcs_git_info_exclude`, `test_vcs_git_info_exclude_combined_with_gitignore`) fail on master with the new code reverted, confirming the fix is load-bearing.

## Edge cases

| Scenario | BEFORE | AFTER |
|---|---|---|
| `.git/info/exclude` exists, no `.gitignore` | patterns dropped | patterns honored |
| Both `.gitignore` and `.git/info/exclude` present | only `.gitignore` honored | both honored (additive) |
| `.git` is a file (worktree / submodule) | n/a | conservatively skipped — worktree-private excludes live elsewhere; not changing behavior here |
| `.git` directory exists but `info/exclude` does not | unchanged | unchanged (file-existence check) |
| `ignore-vcs = true` set in build config | VCS sources skipped | unchanged (existing behavior preserved) |

## Code comment

The new code block has a 4-line comment explaining (a) that this matches Git's own gitignore-source list, (b) why we only honor the regular-clone case and not the worktree-file case, and (c) referencing #2204. This way a reviewer reading the diff cold doesn't have to re-derive the design choices.

---

🤖 *AI disclosure: this PR was prepared with assistance from Claude (Anthropic) under the supervision of @jbbqqf, who reviewed the diff, ran the tests, and verified the BEFORE/AFTER behavior before opening it.*