### PR TITLE
test: Fix test expectations for metadata generated by `flit-core`

### DIFF
--- a/tests/project/test_frontend.py
+++ b/tests/project/test_frontend.py
@@ -1,5 +1,6 @@
 import json
 import sys
+from typing import Any
 
 import pytest
 
@@ -88,11 +89,15 @@ description = "text"
         output = json.loads((output_dir / "output.json").read_text())
         metadata_file = work_dir / output["return_val"] / "METADATA"
 
-        assert project_metadata_from_core_metadata(metadata_file.read_text()) == {
+        expected_metadata: dict[str, Any] = {
             "name": "foo",
             "version": "9000.42",
             "description": "text",
         }
+        if backend_pkg == "flit-core":
+            expected_metadata["import-names"] = ["foo"]
+
+        assert project_metadata_from_core_metadata(metadata_file.read_text()) == expected_metadata
 
     @pytest.mark.parametrize(
         ("backend_pkg", "backend_api"),
@@ -142,11 +147,15 @@ description = "text"
         output = json.loads((output_dir / "output.json").read_text())
         metadata_file = work_dir / output["return_val"] / "METADATA"
 
-        assert project_metadata_from_core_metadata(metadata_file.read_text()) == {
+        expected_metadata: dict[str, Any] = {
             "name": "foo",
             "version": "9000.42",
             "description": "text",
         }
+        if backend_pkg == "flit-core":
+            expected_metadata["import-names"] = ["foo"]
+
+        assert project_metadata_from_core_metadata(metadata_file.read_text()) == expected_metadata
 
 
 class TestBuildWheel:


### PR DESCRIPTION
Flit >=4 creates PEP 794 metadata automatically, so it broke the metadata expectations for the backend.

I wonder if hatchling should similarly try to be clever and create the import names automatically.
