### PR TITLE
docs: remove broken community highlight link

### DIFF
--- a/docs/community/highlights.md
+++ b/docs/community/highlights.md
@@ -10,4 +10,3 @@
 ## Adoption
 
 - Black - https://ichard26.github.io/blog/2022/10/black-22.10.0/#goodbye-python-36-and-hello-hatchling
-- "Switching to Hatch" - https://andrich.me/2023/08/switching-to-hatch/


### PR DESCRIPTION
## Problem

The community highlights page includes a `Switching to Hatch` adoption link that now returns 404. Readers who click it leave the Hatch docs and land on a missing page.

## Root Cause

The linked article at `https://andrich.me/2023/08/switching-to-hatch/` appears to have been removed or moved. I checked for a stable replacement and did not find one that clearly preserves the original article.

## What Changed

- Removed the dead `Switching to Hatch` entry from `docs/community/highlights.md`.
- Left the working Black adoption highlight intact.

## Why This Approach

Removing the dead entry is safer than replacing it with a different article that may not be the same source. It fixes the broken-link report without changing the meaning of the remaining highlights.

## Validation

- `git diff --check`
- HEAD request to `https://andrich.me/2023/08/switching-to-hatch/` returns 404

## Risk

Low. Documentation-only link cleanup. The only user-visible change is removing a link that no longer resolves.

Closes #1997
