### PR TITLE
docs: surface testing config reference in `hatch test -h`

### DIFF
--- a/docs/config/internal/testing.md
+++ b/docs/config/internal/testing.md
@@ -86,6 +86,9 @@ The following is the default configuration:
 <HATCH_TEST_ENV_DEPENDENCIES>
 ```
 
+!!! note
+    `extra-dependencies` is **additive** to the defaults shown above — it does not replace them. If you specify a package that is already in the defaults with an incompatible version, dependency resolution will fail. To take full control of the dependency set (for example, to pin `pytest-rerunfailures` to a different major version), override `dependencies` instead of `extra-dependencies`. You can inspect the resolved dependency set for a given environment with `hatch test --show`.
+
 ### Matrix
 
 You can override the default series of [matrices](../environment/advanced.md#matrix):

--- a/docs/history/hatch.md
+++ b/docs/history/hatch.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Fixed:***
+
+- `hatch test --help` now points at the testing configuration reference and notes that `extra-dependencies` is additive to the built-in defaults, surfacing the cause of "no solution found when resolving dependencies" errors when a user pins a package that is already in the defaults.
+
 ## [1.16.5](https://github.com/pypa/hatch/releases/tag/hatch-v1.16.5) - 2026-02-26 ## {: #hatch-v1.16.5 }
 
 ***Fixed:***

--- a/src/hatch/cli/test/__init__.py
+++ b/src/hatch/cli/test/__init__.py
@@ -83,6 +83,12 @@ def test(
         The inclusion option is treated as an intersection while the exclusion option is treated as a
         union i.e. an environment must match all of the included variables to be selected while matching
         any of the excluded variables will prevent selection.
+
+    The `hatch-test` environment ships with a default set of dependencies (pytest,
+    coverage, pytest-rerunfailures, ...) and `extra-dependencies` is additive to those.
+    To customize testing — including the dependency list, default arguments, scripts,
+    or matrix — see the testing configuration reference:
+    https://hatch.pypa.io/latest/config/internal/testing/
     """
     app: Application = ctx.obj
 

--- a/tests/cli/test/test_test.py
+++ b/tests/cli/test/test_test.py
@@ -16,6 +16,25 @@ def _terminal_width():
         yield
 
 
+class TestHelpText:
+    """Regression tests for https://github.com/pypa/hatch/issues/2202 — `hatch test -h`
+    should point users at the testing configuration reference and warn that
+    `extra-dependencies` is additive to the built-in defaults."""
+
+    def test_help_links_to_testing_config_docs(self, hatch):
+        result = hatch("test", "-h")
+        assert result.exit_code == 0, result.output
+        assert "https://hatch.pypa.io/latest/config/internal/testing/" in result.output
+
+    def test_help_mentions_extra_dependencies_is_additive(self, hatch):
+        result = hatch("test", "-h")
+        assert result.exit_code == 0, result.output
+        # The exact phrasing isn't load-bearing; the user-visible signal is that the
+        # help text acknowledges defaults exist and that extra-dependencies adds to them.
+        assert "extra-dependencies" in result.output
+        assert "additive" in result.output
+
+
 class TestDefaults:
     def test_basic(self, hatch, temp_dir, config_file, env_run, mocker):
         config_file.model.template.plugins["default"]["tests"] = False


### PR DESCRIPTION
## Summary

Users who hit "no solution found when resolving dependencies" after pinning a package (e.g. `pytest-rerunfailures==15.0`) that's already in the `hatch-test` defaults have no signal that the conflict comes from hatch's built-in defaults — the existing `--help` text doesn't mention them, and finding the testing-config docs requires knowing they exist. Add a pointer in the CLI help and a matching note on the docs page.

Closes #2202.

## Why

The reporter's exact scenario (issue #2202): they added `extra-dependencies = ["pytest-rerunfailures==15.0"]` and got a confusing uv resolver error referring to `pytest-rerunfailures>=14.0,<15.dev0`. The lower bound came from hatch-test's built-in defaults, but nothing in the user-facing surface — `--help`, the error message, the tutorial — said so. Surfacing the docs URL plus a one-line "additive" hint in `--help` lets the user diagnose the conflict without first knowing to run `hatch test --show`.

## What changed

- `src/hatch/cli/test/__init__.py`: appended a paragraph to the `test` docstring with the docs URL and an "additive" note. Click renders this into `--help` output.
- `docs/config/internal/testing.md`: added an admonition under the Dependencies section pointing out that `extra-dependencies` is additive, that overriding `dependencies` gives full control, and that `hatch test --show` exposes the resolved set.
- `tests/cli/test/test_test.py`: new `TestHelpText` class with two regression tests on the help output.
- `docs/history/hatch.md`: changelog entry under Unreleased / Fixed.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# 0. Set up a venv with the local checkout
python -m venv /tmp/hatch-2202
/tmp/hatch-2202/bin/pip install -q -e . -e ./backend pytest pytest-mock

# BEFORE — on master, regression tests fail (help output is silent on defaults/docs)
git checkout master -- src/hatch/cli/test/__init__.py
git checkout docs/2202-hatch-test-help -- tests/cli/test/test_test.py
/tmp/hatch-2202/bin/python -m pytest tests/cli/test/test_test.py::TestHelpText -p no:cacheprovider 2>&1 | tail -8
# Expected: 2 failed — `extra-dependencies` and the docs URL are absent from --help.

# AFTER — on this branch, regression tests pass
git checkout docs/2202-hatch-test-help -- src/hatch/cli/test/__init__.py tests/cli/test/test_test.py
/tmp/hatch-2202/bin/python -m pytest tests/cli/test/test_test.py::TestHelpText -p no:cacheprovider 2>&1 | tail -3
# Expected: 2 passed
```

## What I ran locally

- `pytest tests/cli/test/test_test.py::TestHelpText` → 2 passed.
- New tests fail on master (verified by reverting just `src/hatch/cli/test/__init__.py`), confirming the regression coverage is real.
- This is documentation-only behavior; no other test files are impacted.

## Edge cases

| Scenario | BEFORE | AFTER |
|---|---|---|
| `hatch test -h` rendered to a TTY | no mention of defaults / docs | new paragraph at end of help text |
| `hatch test --help` from a script | same | same — Click renders both flags identically |
| Reading the testing-config docs page | no warning that `extra-dependencies` is additive | admonition explains it and references `--show` |
| Existing `hatch test` flags / behavior | unchanged | unchanged — pure docs/help-text change |

---

🤖 *AI disclosure: this PR was prepared with assistance from Claude (Anthropic) under the supervision of @jbbqqf, who reviewed the diff, ran the tests, and verified the BEFORE/AFTER behavior before opening it.*