### PR TITLE
Restore SIGINT handling for Hatch child commands

### DIFF
--- a/src/hatch/cli/application.py
+++ b/src/hatch/cli/application.py
@@ -76,14 +76,21 @@ class Application(Terminal):
                 # and aborts even though the child (e.g. a Python REPL) may choose to stay
                 # alive.  The child's exit code is still used to determine success/failure.
                 original_sigint = signal.getsignal(signal.SIGINT)
+
+                def restore_sigint(original_sigint=original_sigint) -> None:
+                    signal.signal(signal.SIGINT, original_sigint)
+
                 try:
                     signal.signal(signal.SIGINT, signal.SIG_IGN)
-                    process = context.env.run_shell_command(command)
+                    kwargs = {}
+                    if os.name != "nt":
+                        kwargs["preexec_fn"] = restore_sigint
+                    process = context.env.run_shell_command(command, **kwargs)
                 finally:
                     # Restore the original handler in finally so the parent stays
                     # responsive to Ctrl-C even if the child raises or is cancelled.
                     # Don't hoist this out of the finally block.
-                    signal.signal(signal.SIGINT, original_sigint)
+                    restore_sigint()
                 sys.stdout.flush()
                 sys.stderr.flush()
                 if process.returncode:

--- a/tests/cli/test_application.py
+++ b/tests/cli/test_application.py
@@ -1,0 +1,41 @@
+import os
+from contextlib import contextmanager
+from subprocess import CompletedProcess
+from unittest.mock import Mock
+
+from hatch.cli.application import Application
+from hatch.utils.runner import ExecutionContext
+
+
+class FakeEnvironment:
+    @contextmanager
+    def command_context(self):
+        yield
+
+    def resolve_commands(self, commands):
+        return commands
+
+    def run_shell_command(self, command, **kwargs):
+        self.command = command
+        self.kwargs = kwargs
+        return CompletedProcess(command, 0)
+
+
+def test_run_shell_commands_restores_sigint_in_child(monkeypatch):
+    environment = FakeEnvironment()
+    context = ExecutionContext(environment, shell_commands=["echo hello"])
+    application = Application(Mock(), verbosity=0, enable_color=False, interactive=False)
+    signal_handler = Mock()
+    monkeypatch.setattr("hatch.cli.application.signal.getsignal", signal_handler)
+    monkeypatch.setattr("hatch.cli.application.signal.signal", signal_handler)
+
+    application.run_shell_commands(context)
+
+    assert environment.command == "echo hello"
+    if os.name != "nt":
+        assert "preexec_fn" in environment.kwargs
+        environment.kwargs["preexec_fn"]()
+        assert signal_handler.call_count == 4
+    else:
+        assert "preexec_fn" not in environment.kwargs
+        assert signal_handler.call_count == 3


### PR DESCRIPTION
## Summary

- restore the parent SIGINT handler in the child process on POSIX platforms before running Hatch shell commands
- keep the Windows path free of the unsupported `preexec_fn` argument
- add regression coverage for the child callback and parent restoration behavior

Hatch temporarily ignores SIGINT in the parent so foreground Ctrl-C is handled by the child command. On POSIX, that ignored handler is inherited by the child; restoring it through `preexec_fn` lets scripts such as development servers exit on Ctrl-C again while preserving the existing parent behavior.

## Validation

- `pytest tests/cli/test_application.py tests/utils/test_platform.py -q` (9 passed, 16 skipped on Windows)
- `ruff check src/hatch/cli/application.py tests/cli/test_application.py`
- `ruff format --check src/hatch/cli/application.py tests/cli/test_application.py`
- `python -m compileall -q src tests`
- `git diff --check`

Fixes #2348
