### PR TITLE
fix: normalize optional-dependency feature names for underscore/hyphen equivalence

### DIFF
--- a/src/hatch/project/core.py
+++ b/src/hatch/project/core.py
@@ -302,8 +302,13 @@ class Project:
     def get_dependencies(self) -> tuple[list[str], dict[str, list[str]]]:
         dynamic_fields = {"dependencies", "optional-dependencies"}
         if not dynamic_fields.intersection(self.metadata.dynamic):
+            from hatch.utils.metadata import normalize_project_name
+
             dependencies: list[str] = self.metadata.core_raw_metadata.get("dependencies", [])
-            features: dict[str, list[str]] = self.metadata.core_raw_metadata.get("optional-dependencies", {})
+            features: dict[str, list[str]] = {
+                normalize_project_name(k): v
+                for k, v in self.metadata.core_raw_metadata.get("optional-dependencies", {}).items()
+            }
             return dependencies, features
 
         from hatch.project.constants import BUILD_BACKEND

--- a/tests/cli/dep/show/test_requirements.py
+++ b/tests/cli/dep/show/test_requirements.py
@@ -228,6 +228,52 @@ def test_include_features(hatch, helpers, temp_dir, config_file):
     )
 
 
+
+def test_feature_name_with_underscore(hatch, helpers, temp_dir, config_file):
+    """Regression test for issue #2166: feature names with underscores should be equivalent to hyphens."""
+    config_file.model.template.plugins["default"]["tests"] = False
+    config_file.save()
+
+    project_name = "My.App"
+
+    with temp_dir.as_cwd():
+        result = hatch("new", project_name)
+
+    assert result.exit_code == 0, result.output
+
+    project_path = temp_dir / "my-app"
+
+    project = Project(project_path)
+    config = dict(project.raw_config)
+    config["project"]["dependencies"] = ["foo-bar-baz"]
+    config["project"]["optional-dependencies"] = {
+        "foo_bar": ["bar-baz-foo"],
+    }
+    project.save_config(config)
+    helpers.update_project_environment(project, "default", {"dependencies": ["baz-bar-foo"]})
+
+    # The feature name with underscores should work identically to the hyphenated version
+    with project_path.as_cwd():
+        result = hatch("dep", "show", "requirements", "-f", "foo_bar")
+
+    assert result.exit_code == 0, result.output
+    assert result.output == helpers.dedent(
+        """
+        bar-baz-foo
+        """
+    )
+
+    # The hyphenated version should also work
+    with project_path.as_cwd():
+        result = hatch("dep", "show", "requirements", "-f", "foo-bar")
+
+    assert result.exit_code == 0, result.output
+    assert result.output == helpers.dedent(
+        """
+        bar-baz-foo
+        """
+    )
+
 def test_plugin_dependencies_unmet(hatch, helpers, temp_dir, config_file, mock_plugin_installation):
     config_file.model.template.plugins["default"]["tests"] = False
     config_file.save()


### PR DESCRIPTION
When optional-dependencies are statically defined in pyproject.toml with underscore-containing feature names (e.g. `foo_bar`), the `get_dependencies()` method returned raw unnormalized keys. The features configuration normalizes names per PEP 503 (`foo_bar` → `foo-bar`), so the lookup would fail with:

```
Feature 'foo-bar' is not defined in field 'project.optional-dependencies'
```

This only affected static metadata (the common case) — dynamic metadata handled by build backends already returns normalized keys.

Closes #2166