### PR TITLE
chore(ci): set permissions on cli workflow

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -16,6 +16,9 @@ env:
   STABLE_PYTHON_VERSION: '3.12'
   HYPERFINE_VERSION: '1.18.0'
 
+permissions:
+  contents: read
+
 jobs:
   response-time:
     name: CLI responsiveness with latest Python


### PR DESCRIPTION
Adds an explicit least-privilege `permissions:` block to `.github/workflows/cli.yml`. The job only reads the repository, so `contents: read` is sufficient; today the workflow inherits whatever the repository default grants, which is broader than it needs. This is one of the checks OpenSSF Scorecard flags under [Token-Permissions](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions).