### PR TITLE
Fix metadata hook extra dependencies

### DIFF
--- a/docs/history/hatch.md
+++ b/docs/history/hatch.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Fixed:***
+
+- Fix self-referencing extras being skipped when static optional dependencies are used with metadata hooks
+
 ## [1.17.0](https://github.com/pypa/hatch/releases/tag/hatch-v1.17.0) - 2026-05-31 ## {: #hatch-v1.17.0 }
 
 ***Changed:***

--- a/src/hatch/env/plugin/interface.py
+++ b/src/hatch/env/plugin/interface.py
@@ -422,9 +422,22 @@ class EnvironmentInterface(ABC):
             dep_obj = dep if isinstance(dep, Dependency) else Dependency(str(dep))
 
             if dep_obj.name.lower() in workspace_names and dep_obj.extras:
-                # Only expand if we have static optional dependencies to avoid recursion
                 if not self.metadata.hatch.metadata.hook_config:
                     optional_dependencies = self.metadata.core.optional_dependencies
+                elif self.app.project.has_static_dependencies:
+                    from hatchling.metadata.core import CoreMetadata
+
+                    static_metadata = CoreMetadata(
+                        self.metadata.root,
+                        self.metadata.core_raw_metadata,
+                        self.metadata.hatch.metadata,
+                        self.metadata.context,
+                    )
+                    optional_dependencies = static_metadata.optional_dependencies
+                else:
+                    optional_dependencies = {}
+
+                if optional_dependencies:
                     for extra in dep_obj.extras:
                         if extra in optional_dependencies:
                             filtered_deps.extend(Dependency(d) for d in optional_dependencies[extra])

--- a/tests/env/plugin/test_interface.py
+++ b/tests/env/plugin/test_interface.py
@@ -1541,6 +1541,59 @@ feature3 = ["pkg-feature-3{i}"]
         # Should have my-app[test] which will cause pip to install pytest
         assert any("pytest" in dep.lower() for dep in all_deps_str)
 
+    def test_self_referencing_dependency_with_extras_and_metadata_hook(
+        self, temp_dir, isolated_data_dir, platform, global_application
+    ):
+        project_dir = temp_dir / "my-app"
+        project_dir.mkdir()
+
+        config = {
+            "project": {
+                "name": "my-app",
+                "version": "0.0.1",
+                "dependencies": [],
+                "optional-dependencies": {
+                    "test": ["pytest>=7.0"],
+                },
+            },
+            "tool": {
+                "hatch": {
+                    "metadata": {
+                        "hooks": {
+                            "docstring-description": {},
+                        },
+                    },
+                    "envs": {
+                        "dev": {
+                            "skip-install": False,
+                            "dependencies": ["my-app[test]"],
+                        }
+                    },
+                }
+            },
+        }
+
+        project = Project(project_dir, config=config)
+        global_application.project = project
+
+        environment = MockEnvironment(
+            project_dir,
+            project.metadata,
+            "dev",
+            project.config.envs["dev"],
+            {},
+            isolated_data_dir,
+            isolated_data_dir,
+            platform,
+            0,
+            global_application,
+        )
+
+        all_deps_str = [str(d) for d in environment.all_dependencies_complex]
+
+        assert any("my-app" in dep and "file://" in dep for dep in all_deps_str)
+        assert any("pytest" in dep.lower() for dep in all_deps_str)
+
     def test_dev_mode_true_returns_editable(self, temp_dir, isolated_data_dir, platform, temp_application):
         """Verify dev-mode=true creates editable local dependency."""
         # Create a pyproject.toml file so skip_install defaults to False


### PR DESCRIPTION
Fixes #2252.

## Summary

- Expands self-referencing extras when dependency metadata is static, even if a metadata hook is configured.
- Keeps the dynamic-metadata guard: if dependencies or optional dependencies are dynamic, Hatch still avoids loading metadata hooks while resolving the local self-reference.
- Adds regression coverage for the metadata-hook + static optional-dependencies case.

## Verification

- `python -m pytest tests/env/plugin/test_interface.py::TestDependencies::test_self_referencing_dependency_with_extras_and_metadata_hook tests/env/plugin/test_interface.py::TestDependencies::test_self_referencing_dependency_with_extras -q`
- `python -m pytest tests/env/plugin/test_interface.py -q`
- `python -m ruff check src/hatch/env/plugin/interface.py tests/env/plugin/test_interface.py docs/history/hatch.md`
- `python -m ruff format --check src/hatch/env/plugin/interface.py tests/env/plugin/test_interface.py`
- `python scripts/validate_history.py`
- `git diff --check`

## AI assistance

OpenAI Codex was used to investigate, implement, test, and draft this PR. The description was shortened after maintainer feedback to keep only the behavior change and verification.