### PR TITLE
docs: clarify system separator fields

### DIFF
--- a/docs/config/context.md
+++ b/docs/config/context.md
@@ -35,10 +35,17 @@ All paths support the following modifiers:
 
 ### System separators
 
+Use these fields by enclosing the separator character in braces. Hatch replaces
+only the context fields; literal `/` and `;` characters are left unchanged.
+
 | Field | Description |
 | --- | --- |
-| `/` | `\` on Windows, `/` otherwise |
-| `;` | `;` on Windows, `:` otherwise |
+| `{/}` | `\` on Windows, `/` otherwise |
+| `{;}` | `;` on Windows, `:` otherwise |
+
+For example, `data{/}generated` expands to `data\generated` on Windows and
+`data/generated` otherwise, while `src{;}tests` expands to `src;tests` on
+Windows and `src:tests` otherwise.
 
 ### Environment variables
 


### PR DESCRIPTION
## Summary

Clarify that Hatch's system separator context fields must be written as `{/}` and `{;}`, that literal separator characters are unchanged, and show their platform-specific expansions.

Fixes #2026.

## Validation

- focused `Context` tests for directory and path separators: 2 passed
- MkDocs build
- `git diff --check`

The strict social-card build remains unavailable in this Windows environment because of the existing native Cairo dependency.

## AI assistance

Codex (GPT-5) assisted with drafting the documentation. I manually reviewed the final diff and verified the examples against Hatch's existing context formatter tests.