### PR TITLE
Restore exclude/artifacts pattern support for force-include directories

### DIFF
--- a/backend/src/hatchling/builders/config.py
+++ b/backend/src/hatchling/builders/config.py
@@ -73,6 +73,13 @@ class BuilderConfig:
             )
         )
 
+    def include_forced_path(self, distribution_path: str) -> bool:
+        return (
+            self.path_is_build_artifact(distribution_path)
+            or self.path_is_artifact(distribution_path)
+            or (not self.path_is_reserved(distribution_path) and not self.forced_path_is_excluded(distribution_path))
+        )
+
     def path_is_included(self, relative_path: str) -> bool:
         if self.include_spec is None:
             return True
@@ -83,6 +90,15 @@ class BuilderConfig:
         if self.__exclude_all:
             return True
 
+        if self.exclude_spec is None:
+            return False
+
+        return self.exclude_spec.match_file(relative_path)
+
+    def forced_path_is_excluded(self, relative_path: str) -> bool:
+        # Unlike `path_is_excluded`, this ignores `__exclude_all`, which only signals that
+        # default project file selection should be skipped in favor of forced inclusion, not
+        # that forced inclusion should exclude everything.
         if self.exclude_spec is None:
             return False
 

--- a/backend/src/hatchling/builders/plugin/interface.py
+++ b/backend/src/hatchling/builders/plugin/interface.py
@@ -228,7 +228,7 @@ class BuilderInterface(ABC, Generic[BuilderConfigBound, PluginManagerBound]):
 
                         relative_file_path = os.path.join(target_path, relative_directory, f)
                         distribution_path = self.config.get_distribution_path(relative_file_path)
