### PR TITLE
fix: preserve local projects in locked uv environments

### DIFF
--- a/src/hatch/env/virtual.py
+++ b/src/hatch/env/virtual.py
@@ -251,18 +251,29 @@ class VirtualEnvironment(EnvironmentInterface):
 
                 lockfile_path = resolve_lockfile_path(self)
                 if lockfile_path.is_file():
-                    workspace_install_args = []
-                    for dep in workspace_deps:
-                        if dep.editable:
-                            workspace_install_args.extend(["--editable", dep.path])
+                    local_install_args = []
+                    if not self.skip_install:
+                        if self.dev_mode:
+                            local_install_args.extend(["--editable", self.root])
                         else:
-                            workspace_install_args.append(dep.path)
+                            local_install_args.append(self.root)
 
-                    if workspace_install_args:
-                        all_install_args = list(self.get_source_install_args(self.all_dependencies_complex))
-                        all_install_args.extend(workspace_install_args)
-                        self.platform.check_command(self.construct_pip_install_command(all_install_args))
+                    for dep in workspace_deps:
+                        # The root project is installed separately during environment creation.
+                        if dep.path == self.root:
+                            continue
+
+                        if dep.editable:
+                            local_install_args.extend(["--editable", dep.path])
+                        else:
+                            local_install_args.append(dep.path)
+
                     apply_lock_with_locker(self, lockfile_path)
+                    # Exact sync removes local packages that are not represented in the lockfile.
+                    if local_install_args:
+                        self.platform.check_command(
+                            self.construct_pip_install_command(["--no-deps", *local_install_args])
+                        )
                     return
 
             # If we do not have missing dependencies we should not sync

--- a/src/hatch/env/virtual.py
+++ b/src/hatch/env/virtual.py
@@ -251,12 +251,12 @@ class VirtualEnvironment(EnvironmentInterface):
 
                 lockfile_path = resolve_lockfile_path(self)
                 if lockfile_path.is_file():
-                    local_install_args = []
+                    workspace_install_args = []
                     if not self.skip_install:
                         if self.dev_mode:
-                            local_install_args.extend(["--editable", self.root])
+                            workspace_install_args.extend(["--editable", self.root])
                         else:
-                            local_install_args.append(self.root)
+                            workspace_install_args.append(self.root)
 
                     for dep in workspace_deps:
                         # The root project is installed separately during environment creation.
@@ -264,15 +264,15 @@ class VirtualEnvironment(EnvironmentInterface):
                             continue
 
                         if dep.editable:
-                            local_install_args.extend(["--editable", dep.path])
+                            workspace_install_args.extend(["--editable", dep.path])
                         else:
-                            local_install_args.append(dep.path)
+                            workspace_install_args.append(dep.path)
 
                     apply_lock_with_locker(self, lockfile_path)
                     # Exact sync removes local packages that are not represented in the lockfile.
-                    if local_install_args:
+                    if workspace_install_args:
                         self.platform.check_command(
-                            self.construct_pip_install_command(["--no-deps", *local_install_args])
+                            self.construct_pip_install_command(["--no-deps", *workspace_install_args])
                         )
                     return
 

--- a/tests/env/test_virtual.py
+++ b/tests/env/test_virtual.py
@@ -1,0 +1,60 @@
+from contextlib import nullcontext
+
+from hatch.env.virtual import VirtualEnvironment
+from hatch.project.core import Project
+
+
+def test_locked_sync_installs_local_project_after_applying_lock(
+    temp_dir, isolated_data_dir, platform, temp_application, mocker
+):
+    config = {
+        "project": {"name": "my-app", "version": "0.0.1"},
+        "tool": {
+            "hatch": {
+                "envs": {
+                    "default": {
+                        "installer": "uv",
+                        "locked": True,
+                        "skip-install": False,
+                        "dev-mode": True,
+                    }
+                }
+            }
+        },
+    }
+    project = Project(temp_dir, config=config)
+    project.set_app(temp_application)
+    temp_application.project = project
+    environment = VirtualEnvironment(
+        temp_dir,
+        project.metadata,
+        "default",
+        project.config.envs["default"],
+        {},
+        isolated_data_dir,
+        isolated_data_dir,
+        platform,
+        0,
+        temp_application,
+    )
+    assert not environment.workspace.members
+
+    (temp_dir / "pylock.toml").write_text("lock-version = 1\n", encoding="utf-8")
+
+    events = []
+    mocker.patch.object(environment, "safe_activation", return_value=nullcontext())
+    mocker.patch.object(
+        platform,
+        "check_command",
+        side_effect=lambda command: events.append(("install", command)),
+    )
+    mocker.patch(
+        "hatch.env.lock.apply_lock_with_locker",
+        side_effect=lambda *_args: events.append(("lock", None)),
+    )
+
+    environment.sync_dependencies()
+
+    assert [event for event, _ in events] == ["lock", "install"]
+    install_command = events[1][1]
+    assert install_command[-3:] == ["--no-deps", "--editable", temp_dir]


### PR DESCRIPTION
Closes #2372

## Summary

- apply the lock before restoring local project and workspace packages
- reinstall local packages with `--no-deps` so the lock remains authoritative
- add a deterministic regression test for the sync/install order and command

## Why

`uv pip sync` removes packages that are not represented in the lockfile. Hatch currently installs the editable project first and then syncs the lock, so the project disappears from the environment. Restoring local packages after the exact sync preserves both the editable install and locked third-party versions.

## Validation

- regression test fails on the unchanged base (`install -> lock`) and passes with this patch (`lock -> install --no-deps`)
- `hatch test tests/env/test_virtual.py`
- `hatch test tests/cli/env/test_create.py -k test_sync_dependencies_uv`
- `hatch run types:check src/hatch/env/virtual.py tests/env/test_virtual.py`
- targeted Ruff check and format check
- full suite reached 2,418 passed / 20 skipped; 22 publish-test setup errors were caused by the local Docker daemon being unavailable, and the remaining slow tail was interrupted after 93%
- repository-wide `hatch check` currently reports 545 pre-existing latest-Ruff/docstring violations; neither changed file reports a violation

## AI assistance

I used OpenAI Codex to inspect the implementation, draft the focused patch and regression test, and run validation. I reviewed the final diff and understand how the post-lock `--no-deps` install preserves local packages without changing locked dependencies.
