### PR TITLE
fix: include `.git/info/exclude` in Hatchling VCS exclusions (#2204)

### DIFF
--- a/backend/src/hatchling/builders/config.py
+++ b/backend/src/hatchling/builders/config.py
@@ -756,6 +756,10 @@ class BuilderConfig:
         if local_gitignore is not None:
             exclusion_files["git"].append(local_gitignore)
 
+        local_git_exclude = locate_file(self.root, os.path.join(".git", "info", "exclude"))
+        if local_git_exclude is not None:
+            exclusion_files["git"].append(local_git_exclude)
+
         local_hgignore = locate_file(self.root, ".hgignore", boundary=".hg")
         if local_hgignore is not None:
             exclusion_files["hg"].append(local_hgignore)

--- a/tests/backend/builders/test_config.py
+++ b/tests/backend/builders/test_config.py
@@ -1840,6 +1840,23 @@ class TestPatternExclude:
             assert not builder.config.exclude_spec.match_file(f"baz{separator}bar{separator}file.py")
 
     @pytest.mark.parametrize("separator", ["/", "\\"])
+    def test_vcs_git_info_exclude(self, temp_dir, separator, platform):
+        if separator == "\\" and not platform.windows:
+            pytest.skip("Not running on Windows")
+
+        git_info_dir = temp_dir / ".git" / "info"
+        git_info_dir.ensure_dir_exists()
+        (git_info_dir / "exclude").write_text("/secret\n*.tmp")
+
+        with temp_dir.as_cwd():
+            config = {"tool": {"hatch": {"build": {"exclude": ["foo"]}}}}
+            builder = MockBuilder(str(temp_dir), config=config)
+
+            assert builder.config.exclude_spec.match_file(f"secret{separator}file.txt")
+            assert builder.config.exclude_spec.match_file(f"bar{separator}file.tmp")
+            assert not builder.config.exclude_spec.match_file(f"bar{separator}file.txt")
+
+    @pytest.mark.parametrize("separator", ["/", "\\"])
     def test_ignore_vcs_git(self, temp_dir, separator, platform):
         if separator == "\\" and not platform.windows:
             pytest.skip("Not running on Windows")


### PR DESCRIPTION
### Summary
Closes #2204

Hatchling's default file exclusion mechanism now checks for and respects ignore patterns specified in `.git/info/exclude` in addition to `.gitignore`.

### Root Cause
In `backend/src/hatchling/builders/config.py`, `vcs_exclusion_files` only checked for `.gitignore` files when locating git VCS ignore rules.

### Solution
Updated `vcs_exclusion_files` property in `backend/src/hatchling/builders/config.py` to check for `.git/info/exclude` via `locate_file` and append it to `exclusion_files['git']`.

### Testing Performed
Added unit test `test_vcs_git_info_exclude` in `tests/backend/builders/test_config.py`. Verified tests pass.
