### PR TITLE
fix: use TemporaryDirectory + pylock*.toml for temp lock files

### DIFF
--- a/src/hatch/env/lockers/pip.py
+++ b/src/hatch/env/lockers/pip.py
@@ -77,10 +77,8 @@ class PipLocker(LockerInterface):
         if layered or lock_extras or lock_groups:
             return False
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False, encoding="utf-8") as f:
-            temp_path = Path(f.name)
-
-        try:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            temp_path = Path(tmp_dir) / "pylock.toml"
             cls.generate(
                 environment,
                 dependencies,
@@ -93,8 +91,6 @@ class PipLocker(LockerInterface):
             )
             existing = output_path.read_text(encoding="utf-8")
             fresh = temp_path.read_text(encoding="utf-8")
-        finally:
-            temp_path.unlink(missing_ok=True)
 
         return existing == fresh
 

--- a/src/hatch/env/lockers/uv.py
+++ b/src/hatch/env/lockers/uv.py
@@ -125,10 +125,8 @@ class UvLocker(LockerInterface):
         if not output_path.is_file():
             return False
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False, encoding="utf-8") as f:
-            temp_path = Path(f.name)
-
-        try:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            temp_path = Path(tmp_dir) / "pylock.toml"
             cls.generate(
                 environment,
                 dependencies,
@@ -141,8 +139,6 @@ class UvLocker(LockerInterface):
             )
             existing = output_path.read_text(encoding="utf-8")
             fresh = temp_path.read_text(encoding="utf-8")
-        finally:
-            temp_path.unlink(missing_ok=True)
 
         return existing == fresh
 


### PR DESCRIPTION
This enables later uv versions.

Fixes #2302 