### PR TITLE
Feat hatch check command with new sub command for types

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -39,7 +39,7 @@ extra-dependencies = [
 [envs.types.scripts]
 check = "mypy --install-types --non-interactive {args:backend/src/hatchling src/hatch tests}"
 
-[envs.hatch-type-check]
+[envs.hatch-check-types]
 workspace.members = ["backend/"]
 extra-dependencies = [
   "editables",

--- a/hatch.toml
+++ b/hatch.toml
@@ -33,6 +33,7 @@ generate-summary = "python scripts/generate_coverage_summary.py"
 write-summary-report = "python scripts/write_coverage_summary_report.py"
 
 [envs.hatch-type-check]
+workspace.members = ["backend/"]
 extra-dependencies = [
   "editables",
   "setuptools",

--- a/hatch.toml
+++ b/hatch.toml
@@ -32,12 +32,11 @@ report-uncovered-html = "coverage html --skip-covered --skip-empty"
 generate-summary = "python scripts/generate_coverage_summary.py"
 write-summary-report = "python scripts/write_coverage_summary_report.py"
 
-[envs.types]
+[envs.hatch-type-check]
 extra-dependencies = [
-  "mypy>=1.0.0",
+  "editables",
+  "setuptools",
 ]
-[envs.types.scripts]
-check = "mypy --install-types --non-interactive {args:backend/src/hatchling src/hatch tests}"
 
 [envs.docs]
 dependencies = [

--- a/hatch.toml
+++ b/hatch.toml
@@ -32,6 +32,13 @@ report-uncovered-html = "coverage html --skip-covered --skip-empty"
 generate-summary = "python scripts/generate_coverage_summary.py"
 write-summary-report = "python scripts/write_coverage_summary_report.py"
 
+[envs.types]
+extra-dependencies = [
+  "mypy>=1.0.0",
+]
+[envs.types.scripts]
+check = "mypy --install-types --non-interactive {args:backend/src/hatchling src/hatch tests}"
+
 [envs.hatch-type-check]
 workspace.members = ["backend/"]
 extra-dependencies = [

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -1,0 +1,9 @@
+project-includes = ["src/hatch", "backend/src/hatchling", "tests"]
+search-path = ["src", "backend/src", "tests"]
+preset = "legacy"
+
+# Disable the heuristic since we're explicitly setting search paths
+disable-search-path-heuristics = true
+
+# Platform-conditional dependencies that may not be installed on all OSes
+ignore-missing-imports = ["distro"]

--- a/src/hatch/cli/__init__.py
+++ b/src/hatch/cli/__init__.py
@@ -8,6 +8,7 @@ import click
 from hatch._version import __version__
 from hatch.cli.application import Application
 from hatch.cli.build import build
+from hatch.cli.check import check
 from hatch.cli.clean import clean
 from hatch.cli.config import config
 from hatch.cli.dep import dep
@@ -23,7 +24,6 @@ from hatch.cli.self import self_command
 from hatch.cli.shell import shell
 from hatch.cli.status import status
 from hatch.cli.test import test
-from hatch.cli.types import types
 from hatch.cli.version import version
 from hatch.config.constants import AppEnvVars, ConfigEnvVars
 from hatch.project.core import Project
@@ -219,6 +219,7 @@ def hatch(
 
 
 hatch.add_command(build)
+hatch.add_command(check)
 hatch.add_command(clean)
 hatch.add_command(config)
 hatch.add_command(dep)
@@ -234,7 +235,6 @@ hatch.add_command(self_command)
 hatch.add_command(shell)
 hatch.add_command(status)
 hatch.add_command(test)
-hatch.add_command(types)
 hatch.add_command(version)
 
 

--- a/src/hatch/cli/__init__.py
+++ b/src/hatch/cli/__init__.py
@@ -23,6 +23,7 @@ from hatch.cli.self import self_command
 from hatch.cli.shell import shell
 from hatch.cli.status import status
 from hatch.cli.test import test
+from hatch.cli.types import types
 from hatch.cli.version import version
 from hatch.config.constants import AppEnvVars, ConfigEnvVars
 from hatch.project.core import Project
@@ -233,6 +234,7 @@ hatch.add_command(self_command)
 hatch.add_command(shell)
 hatch.add_command(status)
 hatch.add_command(test)
+hatch.add_command(types)
 hatch.add_command(version)
 
 

--- a/src/hatch/cli/check/__init__.py
+++ b/src/hatch/cli/check/__init__.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import click
+
+from hatch.cli.check.code import code
+from hatch.cli.check.fmt import fmt
+from hatch.cli.check.types import types
+
+
+@click.group(short_help="Check source code", invoke_without_command=True)
+@click.option("--fix", is_flag=True, help="Fix issues rather than just reporting them")
+@click.pass_context
+def check(ctx: click.Context, *, fix: bool):
+    """Check source code for issues (linting, formatting, type checking).
+
+    When invoked without a subcommand, runs all checks (code, fmt, types).
+    """
+    if ctx.invoked_subcommand is not None:
+        return
+
+    ctx.invoke(code, fix=fix)
+    ctx.invoke(fmt, fix=fix)
+    ctx.invoke(types)
+
+
+check.add_command(code)
+check.add_command(fmt)
+check.add_command(types)

--- a/src/hatch/cli/check/code.py
+++ b/src/hatch/cli/check/code.py
@@ -27,14 +27,14 @@ def code(
 
     app.ensure_environment_plugin_dependencies()
 
-    for context in app.runner_context(["hatch-static-analysis"]):
+    for context in app.runner_context(["hatch-check-code"]):
         sa_env = StaticAnalysisEnvironment(context.env)
 
         # TODO: remove in a few minor releases, this is very new but we don't want to break users on the cutting edge
         if legacy_config_path := app.project.config.config.get("format", {}).get("config-path", ""):
             app.display_warning(
                 "The `tool.hatch.format.config-path` option is deprecated and will be removed in a future release. "
-                "Use `tool.hatch.envs.hatch-static-analysis.config-path` instead."
+                "Use `tool.hatch.envs.hatch-check-code.config-path` instead."
             )
             sa_env.config_path = legacy_config_path
 
@@ -60,7 +60,15 @@ def code(
         formatted_args = context.env.join_command_args(arguments)
         context.add_shell_command(f"{script} {formatted_args}")
 
-        context.env_vars["HATCH_FMT_ARGS"] = internal_args
+        # Check for legacy HATCH_FMT_ARGS usage in scripts and warn about deprecation
+        for script_body in context.env.config.get("scripts", {}).values():
+            if isinstance(script_body, str) and "HATCH_FMT_ARGS" in script_body:
+                app.display_warning(
+                    "The `HATCH_FMT_ARGS` environment variable is deprecated. Use `HATCH_CHECK_CODE_ARGS` instead."
+                )
+                break
+
+        context.env_vars["HATCH_CHECK_CODE_ARGS"] = internal_args
 
         if not sa_env.config_path or sync:
             sa_env.write_config_file(preview=preview)

--- a/src/hatch/cli/check/code.py
+++ b/src/hatch/cli/check/code.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from hatch.cli.application import Application
 
 
-@click.command(short_help="Lint source code", context_settings={"ignore_unknown_options": True})
+@click.command(short_help="Perform static analysis", context_settings={"ignore_unknown_options": True})
 @click.argument("args", nargs=-1)
 @click.option("--fix", is_flag=True, help="Fix lint errors rather than just reporting them")
 @click.option("--sync", is_flag=True, help="Sync the default config file with the current version of Hatch")
@@ -20,7 +20,9 @@ def code(
     fix: bool,
     sync: bool,
 ):
-    """Lint source code using Ruff."""
+    """
+    Perform static analysis, using Ruff by default.
+    """
     from hatch.cli.fmt.core import StaticAnalysisEnvironment
 
     app.ensure_environment_plugin_dependencies()

--- a/src/hatch/cli/check/code.py
+++ b/src/hatch/cli/check/code.py
@@ -8,31 +8,19 @@ if TYPE_CHECKING:
     from hatch.cli.application import Application
 
 
-@click.command(short_help="Format and lint source code", context_settings={"ignore_unknown_options": True})
+@click.command(short_help="Lint source code", context_settings={"ignore_unknown_options": True})
 @click.argument("args", nargs=-1)
-@click.option("--check", is_flag=True, help="Only check for errors rather than fixing them")
-@click.option("--linter", "-l", is_flag=True, help="Only run the linter")
-@click.option("--formatter", "-f", is_flag=True, help="Only run the formatter")
+@click.option("--fix", is_flag=True, help="Fix lint errors rather than just reporting them")
 @click.option("--sync", is_flag=True, help="Sync the default config file with the current version of Hatch")
 @click.pass_obj
-def fmt(
+def code(
     app: Application,
     *,
     args: tuple[str, ...],
-    check: bool,
-    linter: bool,
-    formatter: bool,
+    fix: bool,
     sync: bool,
 ):
-    """Format and lint source code."""
-    app.display_warning(
-        "The `hatch fmt` command is deprecated and will be removed in a future release. "
-        "Use `hatch check code --fix` for linting and `hatch check fmt --fix` for formatting instead."
-    )
-
-    if linter and formatter:
-        app.abort("Cannot specify both --linter and --formatter")
-
+    """Lint source code using Ruff."""
     from hatch.cli.fmt.core import StaticAnalysisEnvironment
 
     app.ensure_environment_plugin_dependencies()
@@ -51,12 +39,7 @@ def fmt(
         if sync and not sa_env.config_path:
             app.abort("The --sync flag can only be used when the `tool.hatch.format.config-path` option is defined")
 
-        scripts: list[str] = []
-        if not formatter:
-            scripts.append("lint-check" if check else "lint-fix")
-
-        if not linter:
-            scripts.append("format-check" if check else "format-fix")
+        script = "lint-fix" if fix else "lint-check"
 
         default_args = sa_env.get_default_args()
         arguments = list(args)
@@ -70,12 +53,10 @@ def fmt(
 
         internal_args = context.env.join_command_args(default_args)
         if internal_args:
-            # Add an extra space if required
             internal_args = f" {internal_args}"
 
         formatted_args = context.env.join_command_args(arguments)
-        for script in scripts:
-            context.add_shell_command(f"{script} {formatted_args}")
+        context.add_shell_command(f"{script} {formatted_args}")
 
         context.env_vars["HATCH_FMT_ARGS"] = internal_args
 

--- a/src/hatch/cli/check/fmt.py
+++ b/src/hatch/cli/check/fmt.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from hatch.cli.application import Application
 
 
-@click.command(short_help="Format source code", context_settings={"ignore_unknown_options": True})
+@click.command(short_help="Verify formatting", context_settings={"ignore_unknown_options": True})
 @click.argument("args", nargs=-1)
 @click.option("--fix", is_flag=True, help="Apply formatting fixes rather than just checking")
 @click.option("--sync", is_flag=True, help="Sync the default config file with the current version of Hatch")
@@ -20,7 +20,9 @@ def fmt(
     fix: bool,
     sync: bool,
 ):
-    """Format source code using Ruff."""
+    """
+    Verify formatting, using Ruff by default.
+    """
     from hatch.cli.fmt.core import StaticAnalysisEnvironment
 
     app.ensure_environment_plugin_dependencies()

--- a/src/hatch/cli/check/fmt.py
+++ b/src/hatch/cli/check/fmt.py
@@ -8,31 +8,19 @@ if TYPE_CHECKING:
     from hatch.cli.application import Application
 
 
-@click.command(short_help="Format and lint source code", context_settings={"ignore_unknown_options": True})
+@click.command(short_help="Format source code", context_settings={"ignore_unknown_options": True})
 @click.argument("args", nargs=-1)
-@click.option("--check", is_flag=True, help="Only check for errors rather than fixing them")
-@click.option("--linter", "-l", is_flag=True, help="Only run the linter")
-@click.option("--formatter", "-f", is_flag=True, help="Only run the formatter")
+@click.option("--fix", is_flag=True, help="Apply formatting fixes rather than just checking")
 @click.option("--sync", is_flag=True, help="Sync the default config file with the current version of Hatch")
 @click.pass_obj
 def fmt(
     app: Application,
     *,
     args: tuple[str, ...],
-    check: bool,
-    linter: bool,
-    formatter: bool,
+    fix: bool,
     sync: bool,
 ):
-    """Format and lint source code."""
-    app.display_warning(
-        "The `hatch fmt` command is deprecated and will be removed in a future release. "
-        "Use `hatch check code --fix` for linting and `hatch check fmt --fix` for formatting instead."
-    )
-
-    if linter and formatter:
-        app.abort("Cannot specify both --linter and --formatter")
-
+    """Format source code using Ruff."""
     from hatch.cli.fmt.core import StaticAnalysisEnvironment
 
     app.ensure_environment_plugin_dependencies()
@@ -51,12 +39,7 @@ def fmt(
         if sync and not sa_env.config_path:
             app.abort("The --sync flag can only be used when the `tool.hatch.format.config-path` option is defined")
 
-        scripts: list[str] = []
-        if not formatter:
-            scripts.append("lint-check" if check else "lint-fix")
-
-        if not linter:
-            scripts.append("format-check" if check else "format-fix")
+        script = "format-fix" if fix else "format-check"
 
         default_args = sa_env.get_default_args()
         arguments = list(args)
@@ -70,12 +53,10 @@ def fmt(
 
         internal_args = context.env.join_command_args(default_args)
         if internal_args:
-            # Add an extra space if required
             internal_args = f" {internal_args}"
 
         formatted_args = context.env.join_command_args(arguments)
-        for script in scripts:
-            context.add_shell_command(f"{script} {formatted_args}")
+        context.add_shell_command(f"{script} {formatted_args}")
 
         context.env_vars["HATCH_FMT_ARGS"] = internal_args
 

--- a/src/hatch/cli/check/fmt.py
+++ b/src/hatch/cli/check/fmt.py
@@ -27,14 +27,14 @@ def fmt(
 
     app.ensure_environment_plugin_dependencies()
 
-    for context in app.runner_context(["hatch-static-analysis"]):
+    for context in app.runner_context(["hatch-check-fmt"]):
         sa_env = StaticAnalysisEnvironment(context.env)
 
         # TODO: remove in a few minor releases, this is very new but we don't want to break users on the cutting edge
         if legacy_config_path := app.project.config.config.get("format", {}).get("config-path", ""):
             app.display_warning(
                 "The `tool.hatch.format.config-path` option is deprecated and will be removed in a future release. "
-                "Use `tool.hatch.envs.hatch-static-analysis.config-path` instead."
+                "Use `tool.hatch.envs.hatch-check-fmt.config-path` instead."
             )
             sa_env.config_path = legacy_config_path
 
@@ -60,7 +60,15 @@ def fmt(
         formatted_args = context.env.join_command_args(arguments)
         context.add_shell_command(f"{script} {formatted_args}")
 
-        context.env_vars["HATCH_FMT_ARGS"] = internal_args
+        # Check for legacy HATCH_FMT_ARGS usage in scripts and warn about deprecation
+        for script_body in context.env.config.get("scripts", {}).values():
+            if isinstance(script_body, str) and "HATCH_FMT_ARGS" in script_body:
+                app.display_warning(
+                    "The `HATCH_FMT_ARGS` environment variable is deprecated. Use `HATCH_CHECK_FMT_ARGS` instead."
+                )
+                break
+
+        context.env_vars["HATCH_CHECK_FMT_ARGS"] = internal_args
 
         if not sa_env.config_path or sync:
             sa_env.write_config_file(preview=preview)

--- a/src/hatch/cli/check/types.py
+++ b/src/hatch/cli/check/types.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from hatch.cli.application import Application
+
+
+@click.command(short_help="Type check source code", context_settings={"ignore_unknown_options": True})
+@click.argument("args", nargs=-1)
+@click.option("--summarize", "-s", is_flag=True, help="Include error summary statistics")
+@click.option("--cover", is_flag=True, help="Generate a type coverage report")
+@click.pass_obj
+def types(
+    app: Application,
+    *,
+    args: tuple[str, ...],
+    summarize: bool,
+    cover: bool,
+):
+    """Type check source code using Pyrefly."""
+    from hatch.cli.types.core import TypeCheckEnvironment
+
+    app.ensure_environment_plugin_dependencies()
+
+    for context in app.runner_context(["hatch-type-check"]):
+        tc_env = TypeCheckEnvironment(context.env)
+
+        if cover:
+            script = "coverage"
+        elif summarize:
+            script = "check-summarize"
+        else:
+            script = "check"
+
+        default_args = tc_env.get_default_args()
+        internal_args = context.env.join_command_args(default_args)
+        if internal_args:
+            internal_args = f" {internal_args}"
+
+        formatted_args = context.env.join_command_args(list(args))
+        context.add_shell_command(f"{script} {formatted_args}")
+
+        context.env_vars["HATCH_TYPES_ARGS"] = internal_args
+
+        if not tc_env.config_path:
+            tc_env.write_config_file()

--- a/src/hatch/cli/check/types.py
+++ b/src/hatch/cli/check/types.py
@@ -20,12 +20,14 @@ def types(
     summarize: bool,
     cover: bool,
 ):
-    """Type check source code using Pyrefly."""
+    """
+    Type check source code, using Pyrefly by default.
+    """
     from hatch.cli.types.core import TypeCheckEnvironment
 
     app.ensure_environment_plugin_dependencies()
 
-    for context in app.runner_context(["hatch-type-check"]):
+    for context in app.runner_context(["hatch-check-types"]):
         tc_env = TypeCheckEnvironment(context.env)
 
         if cover:
@@ -43,7 +45,7 @@ def types(
         formatted_args = context.env.join_command_args(list(args))
         context.add_shell_command(f"{script} {formatted_args}")
 
-        context.env_vars["HATCH_TYPES_ARGS"] = internal_args
+        context.env_vars["HATCH_CHECK_TYPES_ARGS"] = internal_args
 
         if not tc_env.config_path:
             tc_env.write_config_file()

--- a/src/hatch/cli/types/__init__.py
+++ b/src/hatch/cli/types/__init__.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from hatch.cli.application import Application
+
+
+@click.command(short_help="Type check source code", context_settings={"ignore_unknown_options": True})
+@click.argument("args", nargs=-1)
+@click.option("--summarize", "-s", is_flag=True, help="Include error summary statistics")
+@click.option("--cover", is_flag=True, help="Generate a type coverage report")
+@click.option("--sync", is_flag=True, help="Sync the default config file with the current version of Hatch")
+@click.pass_obj
+def types(
+    app: Application,
+    *,
+    args: tuple[str, ...],
+    summarize: bool,
+    cover: bool,
+    sync: bool,
+):
+    """Type check source code."""
+    from hatch.cli.types.core import TypeCheckEnvironment
+
+    app.ensure_environment_plugin_dependencies()
+
+    for context in app.runner_context(["hatch-type-check"]):
+        tc_env = TypeCheckEnvironment(context.env)
+
+        if sync and not tc_env.config_path:
+            app.abort("The --sync flag can only be used when the `tool.hatch.envs.hatch-type-check.config-path` option is defined")
+
+        if cover:
+            script = "coverage"
+        elif summarize:
+            script = "check-summarize"
+        else:
+            script = "check"
+
+        default_args = tc_env.get_default_args()
+        internal_args = context.env.join_command_args(default_args)
+        if internal_args:
+            internal_args = f" {internal_args}"
+
+        formatted_args = context.env.join_command_args(list(args))
+        context.add_shell_command(f"{script} {formatted_args}")
+
+        context.env_vars["HATCH_TYPES_ARGS"] = internal_args
+
+        if not tc_env.config_path or sync:
+            tc_env.write_config_file()

--- a/src/hatch/cli/types/__init__.py
+++ b/src/hatch/cli/types/__init__.py
@@ -12,7 +12,6 @@ if TYPE_CHECKING:
 @click.argument("args", nargs=-1)
 @click.option("--summarize", "-s", is_flag=True, help="Include error summary statistics")
 @click.option("--cover", is_flag=True, help="Generate a type coverage report")
-@click.option("--sync", is_flag=True, help="Sync the default config file with the current version of Hatch")
 @click.pass_obj
 def types(
     app: Application,
@@ -20,7 +19,6 @@ def types(
     args: tuple[str, ...],
     summarize: bool,
     cover: bool,
-    sync: bool,
 ):
     """Type check source code."""
     from hatch.cli.types.core import TypeCheckEnvironment
@@ -29,9 +27,6 @@ def types(
 
     for context in app.runner_context(["hatch-type-check"]):
         tc_env = TypeCheckEnvironment(context.env)
-
-        if sync and not tc_env.config_path:
-            app.abort("The --sync flag can only be used when the `tool.hatch.envs.hatch-type-check.config-path` option is defined")
 
         if cover:
             script = "coverage"
@@ -50,5 +45,5 @@ def types(
 
         context.env_vars["HATCH_TYPES_ARGS"] = internal_args
 
-        if not tc_env.config_path or sync:
+        if not tc_env.config_path:
             tc_env.write_config_file()

--- a/src/hatch/cli/types/core.py
+++ b/src/hatch/cli/types/core.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import os
+from functools import cached_property
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from hatch.env.plugin.interface import EnvironmentInterface
+    from hatch.utils.fs import Path
+
+
+class TypeCheckEnvironment:
+    def __init__(self, env: EnvironmentInterface) -> None:
+        self.env = env
+
+    @cached_property
+    def config_path(self) -> str:
+        return self.env.config.get("config-path", "")
+
+    def get_default_args(self) -> list[str]:
+        default_args: list[str] = []
+        if not self.config_path and not self.user_config_file:
+            default_args.extend(["--config", str(self.internal_config_file)])
+        return default_args
+
+    @cached_property
+    def internal_config_file(self) -> Path:
+        return self.env.isolated_data_directory / ".config" / self.env.root.id / "pyrefly.toml"
+
+    @cached_property
+    def user_config_file(self) -> Path | None:
+        """Check if the user already has a pyrefly config file."""
+        # Check for standalone pyrefly.toml
+        if (config_file := (self.env.root / "pyrefly.toml")).is_file():
+            return config_file
+
+        # Check for [tool.pyrefly] in pyproject.toml
+        pyproject = self.env.root / "pyproject.toml"
+        if pyproject.is_file():
+            from hatch.utils.toml import load_toml_data
+
+            data = load_toml_data(pyproject.read_text())
+            if "tool" in data and "pyrefly" in data["tool"]:
+                return pyproject
+
+        return None
+
+    def construct_config_file(self) -> str:
+        """Generate a minimal pyrefly.toml based on the project layout."""
+        lines: list[str] = []
+        root = str(self.env.root)
+
+        project_includes = self._detect_project_includes()
+        search_paths = self._detect_search_paths()
+        ignore_imports = self._detect_platform_conditional_deps()
+
+        # Paths must be absolute since the config file may not live in the project root
+        if project_includes:
+            abs_includes = [os.path.join(root, p) for p in project_includes]
+            includes_str = ", ".join(f'"{p}"' for p in abs_includes)
+            lines.append(f"project-includes = [{includes_str}]")
+
+        if search_paths:
+            abs_paths = [os.path.join(root, p) for p in search_paths]
+            paths_str = ", ".join(f'"{p}"' for p in abs_paths)
+            lines.append(f"search-path = [{paths_str}]")
+
+        lines.append('preset = "legacy"')
+        lines.append("disable-search-path-heuristics = true")
+
+        if ignore_imports:
+            imports_str = ", ".join(f'"{m}"' for m in ignore_imports)
+            lines.append(f"ignore-missing-imports = [{imports_str}]")
+
+        # Ensure file ends with newline
+        lines.append("")
+        return "\n".join(lines)
+
+    def write_config_file(self) -> None:
+        """Write the auto-generated config file."""
+        if self.user_config_file:
+            return
+
+        config_contents = self.construct_config_file()
+
+        if self.config_path:
+            (self.env.root / self.config_path).write_atomic(config_contents, "w", encoding="utf-8")
+            return
+
+        self.internal_config_file.parent.ensure_dir_exists()
+        self.internal_config_file.write_text(config_contents)
+
+    def _detect_project_includes(self) -> list[str]:
+        """Detect which directories contain source code to type check."""
+        includes: list[str] = []
+        root = str(self.env.root)
+
+        # Standard src layout
+        src_dir = os.path.join(root, "src")
+        if os.path.isdir(src_dir):
+            # Find the actual package directories under src/
+            for entry in os.listdir(src_dir):
+                entry_path = os.path.join(src_dir, entry)
+                if os.path.isdir(entry_path) and os.path.isfile(os.path.join(entry_path, "__init__.py")):
+                    includes.append(f"src/{entry}")
+
+        # Backend src layout (monorepo pattern)
+        backend_src = os.path.join(root, "backend", "src")
+        if os.path.isdir(backend_src):
+            for entry in os.listdir(backend_src):
+                entry_path = os.path.join(backend_src, entry)
+                if os.path.isdir(entry_path) and os.path.isfile(os.path.join(entry_path, "__init__.py")):
+                    includes.append(f"backend/src/{entry}")
+
+        # Tests directory
+        tests_dir = os.path.join(root, "tests")
+        if os.path.isdir(tests_dir) and os.path.isfile(os.path.join(tests_dir, "__init__.py")):
+            includes.append("tests")
+
+        return includes
+
+    def _detect_search_paths(self) -> list[str]:
+        """Detect import root directories for pyrefly's search-path."""
+        paths: list[str] = []
+        root = str(self.env.root)
+
+        # src/ layout means imports resolve from src/
+        if os.path.isdir(os.path.join(root, "src")):
+            paths.append("src")
+
+        # backend/src/ for monorepo patterns
+        if os.path.isdir(os.path.join(root, "backend", "src")):
+            paths.append("backend/src")
+
+        # tests/ as a package root (for relative imports within tests)
+        tests_dir = os.path.join(root, "tests")
+        if os.path.isdir(tests_dir) and os.path.isfile(os.path.join(tests_dir, "__init__.py")):
+            paths.append("tests")
+
+        return paths
+
+    def _detect_platform_conditional_deps(self) -> list[str]:
+        """Detect dependencies with platform markers that won't be installed locally."""
+        import sys
+
+        ignore: list[str] = []
+
+        try:
+            project_config = self.env.metadata.config
+        except Exception:  # noqa: BLE001
+            return ignore
+
+        dependencies = project_config.get("project", {}).get("dependencies", [])
+        if not isinstance(dependencies, list):
+            return ignore
+
+        for dep in dependencies:
+            if not isinstance(dep, str):
+                continue
+
+            # Simple heuristic: if a dependency has a platform marker that doesn't match
+            # the current platform, add its import name to ignore list
+            if "sys_platform" in dep:
+                dep_lower = dep.lower()
+                current_platform = sys.platform
+
+                # Check if the marker excludes the current platform
+                if f'sys_platform == "linux"' in dep_lower and current_platform != "linux":
+                    ignore.append(self._dep_to_import_name(dep))
+                elif f'sys_platform == "win32"' in dep_lower and current_platform != "win32":
+                    ignore.append(self._dep_to_import_name(dep))
+                elif f'sys_platform == "darwin"' in dep_lower and current_platform != "darwin":
+                    ignore.append(self._dep_to_import_name(dep))
+
+        return ignore
+
+    @staticmethod
+    def _dep_to_import_name(dep: str) -> str:
+        """Convert a dependency string to its likely import name."""
+        # Strip markers (everything after ;)
+        name = dep.split(";")[0].strip()
+        # Strip version specifiers
+        for char in (">=", "<=", "!=", "~=", "==", ">", "<", "["):
+            name = name.split(char)[0]
+        # Normalize: dashes become underscores in import names
+        return name.strip().replace("-", "_").lower()
+
+    @cached_property
+    def user_config(self) -> dict[str, Any]:
+        if self.user_config_file is None:
+            return {}
+
+        from hatch.utils.toml import load_toml_data
+
+        data = load_toml_data(self.user_config_file.read_text())
+
+        if self.user_config_file.name == "pyproject.toml":
+            return data.get("tool", {}).get("pyrefly", {})
+
+        return data

--- a/src/hatch/cli/types/core.py
+++ b/src/hatch/cli/types/core.py
@@ -46,7 +46,15 @@ class TypeCheckEnvironment:
         return None
 
     def construct_config_file(self) -> str:
-        """Generate a minimal pyrefly.toml based on the project layout."""
+        """Generate a minimal pyrefly.toml based on the project layout.
+
+        The generated config tells pyrefly:
+        - Where to find source code (project-includes)
+        - Where to resolve imports from (search-path)
+        - To use relaxed type checking rules (preset = "legacy")
+        - To not guess import roots on its own (disable-search-path-heuristics)
+        - Which platform-specific modules to ignore (ignore-missing-imports)
+        """
         lines: list[str] = []
         root = str(self.env.root)
 
@@ -54,21 +62,31 @@ class TypeCheckEnvironment:
         search_paths = self._detect_search_paths()
         ignore_imports = self._detect_platform_conditional_deps()
 
-        # Paths must be absolute since the config file may not live in the project root
+        # Paths must be absolute because the auto-generated config file is stored in an
+        # isolated data directory (not the project root), so relative paths would not resolve
+        # to the correct project directories.
         if project_includes:
             abs_includes = [os.path.join(root, p) for p in project_includes]
             includes_str = ", ".join(f'"{p}"' for p in abs_includes)
+            # project-includes tells pyrefly which directories contain source files to check
             lines.append(f"project-includes = [{includes_str}]")
 
         if search_paths:
             abs_paths = [os.path.join(root, p) for p in search_paths]
             paths_str = ", ".join(f'"{p}"' for p in abs_paths)
+            # search-path tells pyrefly where to resolve imports from (e.g., "src" for src-layout)
             lines.append(f"search-path = [{paths_str}]")
 
+        # "legacy" preset uses relaxed type checking rules suitable for existing codebases
+        # that haven't been fully annotated yet.
+        # Disable pyrefly's automatic search path detection since we explicitly configure paths
+        # above; without this, pyrefly may add duplicate or incorrect import roots.
         lines.extend(('preset = "legacy"', "disable-search-path-heuristics = true"))
 
         if ignore_imports:
             imports_str = ", ".join(f'"{m}"' for m in ignore_imports)
+            # Suppress errors for platform-conditional dependencies that aren't installed
+            # on the current OS (e.g., a Linux-only package when running on macOS)
             lines.append(f"ignore-missing-imports = [{imports_str}]")
 
         # Ensure file ends with newline
@@ -90,7 +108,14 @@ class TypeCheckEnvironment:
         self.internal_config_file.write_text(config_contents)
 
     def _detect_project_includes(self) -> list[str]:
-        """Detect which directories contain source code to type check."""
+        """Detect which directories contain source code to type check.
+
+        This is used to populate pyrefly's `project-includes` config option, which tells
+        pyrefly which directories to scan for Python files. Without this, pyrefly would
+        either check nothing (if project-includes is empty) or fall back to its own
+        heuristics which may miss source in non-standard layouts like src-layout or
+        monorepo workspace members.
+        """
         includes: list[str] = []
         root = str(self.env.root)
 

--- a/src/hatch/cli/types/core.py
+++ b/src/hatch/cli/types/core.py
@@ -65,8 +65,7 @@ class TypeCheckEnvironment:
             paths_str = ", ".join(f'"{p}"' for p in abs_paths)
             lines.append(f"search-path = [{paths_str}]")
 
-        lines.append('preset = "legacy"')
-        lines.append("disable-search-path-heuristics = true")
+        lines.extend(('preset = "legacy"', "disable-search-path-heuristics = true"))
 
         if ignore_imports:
             imports_str = ", ".join(f'"{m}"' for m in ignore_imports)
@@ -178,11 +177,11 @@ class TypeCheckEnvironment:
                 current_platform = sys.platform
 
                 # Check if the marker excludes the current platform
-                if f'sys_platform == "linux"' in dep_lower and current_platform != "linux":
-                    ignore.append(self._dep_to_import_name(dep))
-                elif f'sys_platform == "win32"' in dep_lower and current_platform != "win32":
-                    ignore.append(self._dep_to_import_name(dep))
-                elif f'sys_platform == "darwin"' in dep_lower and current_platform != "darwin":
+                if (
+                    ('sys_platform == "linux"' in dep_lower and current_platform != "linux")
+                    or ('sys_platform == "win32"' in dep_lower and current_platform != "win32")
+                    or ('sys_platform == "darwin"' in dep_lower and current_platform != "darwin")
+                ):
                     ignore.append(self._dep_to_import_name(dep))
 
         return ignore

--- a/src/hatch/cli/types/core.py
+++ b/src/hatch/cli/types/core.py
@@ -95,22 +95,23 @@ class TypeCheckEnvironment:
         includes: list[str] = []
         root = str(self.env.root)
 
-        # Standard src layout
+        # Standard src layout for the main project
         src_dir = os.path.join(root, "src")
         if os.path.isdir(src_dir):
-            # Find the actual package directories under src/
             for entry in os.listdir(src_dir):
                 entry_path = os.path.join(src_dir, entry)
                 if os.path.isdir(entry_path) and os.path.isfile(os.path.join(entry_path, "__init__.py")):
                     includes.append(f"src/{entry}")
 
-        # Backend src layout (monorepo pattern)
-        backend_src = os.path.join(root, "backend", "src")
-        if os.path.isdir(backend_src):
-            for entry in os.listdir(backend_src):
-                entry_path = os.path.join(backend_src, entry)
-                if os.path.isdir(entry_path) and os.path.isfile(os.path.join(entry_path, "__init__.py")):
-                    includes.append(f"backend/src/{entry}")
+        # Workspace members (monorepo support)
+        for member_path in self._get_workspace_member_paths():
+            relative = os.path.relpath(member_path, root)
+            member_src = os.path.join(member_path, "src")
+            if os.path.isdir(member_src):
+                for entry in os.listdir(member_src):
+                    entry_path = os.path.join(member_src, entry)
+                    if os.path.isdir(entry_path) and os.path.isfile(os.path.join(entry_path, "__init__.py")):
+                        includes.append(f"{relative}/src/{entry}")
 
         # Tests directory
         tests_dir = os.path.join(root, "tests")
@@ -128,9 +129,12 @@ class TypeCheckEnvironment:
         if os.path.isdir(os.path.join(root, "src")):
             paths.append("src")
 
-        # backend/src/ for monorepo patterns
-        if os.path.isdir(os.path.join(root, "backend", "src")):
-            paths.append("backend/src")
+        # Workspace members
+        for member_path in self._get_workspace_member_paths():
+            relative = os.path.relpath(member_path, root)
+            member_src = os.path.join(member_path, "src")
+            if os.path.isdir(member_src):
+                paths.append(f"{relative}/src")
 
         # tests/ as a package root (for relative imports within tests)
         tests_dir = os.path.join(root, "tests")
@@ -138,6 +142,15 @@ class TypeCheckEnvironment:
             paths.append("tests")
 
         return paths
+
+    def _get_workspace_member_paths(self) -> list[str]:
+        """Get filesystem paths of workspace members from the environment config."""
+        try:
+            members = self.env.workspace.members
+        except Exception:  # noqa: BLE001
+            return []
+
+        return [str(member.project.location) for member in members]
 
     def _detect_platform_conditional_deps(self) -> list[str]:
         """Detect dependencies with platform markers that won't be installed locally."""

--- a/src/hatch/env/internal/__init__.py
+++ b/src/hatch/env/internal/__init__.py
@@ -6,13 +6,14 @@ from hatch.env.utils import ensure_valid_environment
 
 
 def get_internal_env_config() -> dict[str, Any]:
-    from hatch.env.internal import build, static_analysis, test, uv
+    from hatch.env.internal import build, static_analysis, test, type_check, uv
 
     internal_config = {}
     for env_name, env_config in (
         ("hatch-build", build.get_default_config()),
         ("hatch-static-analysis", static_analysis.get_default_config()),
         ("hatch-test", test.get_default_config()),
+        ("hatch-type-check", type_check.get_default_config()),
         ("hatch-uv", uv.get_default_config()),
     ):
         env_config["template"] = env_name

--- a/src/hatch/env/internal/__init__.py
+++ b/src/hatch/env/internal/__init__.py
@@ -11,9 +11,11 @@ def get_internal_env_config() -> dict[str, Any]:
     internal_config = {}
     for env_name, env_config in (
         ("hatch-build", build.get_default_config()),
+        ("hatch-check-code", static_analysis.get_check_code_config()),
+        ("hatch-check-fmt", static_analysis.get_check_fmt_config()),
+        ("hatch-check-types", type_check.get_default_config()),
         ("hatch-static-analysis", static_analysis.get_default_config()),
         ("hatch-test", test.get_default_config()),
-        ("hatch-type-check", type_check.get_default_config()),
         ("hatch-uv", uv.get_default_config()),
     ):
         env_config["template"] = env_name

--- a/src/hatch/env/internal/static_analysis.py
+++ b/src/hatch/env/internal/static_analysis.py
@@ -9,10 +9,34 @@ def get_default_config() -> dict[str, Any]:
         "installer": "uv",
         "dependencies": [f"ruff=={RUFF_DEFAULT_VERSION}"],
         "scripts": {
-            "format-check": "ruff format{env:HATCH_FMT_ARGS:} --check --diff {args:.}",
-            "format-fix": "ruff format{env:HATCH_FMT_ARGS:} {args:.}",
-            "lint-check": "ruff check{env:HATCH_FMT_ARGS:} {args:.}",
-            "lint-fix": "ruff check{env:HATCH_FMT_ARGS:} --fix {args:.}",
+            "format-check": "ruff format{env:HATCH_FMT_ARGS:}{env:HATCH_CHECK_FMT_ARGS:} --check --diff {args:.}",
+            "format-fix": "ruff format{env:HATCH_FMT_ARGS:}{env:HATCH_CHECK_FMT_ARGS:} {args:.}",
+            "lint-check": "ruff check{env:HATCH_FMT_ARGS:}{env:HATCH_CHECK_CODE_ARGS:} {args:.}",
+            "lint-fix": "ruff check{env:HATCH_FMT_ARGS:}{env:HATCH_CHECK_CODE_ARGS:} --fix {args:.}",
+        },
+    }
+
+
+def get_check_code_config() -> dict[str, Any]:
+    return {
+        "skip-install": True,
+        "installer": "uv",
+        "dependencies": [f"ruff=={RUFF_DEFAULT_VERSION}"],
+        "scripts": {
+            "lint-check": "ruff check{env:HATCH_CHECK_CODE_ARGS:} {args:.}",
+            "lint-fix": "ruff check{env:HATCH_CHECK_CODE_ARGS:} --fix {args:.}",
+        },
+    }
+
+
+def get_check_fmt_config() -> dict[str, Any]:
+    return {
+        "skip-install": True,
+        "installer": "uv",
+        "dependencies": [f"ruff=={RUFF_DEFAULT_VERSION}"],
+        "scripts": {
+            "format-check": "ruff format{env:HATCH_CHECK_FMT_ARGS:} --check --diff {args:.}",
+            "format-fix": "ruff format{env:HATCH_CHECK_FMT_ARGS:} {args:.}",
         },
     }
 

--- a/src/hatch/env/internal/type_check.py
+++ b/src/hatch/env/internal/type_check.py
@@ -13,9 +13,9 @@ def get_default_config() -> dict[str, Any]:
         "installer": "uv",
         "dependencies": [f"pyrefly=={PYREFLY_DEFAULT_VERSION}", *test_deps],
         "scripts": {
-            "check": "pyrefly check{env:HATCH_TYPES_ARGS:} {args}",
-            "check-summarize": "pyrefly check{env:HATCH_TYPES_ARGS:} --summarize-errors {args}",
-            "coverage": "pyrefly report{env:HATCH_TYPES_ARGS:} {args}",
+            "check": "pyrefly check{env:HATCH_CHECK_TYPES_ARGS:} {args}",
+            "check-summarize": "pyrefly check{env:HATCH_CHECK_TYPES_ARGS:} --summarize-errors {args}",
+            "coverage": "pyrefly report{env:HATCH_CHECK_TYPES_ARGS:} {args}",
             "config": "pyrefly dump-config {args}",
         },
     }

--- a/src/hatch/env/internal/type_check.py
+++ b/src/hatch/env/internal/type_check.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def get_default_config() -> dict[str, Any]:
+    from hatch.env.internal.test import get_default_config as get_test_config
+
+    test_config = get_test_config()
+    test_deps = test_config.get("dependencies", [])
+
+    return {
+        "installer": "uv",
+        "dependencies": [f"pyrefly=={PYREFLY_DEFAULT_VERSION}", *test_deps],
+        "scripts": {
+            "check": "pyrefly check{env:HATCH_TYPES_ARGS:} {args}",
+            "check-summarize": "pyrefly check{env:HATCH_TYPES_ARGS:} --summarize-errors {args}",
+            "coverage": "pyrefly report{env:HATCH_TYPES_ARGS:} {args}",
+            "config": "pyrefly dump-config {args}",
+        },
+    }
+
+
+PYREFLY_DEFAULT_VERSION: str = "1.0.0"

--- a/tests/cli/check/test_check_code.py
+++ b/tests/cli/check/test_check_code.py
@@ -1,0 +1,385 @@
+from __future__ import annotations
+
+import pytest
+
+from hatch.config.constants import ConfigEnvVars
+from hatch.project.core import Project
+
+
+def construct_ruff_defaults_file(rules: tuple[str, ...]) -> str:
+    from hatch.cli.fmt.core import PER_FILE_IGNORED_RULES
+
+    lines = [
+        "line-length = 120",
+        "",
+        "[format]",
+        "docstring-code-format = true",
+        "docstring-code-line-length = 80",
+        "",
+        "[lint]",
+    ]
+
+    # Selected rules
+    lines.append("select = [")
+    lines.extend(f'  "{rule}",' for rule in sorted(rules))
+    lines.extend(("]", ""))
+
+    # Ignored rules
+    lines.append("[lint.per-file-ignores]")
+    for glob, ignored_rules in PER_FILE_IGNORED_RULES.items():
+        lines.append(f'"{glob}" = [')
+        lines.extend(f'  "{ignored_rule}",' for ignored_rule in ignored_rules)
+        lines.append("]")
+
+    # Default config
+    lines.extend((
+        "",
+        "[lint.flake8-tidy-imports]",
+        'ban-relative-imports = "all"',
+        "",
+        "[lint.isort]",
+        'known-first-party = ["my_app"]',
+        "",
+        "[lint.flake8-pytest-style]",
+        "fixture-parentheses = false",
+        "mark-parentheses = false",
+    ))
+
+    # Ensure the file ends with a newline to satisfy other linters
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+@pytest.fixture(scope="module")
+def defaults_file_stable() -> str:
+    from hatch.cli.fmt.core import STABLE_RULES
+
+    return construct_ruff_defaults_file(STABLE_RULES)
+
+
+@pytest.fixture(scope="module")
+def defaults_file_preview() -> str:
+    from hatch.cli.fmt.core import PREVIEW_RULES, STABLE_RULES
+
+    return construct_ruff_defaults_file(STABLE_RULES + PREVIEW_RULES)
+
+
+class TestDefaultCheckMode:
+    """Tests that `hatch check code` defaults to check-only (no fixes applied)."""
+
+    def test_check_only(self, hatch, temp_dir, config_file, env_run, mocker, platform, defaults_file_stable):
+        config_file.model.template.plugins["default"]["tests"] = False
+        config_file.save()
+
+        project_name = "My.App"
+
+        with temp_dir.as_cwd():
+            result = hatch("new", project_name)
+
+        assert result.exit_code == 0, result.output
+
+        project_path = temp_dir / "my-app"
+        data_path = temp_dir / "data"
+        data_path.mkdir()
+
+        config_dir = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config" / project_path.id
+        default_config = config_dir / "ruff_defaults.toml"
+        user_config = config_dir / "pyproject.toml"
+        user_config_path = platform.join_command_args([str(user_config)])
+
+        with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
+            result = hatch("check", "code")
+
+        assert result.exit_code == 0, result.output
+        assert not result.output
+
+        assert env_run.call_args_list == [
+            mocker.call(f"ruff check --config {user_config_path} .", shell=True),
+        ]
+
+        assert default_config.read_text() == defaults_file_stable
+
+    def test_fix(self, hatch, temp_dir, config_file, env_run, mocker, platform, defaults_file_stable):
+        config_file.model.template.plugins["default"]["tests"] = False
+        config_file.save()
+
+        project_name = "My.App"
+
+        with temp_dir.as_cwd():
+            result = hatch("new", project_name)
+
+        assert result.exit_code == 0, result.output
+
+        project_path = temp_dir / "my-app"
+        data_path = temp_dir / "data"
+        data_path.mkdir()
+
+        config_dir = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config" / project_path.id
+        default_config = config_dir / "ruff_defaults.toml"
+        user_config = config_dir / "pyproject.toml"
+        user_config_path = platform.join_command_args([str(user_config)])
+
+        with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
+            result = hatch("check", "code", "--fix")
+
+        assert result.exit_code == 0, result.output
+        assert not result.output
+
+        assert env_run.call_args_list == [
+            mocker.call(f"ruff check --config {user_config_path} --fix .", shell=True),
+        ]
+
+        assert default_config.read_text() == defaults_file_stable
+
+
+class TestPreview:
+    def test_preview_check(self, hatch, temp_dir, config_file, env_run, mocker, platform, defaults_file_preview):
+        config_file.model.template.plugins["default"]["tests"] = False
+        config_file.save()
+
+        project_name = "My.App"
+
+        with temp_dir.as_cwd():
+            result = hatch("new", project_name)
+
+        assert result.exit_code == 0, result.output
+
+        project_path = temp_dir / "my-app"
+        data_path = temp_dir / "data"
+        data_path.mkdir()
+
+        config_dir = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config" / project_path.id
+        default_config = config_dir / "ruff_defaults.toml"
+        user_config = config_dir / "pyproject.toml"
+        user_config_path = platform.join_command_args([str(user_config)])
+
+        with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
+            result = hatch("check", "code", "--", "--preview")
+
+        assert result.exit_code == 0, result.output
+        assert not result.output
+
+        assert env_run.call_args_list == [
+            mocker.call(f"ruff check --config {user_config_path} --preview .", shell=True),
+        ]
+
+        assert default_config.read_text() == defaults_file_preview
+
+    def test_preview_fix(self, hatch, temp_dir, config_file, env_run, mocker, platform, defaults_file_preview):
+        config_file.model.template.plugins["default"]["tests"] = False
+        config_file.save()
+
+        project_name = "My.App"
+
+        with temp_dir.as_cwd():
+            result = hatch("new", project_name)
+
+        assert result.exit_code == 0, result.output
+
+        project_path = temp_dir / "my-app"
+        data_path = temp_dir / "data"
+        data_path.mkdir()
+
+        config_dir = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config" / project_path.id
+        default_config = config_dir / "ruff_defaults.toml"
+        user_config = config_dir / "pyproject.toml"
+        user_config_path = platform.join_command_args([str(user_config)])
+
+        with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
+            result = hatch("check", "code", "--fix", "--", "--preview")
+
+        assert result.exit_code == 0, result.output
+        assert not result.output
+
+        assert env_run.call_args_list == [
+            mocker.call(f"ruff check --config {user_config_path} --preview --fix .", shell=True),
+        ]
+
+        assert default_config.read_text() == defaults_file_preview
+
+
+class TestArguments:
+    def test_forwarding(self, hatch, temp_dir, config_file, env_run, mocker, platform, defaults_file_stable):
+        config_file.model.template.plugins["default"]["tests"] = False
+        config_file.save()
+
+        project_name = "My.App"
+
+        with temp_dir.as_cwd():
+            result = hatch("new", project_name)
+
+        assert result.exit_code == 0, result.output
+
+        project_path = temp_dir / "my-app"
+        data_path = temp_dir / "data"
+        data_path.mkdir()
+
+        config_dir = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config" / project_path.id
+        default_config = config_dir / "ruff_defaults.toml"
+        user_config = config_dir / "pyproject.toml"
+        user_config_path = platform.join_command_args([str(user_config)])
+
+        with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
+            result = hatch("check", "code", "--", "--foo", "bar")
+
+        assert result.exit_code == 0, result.output
+        assert not result.output
+
+        assert env_run.call_args_list == [
+            mocker.call(f"ruff check --config {user_config_path} --foo bar", shell=True),
+        ]
+
+        assert default_config.read_text() == defaults_file_stable
+
+
+class TestConfigPath:
+    @pytest.mark.usefixtures("env_run")
+    def test_sync_without_config(self, hatch, helpers, temp_dir, config_file):
+        config_file.model.template.plugins["default"]["tests"] = False
+        config_file.save()
+
+        project_name = "My.App"
+
+        with temp_dir.as_cwd():
+            result = hatch("new", project_name)
+
+        assert result.exit_code == 0, result.output
+
+        project_path = temp_dir / "my-app"
+        data_path = temp_dir / "data"
+        data_path.mkdir()
+
+        with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
+            result = hatch("check", "code", "--sync")
+
+        assert result.exit_code == 1, result.output
+        assert result.output == helpers.dedent(
+            """
+            The --sync flag can only be used when the `tool.hatch.format.config-path` option is defined
+            """
+        )
+
+    def test_sync(self, hatch, temp_dir, config_file, env_run, mocker, defaults_file_stable):
+        config_file.model.template.plugins["default"]["tests"] = False
+        config_file.save()
+
+        project_name = "My.App"
+
+        with temp_dir.as_cwd():
+            result = hatch("new", project_name)
+
+        assert result.exit_code == 0, result.output
+
+        project_path = temp_dir / "my-app"
+        data_path = temp_dir / "data"
+        data_path.mkdir()
+        default_config_file = project_path / "ruff_defaults.toml"
+        assert not default_config_file.is_file()
+
+        project = Project(project_path)
+        config = dict(project.raw_config)
+        config["tool"]["hatch"]["envs"] = {"hatch-static-analysis": {"config-path": "ruff_defaults.toml"}}
+        config["tool"]["ruff"] = {"extend": "ruff_defaults.toml"}
+        project.save_config(config)
+
+        with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
+            result = hatch("check", "code", "--sync")
+
+        assert result.exit_code == 0, result.output
+        assert not result.output
+
+        root_data_path = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config"
+        assert not root_data_path.is_dir()
+
+        assert env_run.call_args_list == [
+            mocker.call("ruff check .", shell=True),
+        ]
+
+        assert default_config_file.read_text() == defaults_file_stable
+
+
+class TestCustomScripts:
+    def test_fix(self, hatch, temp_dir, config_file, env_run, mocker):
+        config_file.model.template.plugins["default"]["tests"] = False
+        config_file.save()
+
+        project_name = "My.App"
+
+        with temp_dir.as_cwd():
+            result = hatch("new", project_name)
+
+        assert result.exit_code == 0, result.output
+
+        project_path = temp_dir / "my-app"
+        data_path = temp_dir / "data"
+        data_path.mkdir()
+
+        project = Project(project_path)
+        config = dict(project.raw_config)
+        config["tool"]["hatch"]["envs"] = {
+            "hatch-static-analysis": {
+                "config-path": "none",
+                "dependencies": ["flake8"],
+                "scripts": {
+                    "lint-check": "flake8 {args:.}",
+                    "lint-fix": "flake8 --fix {args:.}",
+                },
+            }
+        }
+        project.save_config(config)
+
+        with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
+            result = hatch("check", "code", "--fix")
+
+        assert result.exit_code == 0, result.output
+        assert not result.output
+
+        root_data_path = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config"
+        assert not root_data_path.is_dir()
+
+        assert env_run.call_args_list == [
+            mocker.call("flake8 --fix .", shell=True),
+        ]
+
+    def test_check(self, hatch, temp_dir, config_file, env_run, mocker):
+        config_file.model.template.plugins["default"]["tests"] = False
+        config_file.save()
+
+        project_name = "My.App"
+
+        with temp_dir.as_cwd():
+            result = hatch("new", project_name)
+
+        assert result.exit_code == 0, result.output
+
+        project_path = temp_dir / "my-app"
+        data_path = temp_dir / "data"
+        data_path.mkdir()
+
+        project = Project(project_path)
+        config = dict(project.raw_config)
+        config["tool"]["hatch"]["envs"] = {
+            "hatch-static-analysis": {
+                "config-path": "none",
+                "dependencies": ["flake8"],
+                "scripts": {
+                    "lint-check": "flake8 {args:.}",
+                    "lint-fix": "flake8 --fix {args:.}",
+                },
+            }
+        }
+        project.save_config(config)
+
+        with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
+            result = hatch("check", "code")
+
+        assert result.exit_code == 0, result.output
+        assert not result.output
+
+        root_data_path = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config"
+        assert not root_data_path.is_dir()
+
+        assert env_run.call_args_list == [
+            mocker.call("flake8 .", shell=True),
+        ]

--- a/tests/cli/check/test_check_code.py
+++ b/tests/cli/check/test_check_code.py
@@ -83,7 +83,7 @@ class TestDefaultCheckMode:
         data_path = temp_dir / "data"
         data_path.mkdir()
 
-        config_dir = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config" / project_path.id
+        config_dir = data_path / "env" / ".internal" / "hatch-check-code" / ".config" / project_path.id
         default_config = config_dir / "ruff_defaults.toml"
         user_config = config_dir / "pyproject.toml"
         user_config_path = platform.join_command_args([str(user_config)])
@@ -115,7 +115,7 @@ class TestDefaultCheckMode:
         data_path = temp_dir / "data"
         data_path.mkdir()
 
-        config_dir = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config" / project_path.id
+        config_dir = data_path / "env" / ".internal" / "hatch-check-code" / ".config" / project_path.id
         default_config = config_dir / "ruff_defaults.toml"
         user_config = config_dir / "pyproject.toml"
         user_config_path = platform.join_command_args([str(user_config)])
@@ -149,7 +149,7 @@ class TestPreview:
         data_path = temp_dir / "data"
         data_path.mkdir()
 
-        config_dir = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config" / project_path.id
+        config_dir = data_path / "env" / ".internal" / "hatch-check-code" / ".config" / project_path.id
         default_config = config_dir / "ruff_defaults.toml"
         user_config = config_dir / "pyproject.toml"
         user_config_path = platform.join_command_args([str(user_config)])
@@ -181,7 +181,7 @@ class TestPreview:
         data_path = temp_dir / "data"
         data_path.mkdir()
 
-        config_dir = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config" / project_path.id
+        config_dir = data_path / "env" / ".internal" / "hatch-check-code" / ".config" / project_path.id
         default_config = config_dir / "ruff_defaults.toml"
         user_config = config_dir / "pyproject.toml"
         user_config_path = platform.join_command_args([str(user_config)])
@@ -215,7 +215,7 @@ class TestArguments:
         data_path = temp_dir / "data"
         data_path.mkdir()
 
-        config_dir = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config" / project_path.id
+        config_dir = data_path / "env" / ".internal" / "hatch-check-code" / ".config" / project_path.id
         default_config = config_dir / "ruff_defaults.toml"
         user_config = config_dir / "pyproject.toml"
         user_config_path = platform.join_command_args([str(user_config)])
@@ -279,7 +279,7 @@ class TestConfigPath:
 
         project = Project(project_path)
         config = dict(project.raw_config)
-        config["tool"]["hatch"]["envs"] = {"hatch-static-analysis": {"config-path": "ruff_defaults.toml"}}
+        config["tool"]["hatch"]["envs"] = {"hatch-check-code": {"config-path": "ruff_defaults.toml"}}
         config["tool"]["ruff"] = {"extend": "ruff_defaults.toml"}
         project.save_config(config)
 
@@ -289,7 +289,7 @@ class TestConfigPath:
         assert result.exit_code == 0, result.output
         assert not result.output
 
-        root_data_path = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config"
+        root_data_path = data_path / "env" / ".internal" / "hatch-check-code" / ".config"
         assert not root_data_path.is_dir()
 
         assert env_run.call_args_list == [
@@ -318,7 +318,7 @@ class TestCustomScripts:
         project = Project(project_path)
         config = dict(project.raw_config)
         config["tool"]["hatch"]["envs"] = {
-            "hatch-static-analysis": {
+            "hatch-check-code": {
                 "config-path": "none",
                 "dependencies": ["flake8"],
                 "scripts": {
@@ -335,7 +335,7 @@ class TestCustomScripts:
         assert result.exit_code == 0, result.output
         assert not result.output
 
-        root_data_path = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config"
+        root_data_path = data_path / "env" / ".internal" / "hatch-check-code" / ".config"
         assert not root_data_path.is_dir()
 
         assert env_run.call_args_list == [
@@ -360,7 +360,7 @@ class TestCustomScripts:
         project = Project(project_path)
         config = dict(project.raw_config)
         config["tool"]["hatch"]["envs"] = {
-            "hatch-static-analysis": {
+            "hatch-check-code": {
                 "config-path": "none",
                 "dependencies": ["flake8"],
                 "scripts": {
@@ -377,7 +377,7 @@ class TestCustomScripts:
         assert result.exit_code == 0, result.output
         assert not result.output
 
-        root_data_path = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config"
+        root_data_path = data_path / "env" / ".internal" / "hatch-check-code" / ".config"
         assert not root_data_path.is_dir()
 
         assert env_run.call_args_list == [

--- a/tests/cli/check/test_check_fmt.py
+++ b/tests/cli/check/test_check_fmt.py
@@ -83,7 +83,7 @@ class TestDefaultCheckMode:
         data_path = temp_dir / "data"
         data_path.mkdir()
 
-        config_dir = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config" / project_path.id
+        config_dir = data_path / "env" / ".internal" / "hatch-check-fmt" / ".config" / project_path.id
         default_config = config_dir / "ruff_defaults.toml"
         user_config = config_dir / "pyproject.toml"
         user_config_path = platform.join_command_args([str(user_config)])
@@ -115,7 +115,7 @@ class TestDefaultCheckMode:
         data_path = temp_dir / "data"
         data_path.mkdir()
 
-        config_dir = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config" / project_path.id
+        config_dir = data_path / "env" / ".internal" / "hatch-check-fmt" / ".config" / project_path.id
         default_config = config_dir / "ruff_defaults.toml"
         user_config = config_dir / "pyproject.toml"
         user_config_path = platform.join_command_args([str(user_config)])
@@ -149,7 +149,7 @@ class TestPreview:
         data_path = temp_dir / "data"
         data_path.mkdir()
 
-        config_dir = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config" / project_path.id
+        config_dir = data_path / "env" / ".internal" / "hatch-check-fmt" / ".config" / project_path.id
         default_config = config_dir / "ruff_defaults.toml"
         user_config = config_dir / "pyproject.toml"
         user_config_path = platform.join_command_args([str(user_config)])
@@ -181,7 +181,7 @@ class TestPreview:
         data_path = temp_dir / "data"
         data_path.mkdir()
 
-        config_dir = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config" / project_path.id
+        config_dir = data_path / "env" / ".internal" / "hatch-check-fmt" / ".config" / project_path.id
         default_config = config_dir / "ruff_defaults.toml"
         user_config = config_dir / "pyproject.toml"
         user_config_path = platform.join_command_args([str(user_config)])
@@ -215,7 +215,7 @@ class TestArguments:
         data_path = temp_dir / "data"
         data_path.mkdir()
 
-        config_dir = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config" / project_path.id
+        config_dir = data_path / "env" / ".internal" / "hatch-check-fmt" / ".config" / project_path.id
         default_config = config_dir / "ruff_defaults.toml"
         user_config = config_dir / "pyproject.toml"
         user_config_path = platform.join_command_args([str(user_config)])
@@ -279,7 +279,7 @@ class TestConfigPath:
 
         project = Project(project_path)
         config = dict(project.raw_config)
-        config["tool"]["hatch"]["envs"] = {"hatch-static-analysis": {"config-path": "ruff_defaults.toml"}}
+        config["tool"]["hatch"]["envs"] = {"hatch-check-fmt": {"config-path": "ruff_defaults.toml"}}
         config["tool"]["ruff"] = {"extend": "ruff_defaults.toml"}
         project.save_config(config)
 
@@ -289,7 +289,7 @@ class TestConfigPath:
         assert result.exit_code == 0, result.output
         assert not result.output
 
-        root_data_path = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config"
+        root_data_path = data_path / "env" / ".internal" / "hatch-check-fmt" / ".config"
         assert not root_data_path.is_dir()
 
         assert env_run.call_args_list == [

--- a/tests/cli/check/test_check_fmt.py
+++ b/tests/cli/check/test_check_fmt.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import pytest
+
+from hatch.config.constants import ConfigEnvVars
+from hatch.project.core import Project
+
+
+def construct_ruff_defaults_file(rules: tuple[str, ...]) -> str:
+    from hatch.cli.fmt.core import PER_FILE_IGNORED_RULES
+
+    lines = [
+        "line-length = 120",
+        "",
+        "[format]",
+        "docstring-code-format = true",
+        "docstring-code-line-length = 80",
+        "",
+        "[lint]",
+    ]
+
+    # Selected rules
+    lines.append("select = [")
+    lines.extend(f'  "{rule}",' for rule in sorted(rules))
+    lines.extend(("]", ""))
+
+    # Ignored rules
+    lines.append("[lint.per-file-ignores]")
+    for glob, ignored_rules in PER_FILE_IGNORED_RULES.items():
+        lines.append(f'"{glob}" = [')
+        lines.extend(f'  "{ignored_rule}",' for ignored_rule in ignored_rules)
+        lines.append("]")
+
+    # Default config
+    lines.extend((
+        "",
+        "[lint.flake8-tidy-imports]",
+        'ban-relative-imports = "all"',
+        "",
+        "[lint.isort]",
+        'known-first-party = ["my_app"]',
+        "",
+        "[lint.flake8-pytest-style]",
+        "fixture-parentheses = false",
+        "mark-parentheses = false",
+    ))
+
+    # Ensure the file ends with a newline to satisfy other linters
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+@pytest.fixture(scope="module")
+def defaults_file_stable() -> str:
+    from hatch.cli.fmt.core import STABLE_RULES
+
+    return construct_ruff_defaults_file(STABLE_RULES)
+
+
+@pytest.fixture(scope="module")
+def defaults_file_preview() -> str:
+    from hatch.cli.fmt.core import PREVIEW_RULES, STABLE_RULES
+
+    return construct_ruff_defaults_file(STABLE_RULES + PREVIEW_RULES)
+
+
+class TestDefaultCheckMode:
+    """Tests that `hatch check fmt` defaults to check-only (no fixes applied)."""
+
+    def test_check_only(self, hatch, temp_dir, config_file, env_run, mocker, platform, defaults_file_stable):
+        config_file.model.template.plugins["default"]["tests"] = False
+        config_file.save()
+
+        project_name = "My.App"
+
+        with temp_dir.as_cwd():
+            result = hatch("new", project_name)
+
+        assert result.exit_code == 0, result.output
+
+        project_path = temp_dir / "my-app"
+        data_path = temp_dir / "data"
+        data_path.mkdir()
+
+        config_dir = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config" / project_path.id
+        default_config = config_dir / "ruff_defaults.toml"
+        user_config = config_dir / "pyproject.toml"
+        user_config_path = platform.join_command_args([str(user_config)])
+
+        with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
+            result = hatch("check", "fmt")
+
+        assert result.exit_code == 0, result.output
+        assert not result.output
+
+        assert env_run.call_args_list == [
+            mocker.call(f"ruff format --config {user_config_path} --check --diff .", shell=True),
+        ]
+
+        assert default_config.read_text() == defaults_file_stable
+
+    def test_fix(self, hatch, temp_dir, config_file, env_run, mocker, platform, defaults_file_stable):
+        config_file.model.template.plugins["default"]["tests"] = False
+        config_file.save()
+
+        project_name = "My.App"
+
+        with temp_dir.as_cwd():
+            result = hatch("new", project_name)
+
+        assert result.exit_code == 0, result.output
+
+        project_path = temp_dir / "my-app"
+        data_path = temp_dir / "data"
+        data_path.mkdir()
+
+        config_dir = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config" / project_path.id
+        default_config = config_dir / "ruff_defaults.toml"
+        user_config = config_dir / "pyproject.toml"
+        user_config_path = platform.join_command_args([str(user_config)])
+
+        with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
+            result = hatch("check", "fmt", "--fix")
+
+        assert result.exit_code == 0, result.output
+        assert not result.output
+
+        assert env_run.call_args_list == [
+            mocker.call(f"ruff format --config {user_config_path} .", shell=True),
+        ]
+
+        assert default_config.read_text() == defaults_file_stable
+
+
+class TestPreview:
+    def test_preview_check(self, hatch, temp_dir, config_file, env_run, mocker, platform, defaults_file_preview):
+        config_file.model.template.plugins["default"]["tests"] = False
+        config_file.save()
+
+        project_name = "My.App"
+
+        with temp_dir.as_cwd():
+            result = hatch("new", project_name)
+
+        assert result.exit_code == 0, result.output
+
+        project_path = temp_dir / "my-app"
+        data_path = temp_dir / "data"
+        data_path.mkdir()
+
+        config_dir = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config" / project_path.id
+        default_config = config_dir / "ruff_defaults.toml"
+        user_config = config_dir / "pyproject.toml"
+        user_config_path = platform.join_command_args([str(user_config)])
+
+        with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
+            result = hatch("check", "fmt", "--", "--preview")
+
+        assert result.exit_code == 0, result.output
+        assert not result.output
+
+        assert env_run.call_args_list == [
+            mocker.call(f"ruff format --config {user_config_path} --preview --check --diff .", shell=True),
+        ]
+
+        assert default_config.read_text() == defaults_file_preview
+
+    def test_preview_fix(self, hatch, temp_dir, config_file, env_run, mocker, platform, defaults_file_preview):
+        config_file.model.template.plugins["default"]["tests"] = False
+        config_file.save()
+
+        project_name = "My.App"
+
+        with temp_dir.as_cwd():
+            result = hatch("new", project_name)
+
+        assert result.exit_code == 0, result.output
+
+        project_path = temp_dir / "my-app"
+        data_path = temp_dir / "data"
+        data_path.mkdir()
+
+        config_dir = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config" / project_path.id
+        default_config = config_dir / "ruff_defaults.toml"
+        user_config = config_dir / "pyproject.toml"
+        user_config_path = platform.join_command_args([str(user_config)])
+
+        with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
+            result = hatch("check", "fmt", "--fix", "--", "--preview")
+
+        assert result.exit_code == 0, result.output
+        assert not result.output
+
+        assert env_run.call_args_list == [
+            mocker.call(f"ruff format --config {user_config_path} --preview .", shell=True),
+        ]
+
+        assert default_config.read_text() == defaults_file_preview
+
+
+class TestArguments:
+    def test_forwarding(self, hatch, temp_dir, config_file, env_run, mocker, platform, defaults_file_stable):
+        config_file.model.template.plugins["default"]["tests"] = False
+        config_file.save()
+
+        project_name = "My.App"
+
+        with temp_dir.as_cwd():
+            result = hatch("new", project_name)
+
+        assert result.exit_code == 0, result.output
+
+        project_path = temp_dir / "my-app"
+        data_path = temp_dir / "data"
+        data_path.mkdir()
+
+        config_dir = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config" / project_path.id
+        default_config = config_dir / "ruff_defaults.toml"
+        user_config = config_dir / "pyproject.toml"
+        user_config_path = platform.join_command_args([str(user_config)])
+
+        with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
+            result = hatch("check", "fmt", "--", "--foo", "bar")
+
+        assert result.exit_code == 0, result.output
+        assert not result.output
+
+        assert env_run.call_args_list == [
+            mocker.call(f"ruff format --config {user_config_path} --check --diff --foo bar", shell=True),
+        ]
+
+        assert default_config.read_text() == defaults_file_stable
+
+
+class TestConfigPath:
+    @pytest.mark.usefixtures("env_run")
+    def test_sync_without_config(self, hatch, helpers, temp_dir, config_file):
+        config_file.model.template.plugins["default"]["tests"] = False
+        config_file.save()
+
+        project_name = "My.App"
+
+        with temp_dir.as_cwd():
+            result = hatch("new", project_name)
+
+        assert result.exit_code == 0, result.output
+
+        project_path = temp_dir / "my-app"
+        data_path = temp_dir / "data"
+        data_path.mkdir()
+
+        with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
+            result = hatch("check", "fmt", "--sync")
+
+        assert result.exit_code == 1, result.output
+        assert result.output == helpers.dedent(
+            """
+            The --sync flag can only be used when the `tool.hatch.format.config-path` option is defined
+            """
+        )
+
+    def test_sync(self, hatch, temp_dir, config_file, env_run, mocker, defaults_file_stable):
+        config_file.model.template.plugins["default"]["tests"] = False
+        config_file.save()
+
+        project_name = "My.App"
+
+        with temp_dir.as_cwd():
+            result = hatch("new", project_name)
+
+        assert result.exit_code == 0, result.output
+
+        project_path = temp_dir / "my-app"
+        data_path = temp_dir / "data"
+        data_path.mkdir()
+        default_config_file = project_path / "ruff_defaults.toml"
+        assert not default_config_file.is_file()
+
+        project = Project(project_path)
+        config = dict(project.raw_config)
+        config["tool"]["hatch"]["envs"] = {"hatch-static-analysis": {"config-path": "ruff_defaults.toml"}}
+        config["tool"]["ruff"] = {"extend": "ruff_defaults.toml"}
+        project.save_config(config)
+
+        with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
+            result = hatch("check", "fmt", "--sync")
+
+        assert result.exit_code == 0, result.output
+        assert not result.output
+
+        root_data_path = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config"
+        assert not root_data_path.is_dir()
+
+        assert env_run.call_args_list == [
+            mocker.call("ruff format --check --diff .", shell=True),
+        ]
+
+        assert default_config_file.read_text() == defaults_file_stable

--- a/tests/cli/check/test_check_group.py
+++ b/tests/cli/check/test_check_group.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from hatch.config.constants import ConfigEnvVars
+
+
+class TestNoSubcommand:
+    """Tests that `hatch check` with no subcommand runs all checks."""
+
+    def test_runs_all_checks(self, hatch, temp_dir, config_file, env_run):
+        config_file.model.template.plugins["default"]["tests"] = False
+        config_file.save()
+
+        project_name = "My.App"
+
+        with temp_dir.as_cwd():
+            result = hatch("new", project_name)
+
+        assert result.exit_code == 0, result.output
+
+        project_path = temp_dir / "my-app"
+        data_path = temp_dir / "data"
+        data_path.mkdir()
+
+        with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
+            result = hatch("check")
+
+        assert result.exit_code == 0, result.output
+
+        # Should have run lint-check, format-check, and pyrefly check
+        commands_run = [call.args[0] for call in env_run.call_args_list]
+        assert any("ruff check" in cmd and "--fix" not in cmd for cmd in commands_run)
+        assert any("ruff format" in cmd and "--check" in cmd for cmd in commands_run)
+        assert any("pyrefly check" in cmd for cmd in commands_run)
+
+    def test_runs_all_with_fix(self, hatch, temp_dir, config_file, env_run):
+        config_file.model.template.plugins["default"]["tests"] = False
+        config_file.save()
+
+        project_name = "My.App"
+
+        with temp_dir.as_cwd():
+            result = hatch("new", project_name)
+
+        assert result.exit_code == 0, result.output
+
+        project_path = temp_dir / "my-app"
+        data_path = temp_dir / "data"
+        data_path.mkdir()
+
+        with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
+            result = hatch("check", "--fix")
+
+        assert result.exit_code == 0, result.output
+
+        # Should have run lint-fix, format-fix, and pyrefly check
+        commands_run = [call.args[0] for call in env_run.call_args_list]
+        assert any("ruff check" in cmd and "--fix" in cmd for cmd in commands_run)
+        assert any("ruff format" in cmd and "--check" not in cmd for cmd in commands_run)
+        assert any("pyrefly check" in cmd for cmd in commands_run)
+
+
+class TestHelp:
+    def test_help_output(self, hatch):
+        result = hatch("check", "--help")
+
+        assert result.exit_code == 0
+        assert "code" in result.output
+        assert "fmt" in result.output
+        assert "types" in result.output

--- a/tests/cli/check/test_check_types.py
+++ b/tests/cli/check/test_check_types.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from hatch.config.constants import ConfigEnvVars
+
+
+class TestDefaults:
+    def test_check(self, hatch, temp_dir, config_file, env_run):
+        config_file.model.template.plugins["default"]["tests"] = False
+        config_file.save()
+
+        project_name = "My.App"
+
+        with temp_dir.as_cwd():
+            result = hatch("new", project_name)
+
+        assert result.exit_code == 0, result.output
+
+        project_path = temp_dir / "my-app"
+        data_path = temp_dir / "data"
+        data_path.mkdir()
+
+        with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
+            result = hatch("check", "types")
+
+        assert result.exit_code == 0, result.output
+        assert not result.output
+
+        # Pyrefly adds --config with auto-generated config path
+        assert len(env_run.call_args_list) == 1
+        command = env_run.call_args_list[0].args[0]
+        assert command.startswith("pyrefly check --config ")
+
+    def test_summarize(self, hatch, temp_dir, config_file, env_run):
+        config_file.model.template.plugins["default"]["tests"] = False
+        config_file.save()
+
+        project_name = "My.App"
+
+        with temp_dir.as_cwd():
+            result = hatch("new", project_name)
+
+        assert result.exit_code == 0, result.output
+
+        project_path = temp_dir / "my-app"
+        data_path = temp_dir / "data"
+        data_path.mkdir()
+
+        with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
+            result = hatch("check", "types", "--summarize")
+
+        assert result.exit_code == 0, result.output
+        assert not result.output
+
+        assert len(env_run.call_args_list) == 1
+        command = env_run.call_args_list[0].args[0]
+        assert command.startswith("pyrefly check --config ")
+        assert "--summarize-errors" in command
+
+    def test_cover(self, hatch, temp_dir, config_file, env_run):
+        config_file.model.template.plugins["default"]["tests"] = False
+        config_file.save()
+
+        project_name = "My.App"
+
+        with temp_dir.as_cwd():
+            result = hatch("new", project_name)
+
+        assert result.exit_code == 0, result.output
+
+        project_path = temp_dir / "my-app"
+        data_path = temp_dir / "data"
+        data_path.mkdir()
+
+        with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
+            result = hatch("check", "types", "--cover")
+
+        assert result.exit_code == 0, result.output
+        assert not result.output
+
+        assert len(env_run.call_args_list) == 1
+        command = env_run.call_args_list[0].args[0]
+        assert command.startswith("pyrefly report --config ")
+
+
+class TestArguments:
+    def test_forwarding(self, hatch, temp_dir, config_file, env_run):
+        config_file.model.template.plugins["default"]["tests"] = False
+        config_file.save()
+
+        project_name = "My.App"
+
+        with temp_dir.as_cwd():
+            result = hatch("new", project_name)
+
+        assert result.exit_code == 0, result.output
+
+        project_path = temp_dir / "my-app"
+        data_path = temp_dir / "data"
+        data_path.mkdir()
+
+        with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
+            result = hatch("check", "types", "--", "--foo", "bar")
+
+        assert result.exit_code == 0, result.output
+        assert not result.output
+
+        assert len(env_run.call_args_list) == 1
+        command = env_run.call_args_list[0].args[0]
+        assert command.startswith("pyrefly check --config ")
+        assert "--foo bar" in command

--- a/tests/cli/env/test_show.py
+++ b/tests/cli/env/test_show.py
@@ -70,6 +70,9 @@ def test_default_as_json(hatch, temp_dir, config_file):
     assert list(environments) == [
         "default",
         "hatch-build",
+        "hatch-check-code",
+        "hatch-check-fmt",
+        "hatch-check-types",
         "hatch-static-analysis",
         "hatch-test.py3.14",
         "hatch-test.py3.14t",
@@ -77,7 +80,6 @@ def test_default_as_json(hatch, temp_dir, config_file):
         "hatch-test.py3.12",
         "hatch-test.py3.11",
         "hatch-test.py3.10",
-        "hatch-type-check",
         "hatch-uv",
     ]
     assert environments["default"] == {"type": "virtual"}

--- a/tests/cli/env/test_show.py
+++ b/tests/cli/env/test_show.py
@@ -78,6 +78,7 @@ def test_default_as_json(hatch, temp_dir, config_file):
         "hatch-test.py3.11",
         "hatch-test.py3.10",
         "hatch-uv",
+        "hatch-type-check",
     ]
     assert environments["default"] == {"type": "virtual"}
 

--- a/tests/cli/env/test_show.py
+++ b/tests/cli/env/test_show.py
@@ -77,8 +77,8 @@ def test_default_as_json(hatch, temp_dir, config_file):
         "hatch-test.py3.12",
         "hatch-test.py3.11",
         "hatch-test.py3.10",
-        "hatch-uv",
         "hatch-type-check",
+        "hatch-uv",
     ]
     assert environments["default"] == {"type": "virtual"}
 

--- a/tests/cli/fmt/test_fmt.py
+++ b/tests/cli/fmt/test_fmt.py
@@ -5,6 +5,11 @@ import pytest
 from hatch.config.constants import ConfigEnvVars
 from hatch.project.core import Project
 
+FMT_DEPRECATION_WARNING = (
+    "The `hatch fmt` command is deprecated and will be removed in a future release."
+    " Use `hatch check code --fix` for linting and `hatch check fmt --fix` for formatting instead.\n"
+)
+
 
 def construct_ruff_defaults_file(rules: tuple[str, ...]) -> str:
     from hatch.cli.fmt.core import PER_FILE_IGNORED_RULES
@@ -90,7 +95,7 @@ class TestDefaults:
             result = hatch("fmt")
 
         assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
+        assert result.output == FMT_DEPRECATION_WARNING + helpers.dedent(
             f"""
             cmd [1] | ruff check --config {user_config_path} --fix .
             cmd [2] | ruff format --config {user_config_path} .
@@ -138,7 +143,7 @@ extend = "{config_path}\""""
             result = hatch("fmt", "--check")
 
         assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
+        assert result.output == FMT_DEPRECATION_WARNING + helpers.dedent(
             f"""
             cmd [1] | ruff check --config {user_config_path} .
             cmd [2] | ruff format --config {user_config_path} --check --diff .
@@ -192,7 +197,7 @@ extend = "{config_path}\""""
             result = hatch("fmt", "--check")
 
         assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
+        assert result.output == FMT_DEPRECATION_WARNING + helpers.dedent(
             f"""
             cmd [1] | ruff check --config {user_config_path} .
             cmd [2] | ruff format --config {user_config_path} --check --diff .
@@ -241,7 +246,7 @@ class TestPreview:
             result = hatch("fmt", "--preview")
 
         assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
+        assert result.output == FMT_DEPRECATION_WARNING + helpers.dedent(
             f"""
             cmd [1] | ruff check --config {user_config_path} --preview --fix .
             cmd [2] | ruff format --config {user_config_path} --preview .
@@ -289,7 +294,7 @@ extend = "{config_path}\""""
             result = hatch("fmt", "--check", "--preview")
 
         assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
+        assert result.output == FMT_DEPRECATION_WARNING + helpers.dedent(
             f"""
             cmd [1] | ruff check --config {user_config_path} --preview .
             cmd [2] | ruff format --config {user_config_path} --preview --check --diff .
@@ -334,7 +339,7 @@ class TestComponents:
             result = hatch("fmt", "--linter")
 
         assert result.exit_code == 0, result.output
-        assert not result.output
+        assert result.output == FMT_DEPRECATION_WARNING
 
         root_data_path = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config"
         config_dir = next(root_data_path.iterdir())
@@ -377,7 +382,7 @@ extend = "{config_path}\""""
             result = hatch("fmt", "--formatter")
 
         assert result.exit_code == 0, result.output
-        assert not result.output
+        assert result.output == FMT_DEPRECATION_WARNING
 
         root_data_path = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config"
         config_dir = next(root_data_path.iterdir())
@@ -421,7 +426,7 @@ extend = "{config_path}\""""
             result = hatch("fmt", "--linter", "--formatter")
 
         assert result.exit_code == 1, result.output
-        assert result.output == helpers.dedent(
+        assert result.output == FMT_DEPRECATION_WARNING + helpers.dedent(
             """
             Cannot specify both --linter and --formatter
             """
@@ -453,7 +458,7 @@ class TestArguments:
             result = hatch("fmt", "--", "--foo", "bar")
 
         assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
+        assert result.output == FMT_DEPRECATION_WARNING + helpers.dedent(
             f"""
             cmd [1] | ruff check --config {user_config_path} --fix --foo bar
             cmd [2] | ruff format --config {user_config_path} --foo bar
@@ -499,7 +504,7 @@ class TestConfigPath:
             result = hatch("fmt", "--sync")
 
         assert result.exit_code == 1, result.output
-        assert result.output == helpers.dedent(
+        assert result.output == FMT_DEPRECATION_WARNING + helpers.dedent(
             """
             The --sync flag can only be used when the `tool.hatch.format.config-path` option is defined
             """
@@ -532,7 +537,7 @@ class TestConfigPath:
             result = hatch("fmt", "--sync")
 
         assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
+        assert result.output == FMT_DEPRECATION_WARNING + helpers.dedent(
             """
             cmd [1] | ruff check --fix .
             cmd [2] | ruff format .
@@ -576,7 +581,7 @@ class TestConfigPath:
             result = hatch("fmt")
 
         assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
+        assert result.output == FMT_DEPRECATION_WARNING + helpers.dedent(
             """
             cmd [1] | ruff check --fix .
             cmd [2] | ruff format .
@@ -620,7 +625,7 @@ class TestConfigPath:
             result = hatch("fmt", "--sync")
 
         assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
+        assert result.output == FMT_DEPRECATION_WARNING + helpers.dedent(
             """
             The `tool.hatch.format.config-path` option is deprecated and will be removed in a future release. Use `tool.hatch.envs.hatch-static-analysis.config-path` instead.
             cmd [1] | ruff check --fix .
@@ -681,7 +686,7 @@ class TestCustomScripts:
             result = hatch("fmt", "--linter")
 
         assert result.exit_code == 0, result.output
-        assert not result.output
+        assert result.output == FMT_DEPRECATION_WARNING
 
         root_data_path = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config"
         assert not root_data_path.is_dir()
@@ -731,7 +736,7 @@ class TestCustomScripts:
             result = hatch("fmt", "--check", "--linter")
 
         assert result.exit_code == 0, result.output
-        assert not result.output
+        assert result.output == FMT_DEPRECATION_WARNING
 
         root_data_path = data_path / "env" / ".internal" / "hatch-static-analysis" / ".config"
         assert not root_data_path.is_dir()
@@ -781,7 +786,7 @@ class TestCustomScripts:
             result = hatch("fmt", "--formatter")
 
         assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
+        assert result.output == FMT_DEPRECATION_WARNING + helpers.dedent(
             """
             cmd [1] | isort .
             cmd [2] | black .
@@ -837,7 +842,7 @@ class TestCustomScripts:
             result = hatch("fmt", "--check", "--formatter")
 
         assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
+        assert result.output == FMT_DEPRECATION_WARNING + helpers.dedent(
             """
             cmd [1] | black --check --diff .
             cmd [2] | isort --check-only --diff .
@@ -893,7 +898,7 @@ class TestCustomScripts:
             result = hatch("fmt")
 
         assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
+        assert result.output == FMT_DEPRECATION_WARNING + helpers.dedent(
             """
             cmd [1] | flake8 .
             cmd [2] | isort .
@@ -951,7 +956,7 @@ class TestCustomScripts:
             result = hatch("fmt", "--check")
 
         assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
+        assert result.output == FMT_DEPRECATION_WARNING + helpers.dedent(
             """
             cmd [1] | flake8 .
             cmd [2] | black --check --diff .


### PR DESCRIPTION
This PR adds a new command group `hatch check` that will make for a better user experience and a sub command `hatch check types` that runs type checking with pyrefly. It enables summarize to get an error summary and report which generates to stdout json of the types coverage. This does auto generate a pyrefly config if none is present. The auto generated config is the minimal config to make pyrefly work in a hatch environment by setting up search paths correctly. 

Other sub commands are code and fmt. This moves what was under `hatch fmt` into two separate commands and redirects `hatch fmt` to call the new sub commands. There is also a deprecation warning printed for `hatch fmt` to indicate to users that we will eventually remove it in favor of the new commands

