### PR TITLE
fix(template): omit email field from new project when user blanks it

### DIFF
--- a/docs/history/hatch.md
+++ b/docs/history/hatch.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Fixed:***
+
+- `hatch new` now omits the `email` field from the generated `authors` entry and from SPDX license headers when the user explicitly sets `[template] email = ""` in their config, instead of rendering empty `<>` placeholders.
+
 ## [1.16.5](https://github.com/pypa/hatch/releases/tag/hatch-v1.16.5) - 2026-02-26 ## {: #hatch-v1.16.5 }
 
 ***Fixed:***

--- a/src/hatch/template/default.py
+++ b/src/hatch/template/default.py
@@ -53,11 +53,17 @@ class DefaultTemplate(TemplateInterface):
 
         config["license_data"] = license_data
         config["license_expression"] = " OR ".join(license_data)
+        # When the user explicitly opts out of an email in their hatch template
+        # config (issue #1991), drop the `<>` placeholder from REUSE
+        # SPDX-FileCopyrightText so the rendered header isn't `Author <>`.
+        copyright_holder = (
+            f'{config["name"]} <{config["email"]}>' if config.get("email") else config["name"]
+        )
         config["license_header"] = (
             ""
             if not config["licenses"]["headers"]
             else f"""\
-# SPDX-FileCopyrightText: {self.creation_time.year}-present {config["name"]} <{config["email"]}>
+# SPDX-FileCopyrightText: {self.creation_time.year}-present {copyright_holder}
 #
 # SPDX-License-Identifier: {config["license_expression"]}
 """
@@ -119,11 +125,15 @@ class DefaultTemplate(TemplateInterface):
 
 
 def get_license_text(config, license_id, license_text, creation_time):
+    # Drop the `<>` placeholder when the user opted out of an email (issue #1991);
+    # SPDX upstream license texts use `<copyright holders>` / `<owner>` as a single
+    # token, so substituting just the name is well-formed.
+    holder = f"{config['name']} <{config['email']}>" if config.get("email") else config["name"]
     if license_id == "MIT":
         license_text = license_text.replace("<year>", f"{creation_time.year}-present", 1)
-        license_text = license_text.replace("<copyright holders>", f"{config['name']} <{config['email']}>", 1)
+        license_text = license_text.replace("<copyright holders>", holder, 1)
     elif license_id == "BSD-3-Clause":
         license_text = license_text.replace("<year>", f"{creation_time.year}-present", 1)
-        license_text = license_text.replace("<owner>", f"{config['name']} <{config['email']}>", 1)
+        license_text = license_text.replace("<owner>", holder, 1)
 
     return f"{license_text.rstrip()}\n"

--- a/src/hatch/template/files_default.py
+++ b/src/hatch/template/files_default.py
@@ -87,7 +87,7 @@ requires-python = ">=3.8"
 license = "{license_expression}"{license_files}
 keywords = []
 authors = [
-  {{ name = "{name}", email = "{email}" }},
+  {authors_entry},
 ]
 classifiers = [
   "Development Status :: 4 - Beta",
@@ -111,6 +111,17 @@ path = "{package_metadata_file_path}"{tests_section}
     def __init__(self, template_config: dict, plugin_config: dict):
         template_config = dict(template_config)
         template_config["name"] = repr(template_config["name"])[1:-1]
+
+        # PEP 621 allows an `authors` entry to omit either `name` or `email`. When the
+        # user explicitly sets an empty string for the email — e.g. via a blank
+        # `[template] email = ""` in their hatch config — emit `{ name = "..." }`
+        # alone instead of `{ name = "...", email = "" }`, which would otherwise
+        # leak `Author <>` artifacts into rendered metadata. See issue #1991.
+        if template_config.get("email"):
+            authors_entry = f'{{ name = "{template_config["name"]}", email = "{template_config["email"]}" }}'
+        else:
+            authors_entry = f'{{ name = "{template_config["name"]}" }}'
+        template_config["authors_entry"] = authors_entry
 
         project_url_data = ""
         project_urls = (

--- a/tests/cli/new/test_new.py
+++ b/tests/cli/new/test_new.py
@@ -104,6 +104,34 @@ def test_default_explicit_path(hatch, helpers, temp_dir):
     )
 
 
+def test_default_blank_email(hatch, config_file, temp_dir):
+    """Regression test for https://github.com/pypa/hatch/issues/1991 — when the user
+    explicitly sets an empty email in the template config, neither pyproject.toml's
+    `authors` entry nor the SPDX license headers should leave a `<>` placeholder."""
+    project_name = "My.App"
+    config_file.model.template.email = ""
+    config_file.save()
+
+    with temp_dir.as_cwd():
+        result = hatch("new", project_name)
+
+    assert result.exit_code == 0, result.output
+
+    path = temp_dir / "my-app"
+    pyproject_text = (path / "pyproject.toml").read_text(encoding="utf-8")
+    license_text = (path / "LICENSE.txt").read_text(encoding="utf-8")
+    init_text = (path / "src" / "my_app" / "__init__.py").read_text(encoding="utf-8")
+
+    # pyproject authors entry has no email field at all, not `email = ""`
+    assert 'email = ""' not in pyproject_text
+    assert 'email = "' not in pyproject_text  # the field is omitted entirely
+    assert "authors = [\n  { name = " in pyproject_text
+
+    # SPDX header in __init__.py / __about__.py / tests/__init__.py: no trailing `<>`
+    assert "<>" not in init_text
+    assert "<>" not in license_text
+
+
 def test_default_empty_plugins_table(hatch, helpers, config_file, temp_dir):
     project_name = "My.App"
     config_file.model.template.plugins = {}


### PR DESCRIPTION
## Summary

When a user sets `[template] email = ""` in their hatch config — for instance because they don't want their address in their project metadata or in copyright headers (issue #1991) — `hatch new` rendered:

```toml
authors = [
  { name = "Trey Hunner", email = "" },
]
```

and SPDX headers like `# SPDX-FileCopyrightText: 2026-present Trey Hunner <>`. PEP 621 explicitly allows an `authors` entry to omit either `name` or `email`, so the right thing is to emit only what the user supplied.

Closes #1991.

## Why

The reporter's exact use case: they want to publish without exposing their email in `pyproject.toml`. Setting `email = ""` is the natural opt-out — there's no other dedicated knob — and the current `Author <>` rendering forces them to manually post-edit every generated file.

## What changed

- `src/hatch/template/files_default.py`: `PyProject.__init__` chooses between `{ name = "...", email = "..." }` and `{ name = "..." }` based on whether `email` is truthy. Templated as a new `{authors_entry}` substitution to keep the TOML literal stable.
- `src/hatch/template/default.py`:
  - `initialize_config` builds the SPDX `license_header` with or without `<email>` based on `email`.
  - `get_license_text` trims `<>` from the MIT `<copyright holders>` and BSD-3-Clause `<owner>` substitutions.
- `tests/cli/new/test_new.py`: new `test_default_blank_email` regression test asserting the generated `pyproject.toml`, `LICENSE.txt`, and per-file SPDX headers contain neither `email = ""` nor a trailing `<>` placeholder.
- `docs/history/hatch.md`: changelog entry under Unreleased / Fixed.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# 0. Set up a venv with the local checkout
python -m venv /tmp/hatch-1991
/tmp/hatch-1991/bin/pip install -q -e . -e ./backend pytest pytest-mock

# BEFORE — on master, regression test fails
git checkout master -- src/hatch/template/files_default.py src/hatch/template/default.py
git checkout fix/1991-blank-email-template -- tests/cli/new/test_new.py
/tmp/hatch-1991/bin/python -m pytest tests/cli/new/test_new.py::test_default_blank_email -p no:cacheprovider 2>&1 | tail -10
# Expected: FAILED — generated pyproject.toml contains 'email = ""'.

# AFTER — on this branch, regression test passes; full cli/new suite is green
git checkout fix/1991-blank-email-template -- src/hatch/template/files_default.py src/hatch/template/default.py tests/cli/new/test_new.py
/tmp/hatch-1991/bin/python -m pytest tests/cli/new/ -p no:cacheprovider 2>&1 | tail -3
# Expected: 23 passed
```

## What I ran locally

- `pytest tests/cli/new/` → **23 passed** on this branch.
- New `test_default_blank_email` fails on master (verified by reverting just the two source files).
- Existing template snapshots (`tests/helpers/templates/new/default.py` etc.) keep working unchanged because the default config still ships a non-empty email; only the explicit-blank case takes the new branch.

## Edge cases

| Scenario | BEFORE | AFTER |
|---|---|---|
| Default config (email = `Foo Bar <foo@bar.baz>`) | unchanged | unchanged — full `name`/`email` form |
| `[template] email = ""` set explicitly | `email = ""`, `Author <>` headers | `name`-only entry, plain `Author` headers |
| `email` key absent (impossible — always defaulted) | n/a | falls through to `name`-only form |
| MIT/BSD-3-Clause LICENSE generation with blank email | `<copyright holders>` left as `Author <>` | replaced with just `Author` |
| Project description with backticks/quotes | unchanged | unchanged — only the email substitution path is touched |

## Code comments

The two non-trivial branches each carry a 2–3 line comment explaining (a) the PEP 621 invariant being honored and (b) the issue reference, so a reviewer reading the diff cold doesn't have to re-derive it.

---

🤖 *AI disclosure: this PR was prepared with assistance from Claude (Anthropic) under the supervision of @jbbqqf, who reviewed the diff, ran the tests, and verified the BEFORE/AFTER behavior before opening it.*