### PR TITLE
feat: Bump default core metadata to 2.5

### DIFF
--- a/backend/src/hatchling/metadata/spec.py
+++ b/backend/src/hatchling/metadata/spec.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
 
     from hatchling.metadata.core import ProjectMetadata
 
-DEFAULT_METADATA_VERSION = "2.4"
+DEFAULT_METADATA_VERSION = "2.5"
 LATEST_METADATA_VERSION = "2.5"
 CORE_METADATA_PROJECT_FIELDS = {
     "Author": ("authors",),

--- a/docs/history/hatchling.md
+++ b/docs/history/hatchling.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+**Changed***
+
+- Bump default core metadata version to 2.5
+
 ## [1.31.0](https://github.com/pypa/hatch/releases/tag/hatchling-v1.31.0) - 2026-06-30 ## {: #hatchling-v1.31.0 }
 
 ***Fixed***


### PR DESCRIPTION
- [twine 7](https://github.com/pypa/twine/releases/tag/7.0.0) added support for core metadata 2.5
- [gh-action-pypi-publish v1.14.2](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.14.2) bumped twine

In my opinion the ecosystem is close to being ready for making 2.5 the default, hence this ~draft~ PR.