### PR TITLE
Allow env show JSON with missing plugins

### DIFF
--- a/src/hatch/cli/env/show.py
+++ b/src/hatch/cli/env/show.py
@@ -35,8 +35,12 @@ def show(
         contextual_config = {}
         for environments in (app.project.config.envs, app.project.config.internal_envs):
             for env_name, config in environments.items():
-                environment = app.project.get_environment(env_name)
                 new_config = contextual_config[env_name] = dict(config)
+                environment_class = app.project.plugin_manager.environment.get(config["type"])
+                if environment_class is None:
+                    continue
+
+                environment = app.project.get_environment(env_name)
 
                 env_vars = dict(environment.env_vars)
                 env_vars.pop(AppEnvVars.ENV_ACTIVE)

--- a/tests/cli/env/test_show.py
+++ b/tests/cli/env/test_show.py
@@ -85,6 +85,33 @@ def test_default_as_json(hatch, temp_dir, config_file):
     assert environments["default"] == {"type": "virtual"}
 
 
+def test_default_as_json_unknown_type(hatch, helpers, temp_dir, config_file):
+    config_file.model.template.plugins["default"]["tests"] = False
+    config_file.save()
+
+    project_name = "My.App"
+
+    with temp_dir.as_cwd():
+        result = hatch("new", project_name)
+
+    assert result.exit_code == 0, result.output
+
+    project_path = temp_dir / "my-app"
+    data_path = temp_dir / "data"
+    data_path.mkdir()
+
+    project = Project(project_path)
+    helpers.update_project_environment(project, "default", {"type": "container"})
+
+    with project_path.as_cwd():
+        result = hatch("env", "show", "--json")
+
+    assert result.exit_code == 0, result.output
+
+    environments = json.loads(result.output)
+    assert environments["default"] == {"type": "container"}
+
+
 def test_single_only(hatch, helpers, temp_dir, config_file):
     config_file.model.template.plugins["default"]["tests"] = False
     config_file.save()


### PR DESCRIPTION
Closes #2011

## Summary
- keep `hatch env show --json` usable when an environment type comes from a missing plugin
- preserve the raw environment config in the JSON output for unknown environment types
- add a regression test for JSON output with an unknown environment type

## Tests
- `python -m pytest tests/cli/env/test_show.py -q`
- `python -m pytest tests/cli/env/test_show.py::test_default_as_json_unknown_type tests/cli/env/test_show.py::test_default_as_json -q`