### PR TITLE
Fix Unix launcher paths with spaces

### DIFF
--- a/release/unix/make_scripts_portable.py
+++ b/release/unix/make_scripts_portable.py
@@ -10,7 +10,7 @@ def main():
     interpreter = Path(sys.executable).resolve()
 
     # https://github.com/indygreg/python-build-standalone/blob/20240415/cpython-unix/build-cpython.sh#L812-L813
-    portable_shebang = b'#!/bin/sh\n"exec" "$(dirname $0)/%s" "$0" "$@"\n' % interpreter.name.encode()
+    portable_shebang = b'#!/bin/sh\n"exec" "$(dirname "$0")/%s" "$0" "$@"\n' % interpreter.name.encode()
 
     scripts_dir = Path(sysconfig.get_path("scripts"))
     for script in scripts_dir.iterdir():

--- a/tests/release/__init__.py
+++ b/tests/release/__init__.py
@@ -1,0 +1,1 @@
+"""Release helper tests."""

--- a/tests/release/test_unix_make_scripts_portable.py
+++ b/tests/release/test_unix_make_scripts_portable.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).parents[2] / "release" / "unix" / "make_scripts_portable.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("unix_make_scripts_portable", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_portable_shebang_quotes_script_path(temp_dir, monkeypatch):
+    scripts_dir = temp_dir / "Application Support" / "pyapp" / "hatch" / "python" / "bin"
+    scripts_dir.mkdir(parents=True)
+    interpreter = scripts_dir / "python3.12"
+    interpreter.touch()
+    script = scripts_dir / "hatch"
+    script.write_bytes(b"#!%s\nprint('ok')\n" % str(interpreter).encode())
+
+    module = load_module()
+    monkeypatch.setattr(module.sys, "executable", str(interpreter))
+    monkeypatch.setattr(
+        module.sysconfig,
+        "get_path",
+        lambda name: str(scripts_dir) if name == "scripts" else None,
+    )
+
+    module.main()
+
+    assert script.read_bytes() == (b'#!/bin/sh\n"exec" "$(dirname "$0")/python3.12" "$0" "$@"\nprint(\'ok\')\n')


### PR DESCRIPTION
## Summary

Quote `$0` in the generated Unix portable launcher shebang.

The launcher is installed under paths such as `~/Library/Application Support/...` when Hatch is installed through the standalone action on macOS. Without quoting `$0`, `dirname` splits the script path at the space and the launcher tries to execute a non-existent interpreter path.

Closes #1785.

## Tests

- red before the fix: `PYTHONPATH=src;backend/src python -m pytest tests/release/test_unix_make_scripts_portable.py -q`
- `PYTHONPATH=src;backend/src python -m pytest tests/release/test_unix_make_scripts_portable.py -q`
- `python -m ruff check release/unix/make_scripts_portable.py tests/release/test_unix_make_scripts_portable.py tests/release/__init__.py`
- `python -m ruff format --check release/unix/make_scripts_portable.py tests/release/test_unix_make_scripts_portable.py tests/release/__init__.py`
- `python -m compileall -q release\unix\make_scripts_portable.py tests\release\test_unix_make_scripts_portable.py tests\release\__init__.py`
- `git diff --check`