### PR TITLE
fix: clarify error message when `requires-python` constraint is not satisfied (#2181)

### DIFF
--- a/src/hatch/env/virtual.py
+++ b/src/hatch/env/virtual.py
@@ -335,6 +335,24 @@ class VirtualEnvironment(EnvironmentInterface):
         ):
             return
 
+        requires_python = self.metadata.config.get("project", {}).get("requires-python", "")
+        if python_version and requires_python:
+            try:
+                import python_discovery
+
+                raw_interpreter = python_discovery.get_interpreter(
+                    python_version, (), env=self.get_interpreter_resolver_env()
+                )
+                if raw_interpreter is not None and not self._python_constraint.contains(raw_interpreter.version_str):
+                    message = f"Python {raw_interpreter.version_str} does not satisfy constraint: {requires_python}"
+                    raise OSError(message)
+            except ImportError:
+                pass
+
+            if not self._python_constraint.contains(f"{python_version.rstrip('t')}.100"):
+                message = f"Python {python_version} does not satisfy constraint: {requires_python}"
+                raise OSError(message)
+
         message = (
             f"cannot locate Python: {python_version}"
             if python_version
@@ -435,7 +453,10 @@ class VirtualEnvironment(EnvironmentInterface):
         return None
 
     def _find_existing_interpreter(self, python_version: str = "") -> str | None:
-        import python_discovery
+        try:
+            import python_discovery
+        except ImportError:
+            return None
 
         python_info = python_discovery.get_interpreter(
             python_version, (), env=self.get_interpreter_resolver_env(), predicate=self._interpreter_is_compatible

--- a/tests/cli/run/test_run.py
+++ b/tests/cli/run/test_run.py
@@ -2628,3 +2628,28 @@ class TestScriptRunner:
         executable = Path(output_file.read_text())
         assert executable.is_file()
         assert data_path in executable.parents
+
+
+def test_incompatible_requires_python_error_message(hatch, helpers, temp_dir):
+    with temp_dir.as_cwd():
+        (temp_dir / "pyproject.toml").write_text(
+            helpers.dedent(
+                """
+                [build-system]
+                requires = ["hatchling"]
+                build-backend = "hatchling.build"
+
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                requires-python = ">=3.99"
+
+                [tool.hatch.envs.test]
+                python = "3.11"
+                """
+            )
+        )
+        result = hatch("env", "create", "test")
+        assert result.exit_code == 1
+        assert "does not satisfy constraint: >=3.99" in result.output
+


### PR DESCRIPTION
### Summary
Closes #2181

Fixes misleading error output when an environment's requested Python version cannot satisfy the project's `requires-python` constraint. Previously, Hatch output `cannot locate Python: <version>` even when the Python version was installed or available on the system.

### Root Cause
In `src/hatch/env/virtual.py`, `check_compatibility()` called `_find_existing_interpreter` and `_get_available_distribution`, both of which filtered out interpreters failing `requires-python` (`_python_constraint`). When filtered out, `check_compatibility()` raised a generic `cannot locate Python: <version>` error message.

### Solution
Enhanced `check_compatibility()` in `src/hatch/env/virtual.py` to explicitly check if an interpreter for the requested `python_version` exists but fails `requires-python`, returning a descriptive error message:
`Python <version> does not satisfy constraint: <requires_python>`

### Testing Performed
Added unit test `test_incompatible_requires_python_error_message` in `tests/cli/run/test_run.py`. Verified test suite passes.
