### PR TITLE
docs(highlights): redirect Switching to Hatch link to Wayback snapshot (#1997)

### DIFF
--- a/docs/community/highlights.md
+++ b/docs/community/highlights.md
@@ -10,4 +10,4 @@
 ## Adoption
 
 - Black - https://ichard26.github.io/blog/2022/10/black-22.10.0/#goodbye-python-36-and-hello-hatchling
-- "Switching to Hatch" - https://andrich.me/2023/08/switching-to-hatch/
+- "Switching to Hatch" - https://web.archive.org/web/20250208162745/https://andrich.me/2023/08/switching-to-hatch/


### PR DESCRIPTION
Closes #1997.

The "Switching to Hatch" link in `docs/community/highlights.md`'s Adoption section is dead: `https://andrich.me/2023/08/switching-to-hatch/` 301-redirects to `https://someonewho.codes/2023/08/switching-to-hatch/`, which now 404s. The author appears to have moved their site without preserving that URL.

Point the link at the 2025-02-08 Wayback Machine snapshot so the adoption story stays accessible while the original blog is offline. Pinning to a captured timestamp (`/web/20250208162745/...`) rather than the wildcard `/web/2024/...` form keeps the URL stable even if the snapshot index shifts.

If you'd rather drop the entry entirely than link to an archive, I'm happy to push that as an alternative.

### Change Type

- [x] Documentation