### PR TITLE
Fix env-dependency extras being dropped when a metadata hook is configured

### DIFF
--- a/docs/history/hatch.md
+++ b/docs/history/hatch.md
@@ -12,7 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Use `TemporaryDirectory` and pylock*.toml for temporary lock files.
 - Skip injection of `ruff` extend if a key already exists in `ruff.toml`.
-- Pass `--no-header` to `uv pip compile` in the `uv` locker so that generated lockfiles are deterministic
+- Pass `--no-header` to `uv pip compile` in the `uv` locker so that generated lockfiles are deterministic.
+- Fix env-dependency extras being dropped when a metadata hook is configured and resolve workspace-member extras from the member's own metadata.
 
 
 ## [1.17.0](https://github.com/pypa/hatch/releases/tag/hatch-v1.17.0) - 2026-05-31 ## {: #hatch-v1.17.0 }

--- a/src/hatch/env/plugin/interface.py
+++ b/src/hatch/env/plugin/interface.py
@@ -415,20 +415,27 @@ class EnvironmentInterface(ABC):
         from hatch.dep.core import Dependency
 
         local_deps = list(self.local_dependencies_complex)
-        workspace_names = {dep.name.lower() for dep in local_deps}
+
+        # Map each locally-resolved package name to the metadata that owns its optional-dependencies,
+        # so extras on `<pkg>[extra]` deps are expanded from the *referenced* package's own metadata
+        # rather than always the current project's.
+        local_metadata: dict[str, Any] = {}
+        if not self.skip_install:
+            local_metadata[self.metadata.name.lower()] = self.metadata
+        for member in self.workspace.members:
+            local_metadata[member.name.lower()] = member.project.metadata
 
         filtered_deps: list[Dependency] = []
         for dep in self.dependencies_complex:
             dep_obj = dep if isinstance(dep, Dependency) else Dependency(str(dep))
 
-            if dep_obj.name.lower() in workspace_names and dep_obj.extras:
-                # Only expand if we have static optional dependencies to avoid recursion
-                if not self.metadata.hatch.metadata.hook_config:
-                    optional_dependencies = self.metadata.core.optional_dependencies
-                    for extra in dep_obj.extras:
-                        if extra in optional_dependencies:
-                            filtered_deps.extend(Dependency(d) for d in optional_dependencies[extra])
-            elif dep_obj.name.lower() not in workspace_names:
+            name_lower = dep_obj.name.lower()
+            if name_lower in local_metadata and dep_obj.extras:
+                optional_dependencies = local_metadata[name_lower].core.optional_dependencies
+                for extra in dep_obj.extras:
+                    if extra in optional_dependencies:
+                        filtered_deps.extend(Dependency(d) for d in optional_dependencies[extra])
+            elif name_lower not in local_metadata:
                 filtered_deps.append(dep_obj)
 
         return local_deps + filtered_deps

--- a/tests/env/plugin/test_interface.py
+++ b/tests/env/plugin/test_interface.py
@@ -1541,6 +1541,150 @@ feature3 = ["pkg-feature-3{i}"]
         # Should have my-app[test] which will cause pip to install pytest
         assert any("pytest" in dep.lower() for dep in all_deps_str)
 
