### PR TITLE
docs: document per-environment paths

### DIFF
--- a/docs/config/environment/overview.md
+++ b/docs/config/environment/overview.md
@@ -8,7 +8,18 @@ All environments are defined as sections within the `tool.hatch.envs` table.
 [tool.hatch.envs.<ENV_NAME>]
 ```
 
-The [storage location](../hatch.md#environments) for environments is completely configurable.
+The [global storage location](../hatch.md#environments) for environments is
+configured in Hatch's `config.toml`. To choose the location of a specific
+virtual environment instead, set its `path` option in the project's
+`pyproject.toml`:
+
+```toml config-example
+[tool.hatch.envs.test]
+path = ".venv/test"
+```
+
+Relative paths are resolved from the project root. Absolute paths are also
+supported.
 
 Unless an environment is explicitly selected on the command line, the `default` environment will be used. The [type](#type) of this environment defaults to `virtual`.
 


### PR DESCRIPTION
## Summary

Document the virtual environment `path` option, distinguish it from Hatch's global environment storage setting, and explain relative and absolute path handling.

Fixes #1603.

## Validation

- focused environment creation tests for relative and absolute configured paths: 2 passed
- MkDocs build
- `git diff --check`

The strict social-card build remains unavailable in this Windows environment because of the existing native Cairo dependency.

## AI assistance

Codex (GPT-5) assisted with tracing the path behavior and drafting the documentation. I manually reviewed the final diff and verified the wording against the implementation and focused tests.