### PR TITLE
Don't force interactive mode for `hatch new --init <name>` (#2337)

### DIFF
--- a/docs/history/hatch.md
+++ b/docs/history/hatch.md
@@ -8,13 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-
 ***Fixed:***
 
 - Erase stale coverage data before running `hatch test --cover`.
 
 - Fix environment creation crashing when a metadata hook exists that doesn’t happen to be installed in the `hatch` CLI’s environment.
-
+- Don't prompt for a description when running `hatch new --init <name>` without the `-i`/`--interactive` flag.
 
 ## [1.17.1](https://github.com/pypa/hatch/releases/tag/hatch-v1.17.1) - 2026-07-08 ## {: #hatch-v1.17.1 }
 

--- a/src/hatch/cli/new/__init__.py
+++ b/src/hatch/cli/new/__init__.py
@@ -25,12 +25,18 @@ def new(app, name, location, interactive, feature_cli, initialize, setuptools_op
 
     migration_possible = False
     if initialize:
-        interactive = True
         location = location or Path.cwd()
         if (location / "setup.py").is_file() or (location / "setup.cfg").is_file():
             migration_possible = True
             if not name:
                 name = "temporary"
+
+        # Only force interactive mode when the project name is still missing, so
+        # it can be prompted for; otherwise honor the -i/--interactive flag. This
+        # keeps `hatch new --init <name>` from prompting for a description when
+        # the user did not ask for interactive mode.
+        if not name:
+            interactive = True
 
     if not name:
         if not interactive:

--- a/tests/cli/new/test_new.py
+++ b/tests/cli/new/test_new.py
@@ -521,6 +521,36 @@ def test_initialize_fresh(hatch, helpers, temp_dir):
     )
 
 
+def test_initialize_with_name_non_interactive(hatch, helpers, temp_dir):
+    # Providing the project name on the command line must not trigger interactive
+    # prompts (e.g. for the description) unless -i/--interactive is passed.
+    project_name = "My.App"
+
+    with temp_dir.as_cwd():
+        result = hatch("new", project_name)
+        assert result.exit_code == 0, result.output
+
+    path = temp_dir / "my-app"
+
+    project_file = path / "pyproject.toml"
+    project_file.remove()
+    assert not project_file.is_file()
+
+    with path.as_cwd():
+        result = hatch("new", "--init", project_name)
+
+    expected_files = helpers.get_template_files("new.default", project_name)
+    helpers.assert_files(path, expected_files)
+
+    assert result.exit_code == 0, result.output
+    assert "Description" not in result.output
+    assert remove_trailing_spaces(result.output) == helpers.dedent(
+        """
+        Wrote: pyproject.toml
+        """
+    )
+
+
 def test_initialize_update(hatch, helpers, temp_dir):
     project_name = "My.App"
     description = "foo"


### PR DESCRIPTION
## Summary

Fixes #2337. `hatch new --init` unconditionally set `interactive = True`, so providing a project name on the command line still prompted for a description even though the user never passed `-i`/`--interactive`:

```console
$ hatch new --init myproject
Description []:            # <- unwanted prompt in non-interactive mode
```

## Cause

In `hatch/cli/new`, the `--init` branch did `interactive = True` up front. That flag was only meant to enable prompting for the project **name** when it's missing, but it also gates the description prompt, so any `--init` invocation became interactive.

## Fix

Only force interactive mode when the project name is still missing (so it can be prompted for); otherwise honor the `-i`/`--interactive` flag. Now:

- `hatch new --init myproject` → no prompts, writes `pyproject.toml` with an empty description.
- `hatch new --init` (no name) → still prompts for name and description, as before.
- `hatch new --init myproject -i` → still interactive, as requested.
- setuptools/`setup.cfg` migration is unaffected.

## Tests

- Added `tests/cli/new/test_new.py::test_initialize_with_name_non_interactive`; it fails on `main` (the description prompt appears) and passes with this change.
- The full `tests/cli/new/test_new.py` suite passes (21 passed, 2 network-only deselected); `ruff check`/`ruff format` clean.

*Disclosure: prepared with AI assistance; reviewed and verified locally.*
