### PR TITLE
Fix generated Pyrefly config on Windows

### DIFF
--- a/src/hatch/cli/types/core.py
+++ b/src/hatch/cli/types/core.py
@@ -56,7 +56,6 @@ class TypeCheckEnvironment:
         - Which platform-specific modules to ignore (ignore-missing-imports)
         """
         lines: list[str] = []
-        root = str(self.env.root)
 
         project_includes = self._detect_project_includes()
         search_paths = self._detect_search_paths()
@@ -64,16 +63,15 @@ class TypeCheckEnvironment:
 
         # Paths must be absolute because the auto-generated config file is stored in an
         # isolated data directory (not the project root), so relative paths would not resolve
-        # to the correct project directories.
+        # to the correct project directories. The POSIX form is used so that the quoted values
+        # contain no backslashes, which TOML would interpret as escape sequences.
         if project_includes:
-            abs_includes = [os.path.join(root, p) for p in project_includes]
-            includes_str = ", ".join(f'"{p}"' for p in abs_includes)
+            includes_str = ", ".join(f'"{(self.env.root / p).as_posix()}"' for p in project_includes)
             # project-includes tells pyrefly which directories contain source files to check
             lines.append(f"project-includes = [{includes_str}]")
 
         if search_paths:
-            abs_paths = [os.path.join(root, p) for p in search_paths]
-            paths_str = ", ".join(f'"{p}"' for p in abs_paths)
+            paths_str = ", ".join(f'"{(self.env.root / p).as_posix()}"' for p in search_paths)
             # search-path tells pyrefly where to resolve imports from (e.g., "src" for src-layout)
             lines.append(f"search-path = [{paths_str}]")
 

--- a/tests/cli/check/test_check_types.py
+++ b/tests/cli/check/test_check_types.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from hatch.config.constants import ConfigEnvVars
+from hatch.utils.toml import load_toml_data
 
 
 class TestDefaults:
@@ -110,6 +111,40 @@ class TestArguments:
         command = env_run.call_args_list[0].args[0]
         assert command.startswith("pyrefly check --config ")
         assert "--foo bar" in command
+
+
+class TestGeneratedConfig:
+    @pytest.mark.usefixtures("env_run")
+    def test_valid_toml_with_absolute_paths(self, hatch, temp_dir, config_file):
+        config_file.model.template.plugins["default"]["tests"] = False
+        config_file.save()
+
+        project_name = "My.App"
+
+        with temp_dir.as_cwd():
+            result = hatch("new", project_name)
+
+        assert result.exit_code == 0, result.output
+
+        project_path = temp_dir / "my-app"
+        data_path = temp_dir / "data"
+        data_path.mkdir()
+
+        with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
+            result = hatch("check", "types")
+
+        assert result.exit_code == 0, result.output
+
+        config_files = list(data_path.rglob("pyrefly.toml"))
+        assert len(config_files) == 1
+
+        # Parsing must succeed even when the project root is an absolute Windows path;
+        # raw backslashes would be invalid TOML escape sequences.
+        config = load_toml_data(config_files[0].read_text())
+        assert config["project-includes"] == [f"{project_path.as_posix()}/src/my_app"]
+        assert config["search-path"] == [f"{project_path.as_posix()}/src"]
+        assert config["preset"] == "legacy"
+        assert config["disable-search-path-heuristics"] is True
 
 
 class TestExistingConfig:


### PR DESCRIPTION
Raw backslashes in file paths were being written directly which are treated as escape characters.