### PR TITLE
docs: restore Switching to Hatch link via Wayback Machine

### DIFF
--- a/docs/community/highlights.md
+++ b/docs/community/highlights.md
@@ -10,4 +10,4 @@
 ## Adoption
 
 - Black - https://ichard26.github.io/blog/2022/10/black-22.10.0/#goodbye-python-36-and-hello-hatchling
-- "Switching to Hatch" - https://andrich.me/2023/08/switching-to-hatch/
+- "Switching to Hatch" - https://web.archive.org/web/20241120230301/https://andrich.me/2023/08/switching-to-hatch/


### PR DESCRIPTION
## Summary

The `Switching to Hatch` highlight in `docs/community/highlights.md` points at `https://andrich.me/2023/08/switching-to-hatch/`. That URL now 301-redirects to `https://someonewho.codes/2023/08/switching-to-hatch/` (the author's new domain), but the post isn't reachable on the new domain — the redirect chain ends in a 404. As @brewbodyradiation noted on #1997, searching the new site doesn't surface the article either.

The Internet Archive has a clean 2024-11-20 snapshot of the original post, so this PR swaps the dead link for the Wayback URL. The highlight stays useful, and we avoid the kind of slow-rot that would force another round of triage if/when someonewho.codes goes away too.

Closes #1997.

## Verification

- `curl -sI https://andrich.me/2023/08/switching-to-hatch/` → 301 to `https://someonewho.codes/...` → 404.
- `curl -sI https://web.archive.org/web/20241120230301/https://andrich.me/2023/08/switching-to-hatch/` → 200, the original article renders.

## AI disclosure

This PR was drafted with help from Claude Code (Anthropic), per the CONTRIBUTING `AI Contributions` policy. The change was reviewed and verified by me before submission — I confirmed the broken redirect chain and the Wayback snapshot manually with curl.
