### PR TITLE
Erase stale coverage before hatch test

### DIFF
--- a/docs/history/hatch.md
+++ b/docs/history/hatch.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Fixed:***
+
+- Erase stale coverage data before running `hatch test --cover`.
+
 ## [1.17.1](https://github.com/pypa/hatch/releases/tag/hatch-v1.17.1) - 2026-07-08 ## {: #hatch-v1.17.1 }
 
 ***Fixed***

--- a/src/hatch/cli/test/__init__.py
+++ b/src/hatch/cli/test/__init__.py
@@ -180,6 +180,10 @@ def test(
     if cover:
         patched_coverage.write_config_file()
 
+        for context in app.runner_context([selected_envs[0]]):
+            context.add_shell_command("coverage erase")
+            context.env_vars["COVERAGE_RCFILE"] = coverage_config_file
+
     for context in app.runner_context(selected_envs, ignore_compat=multiple_possible, display_header=multiple_possible):
         internal_arguments: list[str] = list(context.env.config.get("extra-args", []))
 

--- a/tests/cli/test/test_test.py
+++ b/tests/cli/test/test_test.py
@@ -194,6 +194,7 @@ class TestCoverage:
         assert not result.output
 
         assert env_run.call_args_list == [
+            mocker.call("coverage erase", shell=True),
             mocker.call("coverage run -m pytest -p no:randomly tests", shell=True),
             mocker.call("coverage combine", shell=True),
             mocker.call("coverage report", shell=True),
@@ -230,6 +231,7 @@ class TestCoverage:
         assert not result.output
 
         assert env_run.call_args_list == [
+            mocker.call("coverage erase", shell=True),
             mocker.call("coverage run -m pytest -p no:randomly --flag -- arg1 arg2", shell=True),
             mocker.call("coverage combine", shell=True),
             mocker.call("coverage report", shell=True),
@@ -266,6 +268,7 @@ class TestCoverage:
         assert not result.output
 
         assert env_run.call_args_list == [
+            mocker.call("coverage erase", shell=True),
             mocker.call("coverage run -m pytest -p no:randomly tests", shell=True),
             mocker.call("coverage combine", shell=True),
         ]
@@ -303,6 +306,7 @@ class TestCoverage:
         assert not result.output
 
         assert env_run.call_args_list == [
+            mocker.call("coverage erase", shell=True),
             mocker.call("coverage run -m pytest -p no:randomly tests", shell=True),
             mocker.call("coverage combine", shell=True),
             mocker.call("coverage report", shell=True),
@@ -341,6 +345,7 @@ class TestCoverage:
         assert not result.output
 
         assert env_run.call_args_list == [
+            mocker.call("coverage erase", shell=True),
             mocker.call("coverage run -m pytest -p no:randomly tests", shell=True),
             mocker.call("coverage combine", shell=True),
             mocker.call("coverage report", shell=True),
@@ -809,6 +814,7 @@ class TestCustomScripts:
         assert not result.output
 
         assert env_run.call_args_list == [
+            mocker.call("coverage erase", shell=True),
             mocker.call("test with coverage", shell=True),
             mocker.call("combine coverage", shell=True),
             mocker.call("show coverage", shell=True),


### PR DESCRIPTION
## Summary

- erase stale coverage data before running tests with coverage enabled
- use the patched coverage configuration so custom data-file settings are respected
- preserve custom test scripts and the existing quiet command output

Fixes #1984.

## Validation

- `hatch fmt --check`
- `hatch run types:check src/hatch/cli/test/__init__.py`
- `hatch test --python 3.14 -- tests/cli/test/test_test.py -q` (`34 passed`)
- `hatch test --python 3.14 --cover-quiet` (`2405 passed, 50 skipped`)

## AI assistance disclosure

OpenAI Codex was used extensively for repository analysis, implementation, regression-test updates, and validation.
