### PR TITLE
Fix broken community highlight link

### DIFF
--- a/docs/community/highlights.md
+++ b/docs/community/highlights.md
@@ -10,4 +10,4 @@
 ## Adoption
 
 - Black - https://ichard26.github.io/blog/2022/10/black-22.10.0/#goodbye-python-36-and-hello-hatchling
-- "Switching to Hatch" - https://andrich.me/2023/08/switching-to-hatch/
+- "Switching to Hatch" - https://www.sudo.is/docs/python/#switching-project-to-hatch


### PR DESCRIPTION
## Summary

Fixes pypa/hatch#1997 by replacing the dead "Switching to Hatch" community highlight URL with the currently available page that contains the same Hatch migration section.

## Validation

- Verified the diff only updates `docs/community/highlights.md`
- Confirmed the replacement page contains the "Switching project to Hatch" section