### PR TITLE
Block duplicate files in wheel archives (closes #2066)

### DIFF
--- a/backend/src/hatchling/builders/wheel.py
+++ b/backend/src/hatchling/builders/wheel.py
@@ -65,6 +65,21 @@ class RecordFile:
         self.__file_obj.close()
 
 
+class _WheelZipFile(zipfile.ZipFile):
+    def open(self, name, mode="r", pwd=None, *, force_zip64=False):
+        filename = name.filename if isinstance(name, zipfile.ZipInfo) else name
+        if mode == "w" and filename in self.NameToInfo:
+            message = (
+                f"A second file is being added to the wheel archive at the same path: `{filename}`.\n\n"
+                f"The most likely cause of this is an entry in the "
+                f"`tool.hatch.build.targets.wheel.force-include` table. See: "
+                f"https://hatch.pypa.io/1.8/config/build/#forced-inclusion\n\n"
+            )
+            raise ValueError(message)
+
+        return super().open(name, mode, pwd, force_zip64=force_zip64)
+
+
 class WheelArchive:
     def __init__(self, project_id: str, *, reproducible: bool) -> None:
         """
@@ -82,7 +97,7 @@ class WheelArchive:
 
         raw_fd, self.path = tempfile.mkstemp(suffix=".whl")
         self.fd = os.fdopen(raw_fd, "w+b")
-        self.zf = zipfile.ZipFile(self.fd, "w", compression=zipfile.ZIP_DEFLATED)
+        self.zf = _WheelZipFile(self.fd, "w", compression=zipfile.ZIP_DEFLATED)
 
     @staticmethod
     def get_reproducible_time_tuple() -> TIME_TUPLE:

--- a/docs/config/build.md
+++ b/docs/config/build.md
@@ -118,7 +118,7 @@ For example, if there was a directory alongside the project root named `artifact
     - Sources that do not exist will raise an error.
 
 !!! warning
-    Files included using this option will overwrite any file path that was already included by other file selection options.
+    Attempting to overwrite any file path that was already included by other file selection options will raise an error.
 
 ### Default file selection
 

--- a/tests/backend/builders/test_wheel.py
+++ b/tests/backend/builders/test_wheel.py
@@ -207,6 +207,44 @@ class TestDefaultFileSelection:
         assert builder.config.default_packages() == []
         assert builder.config.default_only_include() == []
 
+    def test_force_include_duplicate_path(self, hatch, temp_dir, config_file):
+        config_file.model.template.plugins["default"]["src-layout"] = False
+        config_file.save()
+
+        project_name = "My.App"
+
+        with temp_dir.as_cwd():
+            result = hatch("new", project_name)
+
+        assert result.exit_code == 0, result.output
+
+        project_path = temp_dir / "my-app"
+        (project_path / "my_datafile").write_text("hello world")
+        config = {
+            "project": {"name": project_name, "dynamic": ["version"]},
+            "tool": {
+                "hatch": {
+                    "version": {"path": "my_app/__about__.py"},
+                    "build": {
+                        "targets": {
+                            "wheel": {
+                                "force-include": {
+                                    "my_datafile": "my_app-0.0.1.dist-info/METADATA",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        builder = WheelBuilder(str(project_path), config=config)
+
+        build_path = project_path / "dist"
+        build_path.mkdir()
+
+        with pytest.raises(ValueError, match="second file is being added"):
+            list(builder.build(directory=str(build_path)))
+
     def test_force_include_option_considered_selection(self, temp_dir):
         config = {
             "project": {"name": "my-app", "version": "0.0.1"},


### PR DESCRIPTION
Using `force-include`, it was possible to create invalid wheels. For example, one could add a `MANIFEST` file, and zipfile will (un)happily add both to the archive, emitting only a warning. This commit will catch such cases and raise an exception instead.

If someone is relying on this behaviour, I could imagine this being a breaking change, but I can't imagine any sane use cases that rely on overwriting files in the archive.

_hello from PyCon US!_