### PR TITLE
Document script system package access

### DIFF
--- a/docs/how-to/run/python-scripts.md
+++ b/docs/how-to/run/python-scripts.md
@@ -66,3 +66,13 @@ You may use the `[tool.hatch]` table directly to control the script's [environme
 # installer = "pip"
 # ///
 ```
+
+The same table accepts options for Hatch's [virtual environment plugin](../../plugins/environment/virtual.md). For example, set `system-packages` to allow the script environment to access packages from the parent Python's `site-packages` directory:
+
+```python tab="script.py"
+# /// script
+# ...
+# [tool.hatch]
+# system-packages = true
+# ///
+```

--- a/tests/cli/run/test_run.py
+++ b/tests/cli/run/test_run.py
@@ -2499,6 +2499,43 @@ class TestScriptRunner:
         assert data_path in executable.parents
         assert unit_conversion == "(1.0, 'KiB')"
 
+    def test_system_packages_from_tool_config(self, hatch, helpers, temp_dir):
+        data_path = temp_dir / "data"
+        data_path.mkdir()
+        script = (temp_dir / "script.py").resolve()
+        script.write_text(
+            helpers.dedent(
+                """
+                # /// script
+                # dependencies = []
+                #
+                # [tool.hatch]
+                # installer = "pip"
+                # system-packages = true
+                # ///
+                import pathlib
+
+                import pytest
+
+                pathlib.Path('test.txt').write_text(pytest.__version__)
+                """
+            )
+        )
+
+        with temp_dir.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
+            result = hatch("run", "script.py")
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            f"""
+            Creating environment: {script.id}
+            Checking dependencies
+            """
+        )
+        output_file = temp_dir / "test.txt"
+        assert output_file.is_file()
+        assert output_file.read_text()
+
     def test_unsupported_python_version(self, hatch, helpers, temp_dir):
         data_path = temp_dir / "data"
         data_path.mkdir()


### PR DESCRIPTION
﻿## Summary
- document that PEP 723 inline scripts can use `[tool.hatch] system-packages = true`
- add a regression test showing a script environment can import a package from the parent Python environment when system packages are enabled

Fixes #1963.

## Tests
- `PYTHONPATH=src;backend/src .\.venv\Scripts\python.exe -m pytest tests\cli\run\test_run.py::TestScriptRunner::test_system_packages_from_tool_config -q`
- `.\.venv\Scripts\python.exe -m ruff check docs/how-to/run/python-scripts.md tests/cli/run/test_run.py`
- `.\.venv\Scripts\python.exe -m ruff format --check docs/how-to/run/python-scripts.md tests/cli/run/test_run.py`