+    def test_workspace_member_dependency_with_extras(self, temp_dir, isolated_data_dir, platform, temp_application):
+        """A workspace member's extras must expand against that member's own optional-dependencies,
+        not the root project's.
+        """
+        member_file = temp_dir / "member-pkg" / "pyproject.toml"
+        member_file.parent.mkdir()
+        member_file.write_text(
+            """\
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "member-pkg"
+version = "0.0.1"
+dependencies = []
+
+[project.optional-dependencies]
+test = ["member-test-dep"]
+"""
+        )
+
+        config = {
+            "project": {
+                "name": "my-app",
+                "version": "0.0.1",
+                "dependencies": [],
+                "optional-dependencies": {
+                    # Same extra name on the root project, with a *different* dependency,
+                    # to prove the lookup uses the member's metadata not the root's.
+                    "test": ["root-test-dep"],
+                },
+            },
+            "tool": {
+                "hatch": {
+                    "envs": {
+                        "default": {
+                            "skip-install": False,
+                            "dependencies": ["member-pkg[test]"],
+                            "workspace": {"members": [{"path": "member-pkg"}]},
+                        },
+                    },
+                },
+            },
+        }
+
+        project = Project(temp_dir, config=config)
+        project.set_app(temp_application)
+        temp_application.project = project
+        environment = MockEnvironment(
+            temp_dir,
+            project.metadata,
+            "default",
+            project.config.envs["default"],
+            {},
+            isolated_data_dir,
+            isolated_data_dir,
+            platform,
+            0,
+            temp_application,
+        )
+
+        all_deps_str = [str(d) for d in environment.all_dependencies_complex]
+
+        # The member's own extra must be expanded
+        assert any("member-test-dep" in dep for dep in all_deps_str)
+        # The root project's same-named extra must NOT leak into the env
+        assert not any("root-test-dep" in dep for dep in all_deps_str)
+
+    def test_self_referencing_dependency_with_extras_and_metadata_hook(
+        self, temp_dir, isolated_data_dir, platform, global_application, helpers
+    ):
+        """Regression test for https://github.com/pypa/hatch/issues/2252.
+
+        A configured metadata hook must not cause extras of self-referencing dependencies to be dropped.
+        The hook here only sets ``description``; ``optional-dependencies`` remain static and the extras
+        of ``my-app[test]`` must still expand to ``pytest>=7.0``.
+        """
+        project_dir = temp_dir / "my-app"
+        project_dir.mkdir()
+
+        (project_dir / "my_app").mkdir()
+        (project_dir / "my_app" / "__init__.py").write_text("")
+        (project_dir / "my_app" / "__about__.py").write_text('__version__ = "0.0.1"')
+
+        (project_dir / "hatch_build.py").write_text(
+            helpers.dedent(
+                """
+                from hatchling.metadata.plugin.interface import MetadataHookInterface
+
+                class CustomHook(MetadataHookInterface):
+                    def update(self, metadata):
+                        metadata['description'] = 'set by hook'
+                """
+            )
+        )
+
+        config = {
+            "project": {
+                "name": "my-app",
+                "version": "0.0.1",
+                "dynamic": ["description"],
+                "dependencies": [],
+                "optional-dependencies": {
+                    "test": ["pytest>=7.0"],
+                },
+            },
+            "tool": {
+                "hatch": {
+                    "metadata": {"hooks": {"custom": {}}},
+                    "envs": {
+                        "dev": {
+                            "skip-install": False,
+                            "dependencies": ["my-app[test]"],
+                        }
+                    },
+                }
+            },
+        }
+
+        project = Project(project_dir, config=config)
+        global_application.project = project
+
+        environment = MockEnvironment(
+            project_dir,
+            project.metadata,
+            "dev",
+            project.config.envs["dev"],
+            {},
+            isolated_data_dir,
+            isolated_data_dir,
+            platform,
+            0,
+            global_application,
+        )
+
+        all_deps_str = [str(d) for d in environment.all_dependencies_complex]
+
+        # The self-referenced project must still be installed locally
+        assert any("my-app" in dep and "file://" in dep for dep in all_deps_str)
+
+        # And the extras must be expanded even though a metadata hook is configured
+        assert any("pytest" in dep.lower() for dep in all_deps_str)
+
     def test_dev_mode_true_returns_editable(self, temp_dir, isolated_data_dir, platform, temp_application):
         """Verify dev-mode=true creates editable local dependency."""
         # Create a pyproject.toml file so skip_install defaults to False


### PR DESCRIPTION
Fixes #2252 

Fix extras being dropped when a metadata hook is configured. Also ensures that extras flow through for workspace members, there was a minor bug where that would not have necessarily always happened. 