### PR TITLE
fix: prevent backward relative paths in readme

### DIFF
--- a/backend/src/hatchling/metadata/core.py
+++ b/backend/src/hatchling/metadata/core.py
@@ -528,6 +528,9 @@ class CoreMetadata:
                     raise TypeError(message)
 
                 readme_path = os.path.normpath(os.path.join(self.root, readme))
+                if os.path.isabs(readme) or os.path.relpath(readme_path, self.root).startswith(".."):
+                    message = f"Readme path must be within the project directory: {readme}"
+                    raise ValueError(message)
                 if not os.path.isfile(readme_path):
                     message = f"Readme file does not exist: {readme}"
                     raise OSError(message)
@@ -565,6 +568,9 @@ class CoreMetadata:
                         raise TypeError(message)
 
                     path = os.path.normpath(os.path.join(self.root, relative_path))
+                    if os.path.isabs(relative_path) or os.path.relpath(path, self.root).startswith(".."):
+                        message = f"Readme path must be within the project directory: {relative_path}"
+                        raise ValueError(message)
                     if not os.path.isfile(path):
                         message = f"Readme file does not exist: {relative_path}"
                         raise OSError(message)


### PR DESCRIPTION
Fixes #2353 

### What this PR does
This PR prevents a directory traversal risk and downstream extraction failures caused by backward relative paths in the `readme` field of `pyproject.toml`. 

Previously, if a user specified `readme = "../README.md"`, Hatchling would silently package the sdist with `../README.md` in the archive's file list. When users attempted to extract this sdist, modern versions of Python's `tarfile` module would raise a security exception (e.g., `tarfile.OutsideDestinationError`), or older versions would risk overwriting files outside the extraction directory.

### How it was fixed
Added security checks in `backend/src/hatchling/metadata/core.py` to validate that the resolved `readme` path resides within the project root. 
- Applies to both the string definition (`readme = "..."`) and the dictionary definition (`readme = {file = "..."}`).
- Uses `os.path.isabs()` and `os.path.relpath().startswith("..")` to detect invalid paths.
- Raises a clear `ValueError` at build time if a violation is detected.

### Manual Testing
Tested locally using `--no-isolation` on a mock project with `readme = "../README.md"`. The build now correctly fails fast before packaging:

```text
ValueError: Readme path must be within the project directory: ../README.md
ERROR Backend subprocess exited when trying to invoke build_sdist