### PR TITLE
Keep build backend output off metadata stdout

### DIFF
--- a/docs/history/hatch.md
+++ b/docs/history/hatch.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Fixed:***
+
+- Prevent output from non-Hatchling build backends from polluting stdout when reading project metadata.
+
 ## [1.17.0](https://github.com/pypa/hatch/releases/tag/hatch-v1.17.0) - 2026-05-31 ## {: #hatch-v1.17.0 }
 
 ***Changed:***

--- a/src/hatch/project/frontend/scripts/standard.py
+++ b/src/hatch/project/frontend/scripts/standard.py
@@ -49,6 +49,7 @@ def main() -> int:
             [sys.executable, script_path, hook, str(control_dir)],
             cwd=project_root,
             env=env_vars,
+            stdout=sys.stderr,
             check=False,
         )
         if process.returncode:

--- a/tests/project/test_frontend.py
+++ b/tests/project/test_frontend.py
@@ -94,6 +94,64 @@ description = "text"
             "description": "text",
         }
 
+    def test_backend_stdout_is_forwarded_to_stderr(self, temp_dir, temp_dir_data, platform, global_application):
+        project_dir = temp_dir / "project"
+        project_dir.mkdir()
+        (project_dir / "pyproject.toml").write_text(
+            """\
+[build-system]
+requires = []
+build-backend = "noisy_backend"
+backend-path = ["."]
+
+[project]
+name = "foo"
+version = "9000.42"
+"""
+        )
+        (project_dir / "noisy_backend.py").write_text(
+            """\
+import os
+import sys
+
+
+def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
+    print("backend stdout")
+    print("backend stderr", file=sys.stderr)
+    dist_info = os.path.join(metadata_directory, "foo-9000.42.dist-info")
+    os.mkdir(dist_info)
+    with open(os.path.join(dist_info, "METADATA"), "w", encoding="utf-8") as f:
+        f.write("Metadata-Version: 2.4\\nName: foo\\nVersion: 9000.42\\n")
+    return "foo-9000.42.dist-info"
+"""
+        )
+
+        project = Project(project_dir)
+        project.build_env = MockEnvironment(
+            temp_dir,
+            project.metadata,
+            "default",
+            project.config.envs["default"],
+            {},
+            temp_dir_data,
+            temp_dir_data,
+            platform,
+            0,
+            global_application,
+        )
+
+        output_dir = temp_dir / "output"
+        output_dir.mkdir()
+        script = project.build_frontend.scripts.prepare_metadata(
+            output_dir=str(output_dir), project_root=str(project_dir)
+        )
+        process = platform.run_command([sys.executable, "-c", script], capture_output=True, text=True)
+
+        assert process.returncode == 0
+        assert process.stdout == ""
+        assert "backend stdout" in process.stderr
+        assert "backend stderr" in process.stderr
+
     @pytest.mark.parametrize(
         ("backend_pkg", "backend_api"),
         [pytest.param(backend_pkg, backend_api, id=backend_pkg) for backend_pkg, backend_api in BACKENDS],


### PR DESCRIPTION
Fixes #2069.

When Hatch reads metadata through a non-Hatchling build backend, the PEP 517 hook runs in a child process. Some backends, notably setuptools/setuptools-scm, print build progress such as `running egg_info` to stdout while preparing metadata. That output was forwarded directly to Hatch's stdout before Hatch printed the requested version/metadata, which makes commands like `hatch version` hard to use from scripts.

This redirects backend stdout to stderr for the standard frontend runner. Hatch still preserves backend diagnostics, but stdout remains reserved for Hatch's actual command result.

I verified this with a setuptools-scm sample project: after this change, `hatch version` stdout is only `1.2.3`, while `running egg_info` remains visible on stderr.

Tests run:

- `python -m ruff check src/hatch/project/frontend/scripts/standard.py tests/project/test_frontend.py`
- `python -m ruff format --check src/hatch/project/frontend/scripts/standard.py tests/project/test_frontend.py`
- `python -m pytest tests/project/test_frontend.py tests/cli/version/test_version.py::test_other_backend_show tests/cli/project/test_metadata.py::test_other_backend -q`
- `python scripts/validate_history.py`
- `git diff --check`