### PR TITLE
Fix editable wheel build requirements

### DIFF
--- a/backend/src/hatchling/build.py
+++ b/backend/src/hatchling/build.py
@@ -38,10 +38,19 @@ def get_requires_for_build_wheel(config_settings: dict[str, Any] | None = None) 
     """
     https://peps.python.org/pep-0517/#get-requires-for-build-wheel
     """
+    from hatchling.builders.constants import EDITABLES_REQUIREMENT
     from hatchling.builders.wheel import WheelBuilder
 
     builder = WheelBuilder(os.getcwd())
-    return builder.config.dependencies
+    dependencies = list(builder.config.dependencies)
+    if (
+        "editable" in builder.config.versions
+        and not builder.config.dev_mode_dirs
+        and EDITABLES_REQUIREMENT not in dependencies
+    ):
+        dependencies.append(EDITABLES_REQUIREMENT)
+
+    return dependencies
 
 
 def build_wheel(

--- a/backend/src/hatchling/builders/wheel.py
+++ b/backend/src/hatchling/builders/wheel.py
@@ -539,7 +539,16 @@ class WheelBuilder(BuilderInterface):
         return self.build_editable_detection(directory, **build_data)
 
     def build_editable_detection(self, directory: str, **build_data: Any) -> str:
-        from editables import EditableProject
+        try:
+            from editables import EditableProject
+        except ModuleNotFoundError as e:
+            if e.name != "editables":  # no cov
+                raise
+            message = (
+                "Building editable wheels requires the `editables` package. "
+                f"Install `{EDITABLES_REQUIREMENT}` or use a PEP 517 frontend that installs build requirements."
+            )
+            raise RuntimeError(message) from None
 
         build_data["tag"] = self.get_default_tag()
 

--- a/docs/history/hatch.md
+++ b/docs/history/hatch.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Fixed:***
+
+- Ensure editable wheel builds install dynamic build requirements before invoking Hatchling.
+
 ## [1.17.0](https://github.com/pypa/hatch/releases/tag/hatch-v1.17.0) - 2026-05-31 ## {: #hatch-v1.17.0 }
 
 ***Changed:***

--- a/docs/history/hatchling.md
+++ b/docs/history/hatchling.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Fixed:***
+
+- Include the `editables` build requirement when wheel targets are configured to build editable wheels.
+
 ## [1.30.1](https://github.com/pypa/hatch/releases/tag/hatchling-v1.30.1) - 2026-06-01 ## {: #hatchling-v1.30.1 }
 
 ***Fixed***

--- a/src/hatch/cli/build/__init__.py
+++ b/src/hatch/cli/build/__init__.py
@@ -74,7 +74,7 @@ def build(app: Application, location, targets, hooks_only, no_hooks, ext, clean,
         env_vars[AppEnvVars.QUIET] = str(abs(app.verbosity))
 
     with EnvVars(env_vars):
-        app.project.prepare_build_environment(targets=[target.split(":")[0] for target in targets])
+        app.project.prepare_build_environment(targets=list(targets))
 
     build_backend = app.project.metadata.build.build_backend
     with app.project.location.as_cwd(), app.project.build_env.get_env_vars():

--- a/src/hatch/env/plugin/interface.py
+++ b/src/hatch/env/plugin/interface.py
@@ -388,7 +388,8 @@ class EnvironmentInterface(ABC):
                     all_dependencies_complex.append(Dependency(str(req)))
 
             for target in os.environ.get(BuildEnvVars.REQUESTED_TARGETS, "").split():
-                target_config = self.app.project.config.build.target(target)
+                target_name, _, _ = target.partition(":")
+                target_config = self.app.project.config.build.target(target_name)
                 all_dependencies_complex.extend(map(Dependency, target_config.dependencies))
 
             return all_dependencies_complex
@@ -795,6 +796,16 @@ class EnvironmentInterface(ABC):
         from hatch.utils.dep import hash_dependencies
 
         return hash_dependencies(self.all_dependencies_complex)
+
+    def reset_dependency_cache(self) -> None:
+        for attribute in (
+            "dependencies_complex",
+            "dependencies",
+            "all_dependencies_complex",
+            "all_dependencies",
+            "missing_dependencies",
+        ):
+            self.__dict__.pop(attribute, None)
 
     @contextmanager
     def app_status_creation(self):

--- a/src/hatch/project/config.py
+++ b/src/hatch/project/config.py
@@ -565,6 +565,24 @@ class BuildConfig:
         return list(dependencies)
 
     @cached_property
+    def dev_mode_dirs(self) -> list[str]:
+        dev_mode_dirs: list[str] = self.__config.get("dev-mode-dirs", [])
+        if not isinstance(dev_mode_dirs, list):
+            message = "Field `tool.hatch.build.dev-mode-dirs` must be an array of strings"
+            raise TypeError(message)
+
+        for i, dev_mode_dir in enumerate(dev_mode_dirs, 1):
+            if not isinstance(dev_mode_dir, str):
+                message = f"Directory #{i} in field `tool.hatch.build.dev-mode-dirs` must be a string"
+                raise TypeError(message)
+
+            if not dev_mode_dir:
+                message = f"Directory #{i} in field `tool.hatch.build.dev-mode-dirs` cannot be an empty string"
+                raise ValueError(message)
+
+        return list(dev_mode_dirs)
+
+    @cached_property
     def hook_config(self) -> dict[str, dict[str, Any]]:
         hook_config: dict[str, dict[str, Any]] = self.__config.get("hooks", {})
         if not isinstance(hook_config, dict):
@@ -633,6 +651,53 @@ class BuildTargetConfig:
         all_dependencies = list(self.__global_config.dependencies)
         all_dependencies.extend(dependencies)
         return all_dependencies
+
+    @cached_property
+    def versions(self) -> list[str]:
+        versions: list[str] = self.__config.get("versions", [])
+        if not isinstance(versions, list):
+            message = f"Field `tool.hatch.build.targets.{self.__name}.versions` must be an array of strings"
+            raise TypeError(message)
+
+        for i, version in enumerate(versions, 1):
+            if not isinstance(version, str):
+                message = (
+                    f"Version #{i} in field `tool.hatch.build.targets.{self.__name}.versions` must be a string"
+                )
+                raise TypeError(message)
+
+            if not version:
+                message = (
+                    f"Version #{i} in field `tool.hatch.build.targets.{self.__name}.versions` "
+                    f"cannot be an empty string"
+                )
+                raise ValueError(message)
+
+        return list(versions)
+
+    @cached_property
+    def dev_mode_dirs(self) -> list[str]:
+        if "dev-mode-dirs" in self.__config:
+            dev_mode_dirs: list[str] = self.__config["dev-mode-dirs"]
+            location = f"tool.hatch.build.targets.{self.__name}.dev-mode-dirs"
+        else:
+            dev_mode_dirs = self.__global_config.dev_mode_dirs
+            location = "tool.hatch.build.dev-mode-dirs"
+
+        if not isinstance(dev_mode_dirs, list):
+            message = f"Field `{location}` must be an array of strings"
+            raise TypeError(message)
+
+        for i, dev_mode_dir in enumerate(dev_mode_dirs, 1):
+            if not isinstance(dev_mode_dir, str):
+                message = f"Directory #{i} in field `{location}` must be a string"
+                raise TypeError(message)
+
+            if not dev_mode_dir:
+                message = f"Directory #{i} in field `{location}` cannot be an empty string"
+                raise ValueError(message)
+
+        return list(dev_mode_dirs)
 
     @cached_property
     def hook_config(self) -> dict[str, dict[str, Any]]:

--- a/src/hatch/project/core.py
+++ b/src/hatch/project/core.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import re
 from collections import defaultdict
-from collections.abc import Generator
 from contextlib import contextmanager
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, cast
@@ -278,12 +277,13 @@ class Project:
             with self.app.status("Inspecting build dependencies"):
                 if build_backend != BUILD_BACKEND:
                     for target in targets:
-                        if target == "sdist":
+                        target_name, _, _ = target.partition(":")
+                        if target_name == "sdist":
                             additional_dependencies.extend(self.build_frontend.get_requires("sdist"))
-                        elif target == "wheel":
+                        elif target_name == "wheel":
                             additional_dependencies.extend(self.build_frontend.get_requires("wheel"))
                         else:
-                            self.app.abort(f"Target `{target}` is not supported by `{build_backend}`")
+                            self.app.abort(f"Target `{target_name}` is not supported by `{build_backend}`")
                 else:
                     required_build_deps = self.build_frontend.hatch.get_required_build_deps(targets)
                     if required_build_deps:
@@ -296,6 +296,7 @@ class Project:
                 from hatch.dep.core import Dependency
 
                 self.build_env.additional_dependencies.extend(map(Dependency, additional_dependencies))
+                self.build_env.reset_dependency_cache()
                 with self.build_env.app_status_dependency_synchronization():
                     self.build_env.sync_dependencies()
 

--- a/src/hatch/project/frontend/core.py
+++ b/src/hatch/project/frontend/core.py
@@ -180,12 +180,24 @@ class HatchBuildFrontend:
             return output
 
     def get_required_build_deps(self, targets: list[str]) -> list[str]:
+        from hatchling.builders.constants import EDITABLES_REQUIREMENT
+
         target_dependencies: list[str] = []
         hooks: set[str] = set()
         for target in targets:
-            target_config = self.__project.config.build.target(target)
+            target_name, _, target_version = target.partition(":")
+            target_config = self.__project.config.build.target(target_name)
             target_dependencies.extend(target_config.dependencies)
             hooks.update(target_config.hook_config)
+
+            versions = [target_version] if target_version else target_config.versions
+            if (
+                target_name == "wheel"
+                and "editable" in versions
+                and not target_config.dev_mode_dirs
+                and EDITABLES_REQUIREMENT not in target_dependencies
+            ):
+                target_dependencies.append(EDITABLES_REQUIREMENT)
 
         # Remove any build hooks that are known to not define any dependencies dynamically
         hooks.difference_update((

--- a/src/hatch/project/frontend/scripts/build_deps.py
+++ b/src/hatch/project/frontend/scripts/build_deps.py
@@ -4,6 +4,7 @@ import json
 import os
 
 from hatchling.bridge.app import Application
+from hatchling.builders.constants import EDITABLES_REQUIREMENT
 from hatchling.metadata.core import ProjectMetadata
 from hatchling.plugin.manager import PluginManager
 
@@ -20,7 +21,8 @@ def main() -> None:
     metadata = ProjectMetadata(project_root, plugin_manager)
 
     dependencies: dict[str, None] = {}
-    for target_name in targets:
+    for target in targets:
+        target_name, _, target_version = target.partition(":")
         builder_class = plugin_manager.builder.get(target_name)
         if builder_class is None:
             continue
@@ -30,6 +32,9 @@ def main() -> None:
         )
         for dependency in builder.config.dependencies:
             dependencies[dependency] = None
+        versions = [target_version] if target_version else builder.config.versions
+        if target_name == "wheel" and "editable" in versions and not builder.config.dev_mode_dirs:
+            dependencies[EDITABLES_REQUIREMENT] = None
 
     output = json.dumps(list(dependencies))
     with open(os.path.join(output_dir, "output.json"), "w", encoding="utf-8") as f:

--- a/tests/backend/test_build.py
+++ b/tests/backend/test_build.py
@@ -1,4 +1,5 @@
-from hatchling.build import build_editable, build_sdist, build_wheel
+from hatchling.build import build_editable, build_sdist, build_wheel, get_requires_for_build_wheel
+from hatchling.builders.constants import EDITABLES_REQUIREMENT
 
 
 def test_sdist(hatch, helpers, temp_dir, config_file):
@@ -81,6 +82,53 @@ def test_wheel(hatch, helpers, temp_dir, config_file):
     assert len(build_artifacts) == 1
     assert expected_artifact == str(build_artifacts[0].name)
     assert expected_artifact.endswith(".whl")
+
+
+def test_wheel_requires_editables_when_editable_version_selected(helpers, temp_dir):
+    project_path = temp_dir / "project"
+    package_dir = project_path / "src" / "demo_pkg"
+    package_dir.ensure_dir_exists()
+    package_dir.joinpath("__init__.py").touch()
+    project_path.joinpath("pyproject.toml").write_text(
+        helpers.dedent(
+            """
+            [project]
+            name = "demo-pkg"
+            version = "0.1.0"
+
+            [tool.hatch.build.targets.wheel]
+            packages = ["src/demo_pkg"]
+            versions = ["editable"]
+            """
+        )
+    )
+
+    with project_path.as_cwd():
+        assert get_requires_for_build_wheel(None) == [EDITABLES_REQUIREMENT]
+
+
+def test_wheel_editable_version_with_dev_mode_dirs_does_not_require_editables(helpers, temp_dir):
+    project_path = temp_dir / "project"
+    package_dir = project_path / "src" / "demo_pkg"
+    package_dir.ensure_dir_exists()
+    package_dir.joinpath("__init__.py").touch()
+    project_path.joinpath("pyproject.toml").write_text(
+        helpers.dedent(
+            """
+            [project]
+            name = "demo-pkg"
+            version = "0.1.0"
+
+            [tool.hatch.build.targets.wheel]
+            packages = ["src/demo_pkg"]
+            versions = ["editable"]
+            dev-mode-dirs = ["src"]
+            """
+        )
+    )
+
+    with project_path.as_cwd():
+        assert get_requires_for_build_wheel(None) == []
 
 
 def test_editable(hatch, helpers, temp_dir, config_file):

--- a/tests/env/plugin/test_interface.py
+++ b/tests/env/plugin/test_interface.py
@@ -1844,6 +1844,43 @@ feature3 = ["pkg-feature-3{i}"]
         deps = environment.dependencies_complex
         assert any("extra-dep" in str(d) for d in deps)
 
+    def test_reset_dependency_cache(self, temp_dir, isolated_data_dir, platform, temp_application):
+        pyproject = temp_dir / "pyproject.toml"
+        pyproject.write_text("""
+    [project]
+    name = "my-app"
+    version = "0.0.1"
+    """)
+
+        project = Project(temp_dir)
+        project.set_app(temp_application)
+        temp_application.project = project
+        environment = MockEnvironment(
+            temp_dir,
+            project.metadata,
+            "default",
+            project.config.envs["default"],
+            {},
+            isolated_data_dir,
+            isolated_data_dir,
+            platform,
+            0,
+            temp_application,
+        )
+
+        _ = environment.dependencies_complex
+        _ = environment.dependencies
+        _ = environment.all_dependencies_complex
+        _ = environment.all_dependencies
+
+        environment.additional_dependencies = ["extra-dep"]
+        environment.reset_dependency_cache()
+
+        assert any("extra-dep" in str(d) for d in environment.dependencies_complex)
+        assert any("extra-dep" in dependency for dependency in environment.dependencies)
+        assert any("extra-dep" in str(d) for d in environment.all_dependencies_complex)
+        assert any("extra-dep" in dependency for dependency in environment.all_dependencies)
+
 
 class TestScripts:
     @pytest.mark.parametrize("field", ["scripts", "extra-scripts"])

--- a/tests/project/test_frontend.py
+++ b/tests/project/test_frontend.py
@@ -400,3 +400,98 @@ version = "9000.42"
         output = json.loads((output_dir / "output.json").read_text())
 
         assert output == []
+
+    def test_editable_wheel_version(self, temp_dir, temp_dir_data, platform, global_application):
+        project_dir = temp_dir / "project"
+        project_dir.mkdir()
+        (project_dir / "pyproject.toml").write_text(
+            """\
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "foo"
+version = "9000.42"
+
+[tool.hatch.build.targets.wheel]
+versions = ["editable"]
+"""
+        )
+
+        package_dir = project_dir / "foo"
+        package_dir.mkdir()
+        (package_dir / "__init__.py").touch()
+
+        project = Project(project_dir)
+        project.build_env = MockEnvironment(
+            temp_dir,
+            project.metadata,
+            "default",
+            project.config.envs["default"],
+            {},
+            temp_dir_data,
+            temp_dir_data,
+            platform,
+            0,
+            global_application,
+        )
+
+        output_dir = temp_dir / "output"
+        output_dir.mkdir()
+        script = project.build_frontend.hatch.scripts.get_build_deps(
+            output_dir=str(output_dir), project_root=str(project_dir), targets=["wheel"]
+        )
+        platform.check_command([sys.executable, "-c", script])
+        output = json.loads((output_dir / "output.json").read_text())
+
+        assert output == [EDITABLES_REQUIREMENT]
+
+    def test_editable_wheel_version_with_dev_mode_dirs(
+        self, temp_dir, temp_dir_data, platform, global_application
+    ):
+        project_dir = temp_dir / "project"
+        project_dir.mkdir()
+        (project_dir / "pyproject.toml").write_text(
+            """\
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "foo"
+version = "9000.42"
+
+[tool.hatch.build.targets.wheel]
+versions = ["editable"]
+dev-mode-dirs = ["."]
+"""
+        )
+
+        package_dir = project_dir / "foo"
+        package_dir.mkdir()
+        (package_dir / "__init__.py").touch()
+
+        project = Project(project_dir)
+        project.build_env = MockEnvironment(
+            temp_dir,
+            project.metadata,
+            "default",
+            project.config.envs["default"],
+            {},
+            temp_dir_data,
+            temp_dir_data,
+            platform,
+            0,
+            global_application,
+        )
+
+        output_dir = temp_dir / "output"
+        output_dir.mkdir()
+        script = project.build_frontend.hatch.scripts.get_build_deps(
+            output_dir=str(output_dir), project_root=str(project_dir), targets=["wheel"]
+        )
+        platform.check_command([sys.executable, "-c", script])
+        output = json.loads((output_dir / "output.json").read_text())
+
+        assert output == []


### PR DESCRIPTION
Fixes #2010.

This makes editable wheel builds install `editables` when the wheel target is configured to build the `editable` version, matching the dependency already exposed by `get_requires_for_build_editable`.

The fix covers both paths:

- Hatchling's `get_requires_for_build_wheel` now reports `editables~=0.3` when `[tool.hatch.build.targets.wheel].versions` includes `editable` and `dev-mode-dirs` is not configured.
- Hatch's build frontend keeps full target specs such as `wheel:editable`, detects the same requirement before invoking Hatchling, and resets dependency caches so dynamically discovered build dependencies are actually installed before the second sync.

I also added a clearer runtime error if `build_editable_detection` is invoked without `editables` in non-PEP-517 contexts.

Validation:

- `python -m pytest tests/backend/test_build.py tests/project/test_frontend.py -q`
- `python -m pytest tests/env/plugin/test_interface.py::TestDependencies::test_builder tests/env/plugin/test_interface.py::TestDependencies::test_additional_dependencies_as_strings tests/env/plugin/test_interface.py::TestDependencies::test_reset_dependency_cache -q`
- CLI smoke: temporary project with `versions = ["editable"]`, `hatch build -t wheel`
- CLI smoke: temporary project with `hatch build -t wheel:editable`
- `python -m ruff check ...`
- `python -m compileall -q ...`
- `python scripts/validate_history.py`
- `git diff --check`