-                        if not self.config.path_is_reserved(distribution_path):
+                        if self.config.include_forced_path(distribution_path):
                             yield IncludedFile(
                                 os.path.join(root, f),
                                 "" if external else relative_file_path,

--- a/docs/config/build.md
+++ b/docs/config/build.md
@@ -113,7 +113,7 @@ For example, if there was a directory alongside the project root named `artifact
 
 !!! note
     - Files must be mapped exactly to their desired paths, not to directories.
-    - The contents of directory sources are recursively included.
+    - The contents of directory sources are recursively included, subject to the [`exclude`](#patterns) and [`artifacts`](#artifacts) options.
     - To map directory contents directly to the root use `/` (a forward slash).
     - Sources that do not exist will raise an error.
 

--- a/docs/history/hatchling.md
+++ b/docs/history/hatchling.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Fixed:***
+
+- Restore the `exclude` and `artifacts` patterns being respected for directories added with the `force-include` option
+
 ## [1.31.0](https://github.com/pypa/hatch/releases/tag/hatchling-v1.31.0) - 2026-06-30 ## {: #hatchling-v1.31.0 }
 
 ***Fixed***

--- a/docs/history/hatchling.md
+++ b/docs/history/hatchling.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Fixed:***
+
+- Restore the `exclude` and `artifacts` patterns being respected for directories added with the `force-include` option
+
 ## [1.32.0](https://github.com/pypa/hatch/releases/tag/hatchling-v1.32.0) - 2026-08-11 ## {: #hatchling-v1.32.0 }
 
 ***Changed:***

--- a/tests/backend/builders/plugin/test_interface.py
+++ b/tests/backend/builders/plugin/test_interface.py
@@ -181,6 +181,60 @@ class TestDirectoryRecursion:
 
             assert [f.path for f in builder.recurse_included_files()] == [str(project_dir / "foo" / "bar.txt")]
 
+    def test_force_include_respects_exclude(self, temp_dir):
+        project_dir = temp_dir / "project"
+        project_dir.ensure_dir_exists()
+
+        with project_dir.as_cwd():
+            config = {
+                "tool": {
+                    "hatch": {
+                        "build": {
+                            "exclude": ["*.rst"],
+                            "force-include": {"../external": "pkg"},
+                        }
+                    }
+                }
+            }
+            builder = MockBuilder(str(project_dir), config=config)
+
+            external = temp_dir / "external"
+            external.ensure_dir_exists()
+            (external / "keep.py").touch()
+            (external / "drop.rst").touch()
+
+            assert [(f.path, f.distribution_path) for f in builder.recurse_included_files()] == [
+                (str(external / "keep.py"), f"pkg{path_sep}keep.py"),
+            ]
+
+    def test_force_include_artifacts_override_exclude(self, temp_dir):
+        project_dir = temp_dir / "project"
+        project_dir.ensure_dir_exists()
+
+        with project_dir.as_cwd():
+            config = {
+                "tool": {
+                    "hatch": {
+                        "build": {
+                            "exclude": ["*.rst"],
+                            "artifacts": ["*.rst"],
+                            "force-include": {"../external": "pkg"},
+                        }
+                    }
+                }
+            }
+            builder = MockBuilder(str(project_dir), config=config)
+
+            external = temp_dir / "external"
+            external.ensure_dir_exists()
+            (external / "keep.py").touch()
+            (external / "drop.rst").touch()
+
+            assert [(f.path, f.distribution_path) for f in builder.recurse_included_files()] == [
+                (str(external / "drop.rst"), f"pkg{path_sep}drop.rst"),
+                (str(external / "keep.py"), f"pkg{path_sep}keep.py"),
+            ]
+
     def test_no_duplication_force_include_only(self, temp_dir):
         project_dir = temp_dir / "project"
         project_dir.ensure_dir_exists()

--- a/tests/backend/builders/test_wheel.py
+++ b/tests/backend/builders/test_wheel.py
@@ -279,6 +279,36 @@ class TestDefaultFileSelection:
             assert builder.config.default_packages() == []
             assert builder.config.default_only_include() == []
 
+    def test_force_include_as_sole_selection_respects_exclude(self, temp_dir):
+        external_dir = temp_dir / "external"
+        external_dir.ensure_dir_exists()
+        (external_dir / "keep.py").touch()
+        (external_dir / "drop.rst").touch()
+
+        project_dir = temp_dir / "my-app"
+        project_dir.ensure_dir_exists()
+
+        config = {
+            "project": {"name": "my-app", "version": "0.0.1"},
+            "tool": {
+                "hatch": {
+                    "build": {
+                        "targets": {
+                            "wheel": {
+                                "force-include": {str(external_dir): "pkg"},
+                                "exclude": ["*.rst"],
+                            }
+                        }
+                    }
+                }
+            },
+        }
+        builder = WheelBuilder(str(project_dir), config=config)
+
+        assert [f.distribution_path for f in builder.recurse_included_files()] == [
+            f"pkg{os.sep}keep.py",
+        ]
+
     def test_unnormalized_name_with_unnormalized_directory(self, temp_dir):
         config = {"project": {"name": "MyApp", "version": "0.0.1"}}
         builder = WheelBuilder(str(temp_dir), config=config)


### PR DESCRIPTION
Directories added via `force-include` used to have their contents filtered by the `exclude` and `artifacts` patterns (added in #297), but this got silently dropped when `recurse_forced_files` was split out from the shared file-selection logic in #299 (when `only-include` was introduced). Since then there's been no way to exclude specific files under a force-included directory.

This restores the old `include_forced_path` check for directory sources in `force-include`. To keep it correct, it uses a new `forced_path_is_excluded` helper rather than reusing `path_is_excluded` directly, since the latter also honors the "exclude everything" flag that's set when force-include is the *sole* file-selection mechanism for a build target — that flag is meant to blank out the default project file walk, not the forced files themselves.

Closes #2090
Closes #1989

## Testing

- Added unit tests covering `force-include` + `exclude`, and `force-include` + `exclude` + `artifacts` (artifacts should still override exclude).
- Added an integration-level test using `WheelBuilder` for the case where `force-include` is the only file-selection option configured (the trickiest interaction, due to the "exclude everything" flag mentioned above).
- Ran the full `tests/backend` suite (939 passed) plus `ruff check`, `ruff format --check`, and `mypy` on the touched files.