### PR TITLE
docs: point VS Code guide to Hatch extension

### DIFF
--- a/docs/how-to/integrate/vscode.md
+++ b/docs/how-to/integrate/vscode.md
@@ -2,9 +2,9 @@
 
 -----
 
-Visual Studio Code announced support for [Hatch environment discovery](https://code.visualstudio.com/updates/v1_88#_hatch-environment-discovery) in `vscode-python`'s [2024.4 release](https://github.com/microsoft/vscode-python/releases/tag/v2024.4.0).
+For the best experience, install the dedicated [Hatch extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=PyPA.hatch). The extension is maintained in the [pypa/hatch-code](https://github.com/pypa/hatch-code) repository.
 
-For it to work, you should [install Hatch](../../install.md) globally. If you used the GUI installers on Windows or macOS, or your system package manager on e.g. Arch Linux or Fedora, this should be taken care of.
+For environment discovery to work, you should [install Hatch](../../install.md) globally. If you used the GUI installers on Windows or macOS, or your system package manager on e.g. Arch Linux or Fedora, this should be taken care of.
 
 ??? note "Setting up PATH"
 


### PR DESCRIPTION
## Summary

Fixes #2336 by updating the VS Code integration guide to point users to the dedicated Hatch extension instead of the old `vscode-python` Hatch discovery note.

## Changes

- Link to the Hatch Visual Studio Code Marketplace extension.
- Link to the `pypa/hatch-code` repository.
- Keep the global Hatch installation/PATH setup guidance for environment discovery.

## Verification

- `git diff --check`
- Local doc assertions verified the new Marketplace and `pypa/hatch-code` links are present and the old `vscode-python` reference is gone.
- Verified both linked URLs return HTTP 200.