### PR TITLE
feat: generate default .gitignore with `hatch new` (#2229)

### DIFF
--- a/src/hatch/template/files_default.py
+++ b/src/hatch/template/files_default.py
@@ -2,6 +2,18 @@ from hatch.template import File
 from hatch.utils.fs import Path
 
 
+class GitIgnore(File):
+    def __init__(
+        self,
+        template_config: dict,  # noqa: ARG002
+        plugin_config: dict,  # noqa: ARG002
+    ):
+        super().__init__(
+            Path(".gitignore"),
+            "*.py[cod]\n__pycache__/\n.hatch/\ndist/\n",
+        )
+
+
 class PackageRoot(File):
     def __init__(
         self,

--- a/tests/cli/new/test_new.py
+++ b/tests/cli/new/test_new.py
@@ -72,6 +72,7 @@ def test_default(hatch, helpers, temp_dir):
         │       └── __init__.py
         ├── tests
         │   └── __init__.py
+        ├── .gitignore
         ├── LICENSE.txt
         ├── README.md
         └── pyproject.toml
@@ -97,6 +98,7 @@ def test_default_explicit_path(hatch, helpers, temp_dir):
             └── __init__.py
         tests
         └── __init__.py
+        .gitignore
         LICENSE.txt
         README.md
         pyproject.toml
@@ -127,6 +129,7 @@ def test_default_empty_plugins_table(hatch, helpers, config_file, temp_dir):
         │       └── __init__.py
         ├── tests
         │   └── __init__.py
+        ├── .gitignore
         ├── LICENSE.txt
         ├── README.md
         └── pyproject.toml
@@ -158,6 +161,7 @@ def test_default_no_license_cache(hatch, helpers, temp_dir):
         │       └── __init__.py
         ├── tests
         │   └── __init__.py
+        ├── .gitignore
         ├── LICENSE.txt
         ├── README.md
         └── pyproject.toml
@@ -191,6 +195,7 @@ def test_licenses_multiple(hatch, helpers, config_file, temp_dir):
         │       └── __init__.py
         ├── tests
         │   └── __init__.py
+        ├── .gitignore
         ├── README.md
         └── pyproject.toml
         """
@@ -220,6 +225,7 @@ def test_licenses_empty(hatch, helpers, config_file, temp_dir):
         │       └── __init__.py
         ├── tests
         │   └── __init__.py
+        ├── .gitignore
         ├── README.md
         └── pyproject.toml
         """
@@ -253,6 +259,7 @@ def test_projects_urls_space_in_label(hatch, helpers, config_file, temp_dir):
         │       └── __init__.py
         ├── tests
         │   └── __init__.py
+        ├── .gitignore
         ├── LICENSE.txt
         ├── README.md
         └── pyproject.toml
@@ -283,6 +290,7 @@ def test_projects_urls_empty(hatch, helpers, config_file, temp_dir):
         │       └── __init__.py
         ├── tests
         │   └── __init__.py
+        ├── .gitignore
         ├── LICENSE.txt
         ├── README.md
         └── pyproject.toml
@@ -314,6 +322,7 @@ def test_feature_cli(hatch, helpers, temp_dir):
         │       └── __main__.py
         ├── tests
         │   └── __init__.py
+        ├── .gitignore
         ├── LICENSE.txt
         ├── README.md
         └── pyproject.toml
@@ -348,6 +357,7 @@ def test_feature_ci(hatch, helpers, config_file, temp_dir):
         │       └── __init__.py
         ├── tests
         │   └── __init__.py
+        ├── .gitignore
         ├── LICENSE.txt
         ├── README.md
         └── pyproject.toml
@@ -378,6 +388,7 @@ def test_feature_no_src_layout(hatch, helpers, config_file, temp_dir):
         │   └── __init__.py
         ├── tests
         │   └── __init__.py
+        ├── .gitignore
         ├── LICENSE.txt
         ├── README.md
         └── pyproject.toml
@@ -407,6 +418,7 @@ def test_feature_tests_disable(hatch, helpers, config_file, temp_dir):
         │   └── my_app
         │       ├── __about__.py
         │       └── __init__.py
+        ├── .gitignore
         ├── LICENSE.txt
         ├── README.md
         └── pyproject.toml
@@ -451,6 +463,7 @@ def test_interactive(hatch, helpers, temp_dir):
         │       └── __init__.py
         ├── tests
         │   └── __init__.py
+        ├── .gitignore
         ├── LICENSE.txt
         ├── README.md
         └── pyproject.toml
@@ -483,6 +496,7 @@ def test_no_project_name_enables_interactive(hatch, helpers, temp_dir):
         │       └── __init__.py
         ├── tests
         │   └── __init__.py
+        ├── .gitignore
         ├── LICENSE.txt
         ├── README.md
         └── pyproject.toml

--- a/tests/helpers/templates/new/basic.py
+++ b/tests/helpers/templates/new/basic.py
@@ -7,6 +7,10 @@ from ..licenses import MIT
 def get_files(**kwargs):
     return [
         File(
+            Path(".gitignore"),
+            "*.py[cod]\n__pycache__/\n.hatch/\ndist/\n",
+        ),
+        File(
             Path("LICENSE.txt"),
             MIT.replace("<year>", f"{kwargs['year']}-present", 1).replace(
                 "<copyright holders>", f"{kwargs['author']} <{kwargs['email']}>", 1

--- a/tests/helpers/templates/new/default.py
+++ b/tests/helpers/templates/new/default.py
@@ -9,6 +9,10 @@ def get_files(**kwargs):
 
     return [
         File(
+            Path(".gitignore"),
+            "*.py[cod]\n__pycache__/\n.hatch/\ndist/\n",
+        ),
+        File(
             Path("LICENSE.txt"),
             MIT.replace("<year>", f"{kwargs['year']}-present", 1).replace(
                 "<copyright holders>", f"{kwargs['author']} <{kwargs['email']}>", 1

--- a/tests/helpers/templates/new/feature_cli.py
+++ b/tests/helpers/templates/new/feature_cli.py
@@ -7,6 +7,10 @@ from ..licenses import MIT
 def get_files(**kwargs):
     return [
         File(
+            Path(".gitignore"),
+            "*.py[cod]\n__pycache__/\n.hatch/\ndist/\n",
+        ),
+        File(
             Path("LICENSE.txt"),
             MIT.replace("<year>", f"{kwargs['year']}-present", 1).replace(
                 "<copyright holders>", f"{kwargs['author']} <{kwargs['email']}>", 1

--- a/tests/helpers/templates/new/feature_no_src_layout.py
+++ b/tests/helpers/templates/new/feature_no_src_layout.py
@@ -9,6 +9,10 @@ def get_files(**kwargs):
 
     return [
         File(
+            Path(".gitignore"),
+            "*.py[cod]\n__pycache__/\n.hatch/\ndist/\n",
+        ),
+        File(
             Path("LICENSE.txt"),
             MIT.replace("<year>", f"{kwargs['year']}-present", 1).replace(
                 "<copyright holders>", f"{kwargs['author']} <{kwargs['email']}>", 1

--- a/tests/helpers/templates/new/licenses_empty.py
+++ b/tests/helpers/templates/new/licenses_empty.py
@@ -4,6 +4,10 @@ from hatch.utils.fs import Path
 
 def get_files(**kwargs):
     return [
+        File(
+            Path(".gitignore"),
+            "*.py[cod]\n__pycache__/\n.hatch/\ndist/\n",
+        ),
         File(Path("src", kwargs["package_name"], "__init__.py")),
         File(Path("src", kwargs["package_name"], "__about__.py"), '__version__ = "0.0.1"\n'),
         File(Path("tests", "__init__.py")),

--- a/tests/helpers/templates/new/licenses_multiple.py
+++ b/tests/helpers/templates/new/licenses_multiple.py
@@ -6,6 +6,10 @@ from ..licenses import MIT, Apache_2_0
 
 def get_files(**kwargs):
     return [
+        File(
+            Path(".gitignore"),
+            "*.py[cod]\n__pycache__/\n.hatch/\ndist/\n",
+        ),
         File(Path("LICENSES", "Apache-2.0.txt"), Apache_2_0),
         File(
             Path("LICENSES", "MIT.txt"),

--- a/tests/helpers/templates/new/projects_urls_empty.py
+++ b/tests/helpers/templates/new/projects_urls_empty.py
@@ -7,6 +7,10 @@ from ..licenses import MIT
 def get_files(**kwargs):
     return [
         File(
+            Path(".gitignore"),
+            "*.py[cod]\n__pycache__/\n.hatch/\ndist/\n",
+        ),
+        File(
             Path("LICENSE.txt"),
             MIT.replace("<year>", f"{kwargs['year']}-present", 1).replace(
                 "<copyright holders>", f"{kwargs['author']} <{kwargs['email']}>", 1

--- a/tests/helpers/templates/new/projects_urls_space_in_label.py
+++ b/tests/helpers/templates/new/projects_urls_space_in_label.py
@@ -7,6 +7,10 @@ from ..licenses import MIT
 def get_files(**kwargs):
     return [
         File(
+            Path(".gitignore"),
+            "*.py[cod]\n__pycache__/\n.hatch/\ndist/\n",
+        ),
+        File(
             Path("LICENSE.txt"),
             MIT.replace("<year>", f"{kwargs['year']}-present", 1).replace(
                 "<copyright holders>", f"{kwargs['author']} <{kwargs['email']}>", 1


### PR DESCRIPTION
### Summary
Closes #2229

When creating a new project with `hatch new`, Hatch now includes a default `.gitignore` file with standard Python ignore rules (`*.py[cod]`, `__pycache__/`, `.hatch/`, `dist/`).

### Root Cause
`hatch new` did not define a `.gitignore` template file in its default template generator `files_default.py`.

### Solution
1. Added `GitIgnore` file class to `src/hatch/template/files_default.py`.
2. Updated test template helpers and assertions in `tests/cli/new/test_new.py`.

### Testing Performed
Executed pytest suite `pytest tests/cli/new/test_new.py` (20 passed).
