### PR TITLE
Add hatch-uvenv to known environment third party plugins

### DIFF
--- a/docs/plugins/environment/reference.md
+++ b/docs/plugins/environment/reference.md
@@ -10,6 +10,7 @@ See the documentation for [environment configuration](../../config/environment/o
 - [hatch-containers](https://github.com/ofek/hatch-containers) - environments run inside containers
 - [hatch-pip-compile](https://github.com/juftin/hatch-pip-compile) - use [pip-compile](https://github.com/jazzband/pip-tools) to manage project dependencies and lockfiles
 - [hatch-pip-deepfreeze](https://github.com/sbidoul/hatch-pip-deepfreeze) - [virtual](virtual.md) environments with dependency locking by [pip-deepfreeze](https://github.com/sbidoul/pip-deepfreeze)
+- [hatch-uvenv](https://github.com/djcopley/hatch-uvenv) - [virtual](virtual.md) environments with dependency locking by [uv](https://docs.astral.sh/uv/)
 
 ## Installation
 


### PR DESCRIPTION
hatch-uvenv lets you use uv locked envs (the `uv sync` interface instead of `uv pip install`) to back hatch environments