### PR TITLE
Add `[tool.hatch.requires-hatch]` to enforce runtime constraints on Hatch version

### DIFF
--- a/docs/how-to/config/constrain-hatch.md
+++ b/docs/how-to/config/constrain-hatch.md
@@ -1,0 +1,19 @@
+# How to configure constraints on the runtime version of Hatch
+
+-----
+
+You can specify constraints on the runtime version of Hatch by providing a value for `tool.hatch.requires-hatch`. 
+If the version of Hatch does not satisfy the given contraints, and Hatch is called with a command that reads the project's metadata, it will exit with an error.
+
+```toml tab="pyproject.toml"
+[tool.hatch]
+requires-hatch = ">=1.18.0"
+```
+
+This is useful if your project relies on features that are only supported by specific versions of Hatch.
+
+The value of the field must be a string, a valid [PEP 440](https://peps.python.org/pep-0440/#version-specifiers) version specifier set that specifies the allowed Hatch version(s).
+The field is optional.
+
+!!! note
+    This field was introduced in version 1.18.0. Earlier versions of Hatch thus ignore the field, so `requires-hatch` cannot be used to reject these versions of Hatch.

--- a/docs/how-to/config/constrain-hatch.md
+++ b/docs/how-to/config/constrain-hatch.md
@@ -12,7 +12,7 @@ requires-hatch = ">=1.18.0"
 
 This is useful if your project relies on features that are only supported by specific versions of Hatch.
 
-The value of the field must be a string, a valid [PEP 440](https://peps.python.org/pep-0440/#version-specifiers) version specifier set that specifies the allowed Hatch version(s).
+The value of the field must be a string containing a valid [PEP 440](https://peps.python.org/pep-0440/#version-specifiers) version specifier set.
 The field is optional.
 
 !!! note

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,6 +130,7 @@ nav:
       - Python scripts: how-to/run/python-scripts.md
     - Config:
       - Dynamic metadata: how-to/config/dynamic-metadata.md
+      - Constrain Hatch version: how-to/config/constrain-hatch.md
     - Environments:
       - Select installer: how-to/environment/select-installer.md
       - Dependency resolution: how-to/environment/dependency-resolution.md

--- a/src/hatch/project/config.py
+++ b/src/hatch/project/config.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from functools import cached_property
 from itertools import product
 from os import environ
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from hatch.env.utils import ensure_valid_environment
 from hatch.project.constants import DEFAULT_BUILD_DIRECTORY, BuildEnvVars
@@ -13,6 +13,8 @@ from hatch.project.env import apply_overrides
 from hatch.project.utils import format_script_commands, parse_script_command
 
 if TYPE_CHECKING:
+    from packaging.specifiers import SpecifierSet
+
     from hatch.dep.core import Dependency
 
 
@@ -33,6 +35,8 @@ class ProjectConfig:
         self._matrix_variables = None
         self._publish = None
         self._scripts = None
+        self._requires_hatch: str | None = None
+        self._hatch_specifier_set: SpecifierSet | None = None
         self._cached_env_overrides = {}
 
     @cached_property
@@ -518,6 +522,36 @@ class ProjectConfig:
             self._scripts = config
 
         return self._scripts
+
+    @property
+    def requires_hatch(self) -> str:
+        if self._requires_hatch is None:
+            from packaging.specifiers import InvalidSpecifier, SpecifierSet
+
+            requires_hatch = self.config.get("requires-hatch", "")
+
+            if not isinstance(requires_hatch, str):
+                message = "Field `tool.hatch.requires-hatch` must be a string"
+                raise TypeError(message)
+
+            try:
+                self._hatch_specifier_set = SpecifierSet(requires_hatch)
+            except InvalidSpecifier as e:
+                message = f"Field `tool.hatch.requires-hatch` is invalid: {e}"
+                raise ValueError(message) from None
+
+            self._requires_hatch = str(self._hatch_specifier_set)
+
+        return self._requires_hatch
+
+    @property
+    def hatch_specifier_set(self) -> SpecifierSet:
+        from packaging.specifiers import SpecifierSet
+
+        if self._hatch_specifier_set is None:
+            _ = self.requires_hatch
+
+        return cast(SpecifierSet, self._hatch_specifier_set)
 
     def finalize_env_overrides(self, option_types):
         # We lazily apply overrides because we need type information potentially defined by

--- a/src/hatch/project/core.py
+++ b/src/hatch/project/core.py
@@ -398,12 +398,23 @@ class Project:
         # Used for creating new projects
         return re.sub(r"[-_. ]+", "-", name).lower()
 
+    def _check_hatch_version(self) -> None:
+        specifier_set = self.config.hatch_specifier_set
+        if not specifier_set:
+            return
+
+        from hatch._version import __version__
+
+        if not specifier_set.contains(__version__, prereleases=True):
+            self.app.abort(f"Hatch {specifier_set} is required but {__version__} is installed")
+
     @property
     def metadata(self):
         if self._metadata is None:
             from hatchling.metadata.core import ProjectMetadata
 
             self._metadata = ProjectMetadata(self.location, self.plugin_manager, self.raw_config)
+            self._check_hatch_version()
 
         return self._metadata
 

--- a/tests/cli/env/test_create.py
+++ b/tests/cli/env/test_create.py
@@ -2152,7 +2152,7 @@ def test_requires_hatch_satisfied(hatch, helpers, temp_dir, config_file):
     assert env_data_path.is_dir()
 
 
-def test_requires_hatch_not_satisfied(hatch, helpers, temp_dir, config_file):
+def test_requires_hatch_not_satisfied(hatch, temp_dir, config_file):
     config_file.model.template.plugins["default"]["tests"] = False
     config_file.save()
 

--- a/tests/cli/env/test_create.py
+++ b/tests/cli/env/test_create.py
@@ -2113,3 +2113,67 @@ def test_workspace_members_always_editable_with_dev_mode_false(
         # Workspace members MUST be editable (always)
         assert member_a_req.lower().startswith("-e"), f"Member A should be editable: {member_a_req}"
         assert member_b_req.lower().startswith("-e"), f"Member B should be editable: {member_b_req}"
+
+
+@pytest.mark.requires_internet
+def test_requires_hatch_satisfied(hatch, helpers, temp_dir, config_file):
+    config_file.model.template.plugins["default"]["tests"] = False
+    config_file.save()
+
+    project_name = "My.App"
+
+    with temp_dir.as_cwd():
+        result = hatch("new", project_name)
+
+    assert result.exit_code == 0, result.output
+
+    project_path = temp_dir / "my-app"
+    data_path = temp_dir / "data"
+    data_path.mkdir()
+
+    project = Project(project_path)
+    config = dict(project.raw_config)
+    config["tool"]["hatch"]["requires-hatch"] = ">=0"
+    project.save_config(config)
+
+    with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
+        result = hatch("env", "create")
+
+    assert result.exit_code == 0, result.output
+    assert result.output == helpers.dedent(
+        """
+        Creating environment: default
+        Installing project in development mode
+        Checking dependencies
+        """
+    )
+
+    env_data_path = data_path / "env" / "virtual"
+    assert env_data_path.is_dir()
+
+
+def test_requires_hatch_not_satisfied(hatch, helpers, temp_dir, config_file):
+    config_file.model.template.plugins["default"]["tests"] = False
+    config_file.save()
+
+    project_name = "My.App"
+
+    with temp_dir.as_cwd():
+        result = hatch("new", project_name)
+
+    assert result.exit_code == 0, result.output
+
+    project_path = temp_dir / "my-app"
+    data_path = temp_dir / "data"
+    data_path.mkdir()
+
+    project = Project(project_path)
+    config = dict(project.raw_config)
+    config["tool"]["hatch"]["requires-hatch"] = ">999"
+    project.save_config(config)
+
+    with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
+        result = hatch("env", "create")
+
+    assert result.exit_code == 1, result.output
+    assert ">999" in result.output

--- a/tests/project/test_config.py
+++ b/tests/project/test_config.py
@@ -3039,3 +3039,32 @@ class TestBuild:
             "hook5": {"bar": "foo"},
             "hook6": {"bar": "foo", "enable-by-default": False},
         }
+
+
+class TestRequiresHatch:
+    @pytest.mark.parametrize("attribute", ["requires_hatch", "hatch_specifier_set"])
+    def test_not_string(self, isolation, attribute):
+        project_config = ProjectConfig(isolation, {"requires-hatch": 1.18}, None)
+
+        with pytest.raises(TypeError, match="Field `tool.hatch.requires-hatch` must be a string"):
+            _ = getattr(project_config, attribute)
+
+    def test_invalid(self, isolation):
+        project_config = ProjectConfig(isolation, {"requires-hatch": "^1"}, None)
+
+        with pytest.raises(ValueError, match="Field `tool.hatch.requires-hatch` is invalid: .+"):
+            _ = project_config.requires_hatch
+
+    def test_default(self, isolation):
+        project_config = ProjectConfig(isolation, {}, None)
+
+        assert project_config.requires_hatch == ""
+        for major_version in map(str, range(10)):
+            assert project_config.hatch_specifier_set.contains(major_version)
+
+    def test_custom(self, isolation):
+        project_config = ProjectConfig(isolation, {"requires-hatch": ">1"}, None)
+
+        assert project_config.requires_hatch == ">1"
+        assert not project_config.hatch_specifier_set.contains("1")
+        assert project_config.hatch_specifier_set.contains("2")

--- a/tests/project/test_core.py
+++ b/tests/project/test_core.py
@@ -183,3 +183,62 @@ class TestEnsureCWD:
 
         with temp_dir.as_cwd(), project.ensure_cwd() as cwd:
             assert cwd == subdir
+
+
+class TestCheckHatchVersion:
+    @staticmethod
+    def _setup_project(temp_dir, *, requires_hatch=None):
+        project_file = temp_dir / "pyproject.toml"
+        project_file.touch()
+        project = Project(temp_dir)
+        project.find_project_root()
+
+        hatch_config = {} if requires_hatch is None else {"requires-hatch": requires_hatch}
+        project.save_config({
+            "project": {"name": "foo", "version": "0.0.1"},
+            "tool": {"hatch": hatch_config},
+        })
+        return project
+
+    def test_satisfied(self, temp_dir, mocker):
+        project = self._setup_project(temp_dir, requires_hatch=">=1")
+        app = mocker.MagicMock()
+        project.set_app(app)
+        mocker.patch("hatch._version.__version__", "1.18.0")
+
+        _ = project.metadata
+
+        app.abort.assert_not_called()
+
+    def test_unsatisfied(self, temp_dir, mocker):
+        project = self._setup_project(temp_dir, requires_hatch=">99")
+        app = mocker.MagicMock()
+        project.set_app(app)
+        mocker.patch("hatch._version.__version__", "1.18.0")
+
+        _ = project.metadata
+
+        app.abort.assert_called_once()
+        message = app.abort.call_args[0][0]
+        assert ">99" in message
+        assert "1.18.0" in message
+
+    def test_default_no_constraint(self, temp_dir, mocker):
+        project = self._setup_project(temp_dir)
+        app = mocker.MagicMock()
+        project.set_app(app)
+        mocker.patch("hatch._version.__version__", "1.18.0")
+
+        _ = project.metadata
+
+        app.abort.assert_not_called()
+
+    def test_prerelease_current_version_allowed(self, temp_dir, mocker):
+        project = self._setup_project(temp_dir, requires_hatch=">=1")
+        app = mocker.MagicMock()
+        project.set_app(app)
+        mocker.patch("hatch._version.__version__", "2.0.0rc1")
+
+        _ = project.metadata
+
+        app.abort.assert_not_called()


### PR DESCRIPTION
To close https://github.com/pypa/hatch/issues/2156

I would appreciate input on:
- Where to put the `Project._check_hatch_version` check. It is currently in `Project.metadata`.
- Where to put the documentation. I made a new page because I wasn't sure where to put it, but I assume this is not the best solution!