### PR TITLE
Ignore Jujutsu directory

### DIFF
--- a/backend/src/hatchling/builders/constants.py
+++ b/backend/src/hatchling/builders/constants.py
@@ -23,6 +23,8 @@ EXCLUDED_DIRECTORIES = frozenset((
     ".mypy_cache",
     # pixi
     ".pixi",
+    # jujutsu VCS
+    ".jj",
 ))
 EXCLUDED_FILES = frozenset((
     # https://en.wikipedia.org/wiki/.DS_Store


### PR DESCRIPTION
When attempting to build a sdist in a repo that's controlled by [jujutsu](https://www.jj-vcs.dev/latest/), I often get hit with the following error:
```
❯ uv build
Building source distribution...
  × Failed to build `/home/me/myproj`
  ├─▶ Invalid tar file
  ├─▶ failed to unpack
  │   `/home/me/.cache/uv/sdists-v9/.tmpUH9btv/myproj-1.0.0/.jj/repo/config.toml`
  ╰─▶ symlink path `/home/me/.config/jj/repos/f5fff8505651f2787ef4/config.toml` is
      absolute, but external symlinks are not allowed
```

Typically I ignore this by just adding `.jj/` to the `.gitignore`, however this seems to be a more permanent fix that I hope effectively does the same thing. 