### PR TITLE
fix: do not prompt for description during non-interactive `hatch new --init` (#2337)

### DIFF
--- a/src/hatch/cli/new/__init__.py
+++ b/src/hatch/cli/new/__init__.py
@@ -25,12 +25,13 @@ def new(app, name, location, interactive, feature_cli, initialize, setuptools_op
 
     migration_possible = False
     if initialize:
-        interactive = True
         location = location or Path.cwd()
         if (location / "setup.py").is_file() or (location / "setup.cfg").is_file():
             migration_possible = True
             if not name:
                 name = "temporary"
+        elif not name and not interactive:
+            name = location.name
 
     if not name:
         if not interactive:

--- a/tests/cli/new/test_new.py
+++ b/tests/cli/new/test_new.py
@@ -505,7 +505,7 @@ def test_initialize_fresh(hatch, helpers, temp_dir):
     assert not project_file.is_file()
 
     with path.as_cwd():
-        result = hatch("new", "--init", input=f"{project_name}\n{description}")
+        result = hatch("new", "--init", "-i", input=f"{project_name}\n{description}")
 
     expected_files = helpers.get_template_files("new.default", project_name, description=description)
     helpers.assert_files(path, expected_files)
@@ -516,6 +516,20 @@ def test_initialize_fresh(hatch, helpers, temp_dir):
         Project name: {project_name}
         Description []: {description}
 
+        Wrote: pyproject.toml
+        """
+    )
+
+
+def test_initialize_non_interactive(hatch, helpers, temp_dir):
+    project_name = "my-app"
+
+    with temp_dir.as_cwd():
+        result = hatch("new", "--init", project_name)
+
+    assert result.exit_code == 0, result.output
+    assert remove_trailing_spaces(result.output) == helpers.dedent(
+        """
         Wrote: pyproject.toml
         """
     )
@@ -546,7 +560,7 @@ path = "o/__init__.py"
     )
 
     with temp_dir.as_cwd():
-        result = hatch("new", "--init", input=f"{project_name}\n{description}")
+        result = hatch("new", "--init", "-i", input=f"{project_name}\n{description}")
 
     assert result.exit_code == 0, result.output
     assert remove_trailing_spaces(result.output) == helpers.dedent(


### PR DESCRIPTION
### Summary
Closes #2337

Fixes issue where running `hatch new --init <name>` in non-interactive mode still prompted the user interactively for a project description (`Description []:`).

### Root Cause
In `src/hatch/cli/new/__init__.py`, `if initialize:` unconditionally forced `interactive = True`, causing `hatch new --init` to always invoke interactive prompts even when `-i`/`--interactive` was not passed.

### Solution
1. Removed `interactive = True` override inside `if initialize:` block in `src/hatch/cli/new/__init__.py`.
2. Defaulted `name` to current directory name (`location.name`) when initializing non-interactively without an explicit project name.
3. Updated tests in `tests/cli/new/test_new.py` and added `test_initialize_non_interactive`.

### Testing Performed
Executed pytest suite `pytest tests/cli/new/test_new.py` (21 passed).
