### PR TITLE
fix: expand recursive extras manually, normalize extra names

### DIFF
--- a/docs/history/hatch.md
+++ b/docs/history/hatch.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Fixed:***
+
+- Expand extras of local dependencies transitively, so an extra that references another extra of the same project or of a sibling workspace member (e.g. `pkg[a]` where `a = ["pkg[b]"]`) no longer drops the referenced dependencies
+- Match project and extra names of local dependencies by their normalized form, so e.g. `my_app[test]` resolves against a project named `my-app`
+- Warn rather than silently expand to nothing when a local dependency refers to an extra the project does not define
+
 ## [1.18.0](https://github.com/pypa/hatch/releases/tag/hatch-v1.18.0) - 2026-08-11 ## {: #hatch-v1.18.0 }
 
 ***Changed:***

--- a/src/hatch/env/plugin/interface.py
+++ b/src/hatch/env/plugin/interface.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import sys
 from abc import ABC, abstractmethod
+from collections import deque
 from contextlib import contextmanager
 from functools import cached_property
 from os.path import isabs
@@ -471,32 +472,51 @@ class EnvironmentInterface(ABC):
     @cached_property
     def all_dependencies_complex(self) -> list[Dependency]:
         from hatch.dep.core import Dependency
+        from hatch.utils.metadata import normalize_project_name
 
         local_deps = list(self.local_dependencies_complex)
 
-        # Map each locally-resolved package name to the project that owns its optional-dependencies,
-        # so extras on `<pkg>[extra]` deps are expanded using the *referenced* project's own dependency
-        # resolution. `Project.get_dependencies` only evaluates metadata/version hooks (in that project's
-        # own build environment) when the relevant fields are actually dynamic, avoiding both dropped
-        # extras and spurious plugin errors from evaluating hooks in the wrong environment.
+        # Expand extras on `<pkg>[extra]` deps using the *referenced* project's own dependency resolution.
+        # ProjectMetadata and WorkspaceMember names are already normalized.
         local_projects: dict[str, Project] = {}
         if not self.skip_install:
-            local_projects[self.metadata.name.lower()] = self.app.project
+            local_projects[self.metadata.name] = self.app.project
         for member in self.workspace.members:
-            local_projects[member.name.lower()] = member.project
+            local_projects[member.name] = member.project
 
+        features: dict[str, dict[str, list[str]]] = {}  # project name -> extra -> dependencies
+        seen: set[tuple[str, str]] = set()  # allows handling cyclic extras
         filtered_deps: list[Dependency] = []
-        for dep in self.dependencies_complex:
-            dep_obj = dep if isinstance(dep, Dependency) else Dependency(str(dep))
+        queue = deque(self.dependencies_complex)
+        while queue:
+            dep = queue.popleft()
 
-            name_lower = dep_obj.name.lower()
-            if name_lower in local_projects and dep_obj.extras:
-                _, optional_dependencies = local_projects[name_lower].get_dependencies()
-                for extra in dep_obj.extras:
-                    if extra in optional_dependencies:
-                        filtered_deps.extend(Dependency(d) for d in optional_dependencies[extra])
-            elif name_lower not in local_projects:
-                filtered_deps.append(dep_obj)
+            # Names from `dependencies_complex` are not normalized yet
+            name = normalize_project_name(dep.name)
+            if name not in local_projects:
+                filtered_deps.append(dep)
+                continue
+            if not dep.extras:
+                continue
+
+            if name not in features:
+                optional_dependencies = dict(local_projects[name].get_dependencies()[1])
+                # Also index by normalized (PEP 685) extra name, but never overwrite one as written:
+                # `allow-ambiguous-features` permits `Feature_A` and `feature-a` side by side
+                for option, dependencies in list(optional_dependencies.items()):
+                    optional_dependencies.setdefault(normalize_project_name(option), dependencies)
+                features[name] = optional_dependencies
+
+            for extra in sorted(dep.extras):  # sorted for reproducible ordering
+                option = extra if extra in features[name] else normalize_project_name(extra)
+                if option not in features[name]:
+                    self.app.display_warning(
+                        f"Dependency `{dep}` of environment `{self.name}` refers to extra `{extra}`, "
+                        f"which local project `{name}` does not define"
+                    )
+                elif (name, option) not in seen:
+                    seen.add((name, option))
+                    queue.extend(Dependency(d) for d in features[name][option])
 
         return local_deps + filtered_deps
 

--- a/tests/env/plugin/test_interface.py
+++ b/tests/env/plugin/test_interface.py
@@ -1749,6 +1749,242 @@ test = ["member-test-dep"]
         # unresolvable metadata hook in its own process
         assert any("pytest" in dep.lower() for dep in all_deps_str)
 
+    def test_self_referencing_dependency_with_recursive_extras(
+        self, temp_dir, isolated_data_dir, platform, global_application
+    ):
+        """An extra that references another extra of the same project must be expanded transitively.
+
+        Note that hatchling rejects a cyclic chain like this one outright, so the cycle here only asserts
+        that expansion terminates, not that such a project is otherwise valid.
+        """
+        project_dir = temp_dir / "my-app"
+        project_dir.mkdir()
+
+        config = {
+            "project": {
+                "name": "my-app",
+                "version": "0.0.1",
+                "dependencies": [],
+                "optional-dependencies": {
+                    "all": ["my-app[test]", "direct-dep"],
+                    "test": ["my-app[cycle]", "pytest>=7.0"],
+                    "cycle": ["my-app[all]", "cycle-dep"],
+                },
+            },
+            "tool": {"hatch": {"envs": {"dev": {"skip-install": False, "dependencies": ["my-app[all]"]}}}},
+        }
+
+        project = Project(project_dir, config=config)
+        global_application.project = project
+
+        environment = MockEnvironment(
+            project_dir,
+            project.metadata,
+            "dev",
+            project.config.envs["dev"],
+            {},
+            isolated_data_dir,
+            isolated_data_dir,
+            platform,
+            0,
+            global_application,
+        )
+
+        all_deps_str = [str(d) for d in environment.all_dependencies_complex]
+
+        assert "direct-dep" in all_deps_str
+        assert "pytest>=7.0" in all_deps_str
+        assert "cycle-dep" in all_deps_str
+        # No unexpanded self-references may be handed to the installer
+        assert not any(dep.startswith("my-app[") for dep in all_deps_str)
+
+    def test_self_referencing_dependency_with_unnormalized_names(
+        self, temp_dir, isolated_data_dir, platform, global_application
+    ):
+        """Project and extra names must be matched in their normalized (PEP 503/685) form."""
+        project_dir = temp_dir / "my-app"
+        project_dir.mkdir()
+
+        config = {
+            "project": {
+                "name": "My.App",
+                "version": "0.0.1",
+                "dependencies": [],
+                "optional-dependencies": {
+                    "all": ["My_App[Test_Extra]"],
+                    "test.extra": ["pytest>=7.0"],
+                },
+            },
+            "tool": {"hatch": {"envs": {"dev": {"skip-install": False, "dependencies": ["my_app[ALL]"]}}}},
+        }
+
+        project = Project(project_dir, config=config)
+        global_application.project = project
+
+        environment = MockEnvironment(
+            project_dir,
+            project.metadata,
+            "dev",
+            project.config.envs["dev"],
+            {},
+            isolated_data_dir,
+            isolated_data_dir,
+            platform,
+            0,
+            global_application,
+        )
+
+        all_deps_str = [str(d) for d in environment.all_dependencies_complex]
+
+        assert "pytest>=7.0" in all_deps_str
+        assert not any("my" in dep.lower() and "[" in dep for dep in all_deps_str)
+
+    def test_self_referencing_dependency_with_ambiguous_extras(
+        self, temp_dir, isolated_data_dir, platform, global_application
+    ):
+        """With `allow-ambiguous-features`, an extra as written must win over a normalized alias.
+
+        `Feature_A` normalizes to `feature-a`, which is itself a distinct extra here.
+        """
+        project_dir = temp_dir / "my-app"
+        project_dir.mkdir()
+
+        config = {
+            "project": {
+                "name": "my-app",
+                "version": "0.0.1",
+                "dependencies": [],
+                # Declared in this order so that a plain assignment instead of `setdefault` would
+                # clobber `feature-a` rather than coincidentally restore it
+                "optional-dependencies": {"feature-a": ["dep-lower"], "Feature_A": ["dep-upper"]},
+            },
+            "tool": {
+                "hatch": {
+                    "metadata": {"allow-ambiguous-features": True},
+                    "envs": {"dev": {"skip-install": False, "dependencies": ["my-app[feature-a]"]}},
+                }
+            },
+        }
+
+        project = Project(project_dir, config=config)
+        global_application.project = project
+
+        environment = MockEnvironment(
+            project_dir,
+            project.metadata,
+            "dev",
+            project.config.envs["dev"],
+            {},
+            isolated_data_dir,
+            isolated_data_dir,
+            platform,
+            0,
+            global_application,
+        )
+
+        all_deps_str = [str(d) for d in environment.all_dependencies_complex]
+
+        assert "dep-lower" in all_deps_str
+        assert "dep-upper" not in all_deps_str
+
+    def test_workspace_member_extra_referencing_sibling_member(
+        self, temp_dir, isolated_data_dir, platform, temp_application
+    ):
+        """An extra of one workspace member may reference an extra of another member."""
+        for name, optional_dependencies in (
+            ("member-a", '[project.optional-dependencies]\nall = ["member-b[test]"]'),
+            ("member-b", '[project.optional-dependencies]\ntest = ["member-b-test-dep"]'),
+        ):
+            member_file = temp_dir / name / "pyproject.toml"
+            member_file.parent.mkdir()
+            member_file.write_text(
+                f"""\
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "{name}"
+version = "0.0.1"
+dependencies = []
+
+{optional_dependencies}
+"""
+            )
+
+        config = {
+            "project": {"name": "my-app", "version": "0.0.1", "dependencies": []},
+            "tool": {
+                "hatch": {
+                    "envs": {
+                        "default": {
+                            "skip-install": False,
+                            "dependencies": ["member-a[all]"],
+                            "workspace": {"members": [{"path": "member-a"}, {"path": "member-b"}]},
+                        },
+                    },
+                },
+            },
+        }
+
+        project = Project(temp_dir, config=config)
+        project.set_app(temp_application)
+        temp_application.project = project
+        environment = MockEnvironment(
+            temp_dir,
+            project.metadata,
+            "default",
+            project.config.envs["default"],
+            {},
+            isolated_data_dir,
+            isolated_data_dir,
+            platform,
+            0,
+            temp_application,
+        )
+
+        all_deps_str = [str(d) for d in environment.all_dependencies_complex]
+
+        # `member-a[all]` -> `member-b[test]` -> `member-b-test-dep`
+        assert "member-b-test-dep" in all_deps_str
+        assert not any(dep.startswith("member-") and "[" in dep for dep in all_deps_str)
+
+    def test_self_referencing_dependency_with_unknown_extra_warns(
+        self, temp_dir, isolated_data_dir, platform, global_application, capsys
+    ):
+        """An extra the local project does not define must not vanish silently."""
+        project_dir = temp_dir / "my-app"
+        project_dir.mkdir()
+
+        config = {
+            "project": {
+                "name": "my-app",
+                "version": "0.0.1",
+                "dependencies": [],
+                "optional-dependencies": {"test": ["pytest>=7.0"]},
+            },
+            "tool": {"hatch": {"envs": {"dev": {"skip-install": False, "dependencies": ["my-app[tset]"]}}}},
+        }
+
+        project = Project(project_dir, config=config)
+        global_application.project = project
+
+        environment = MockEnvironment(
+            project_dir,
+            project.metadata,
+            "dev",
+            project.config.envs["dev"],
+            {},
+            isolated_data_dir,
+            isolated_data_dir,
+            platform,
+            0,
+            global_application,
+        )
+
+        assert not any("pytest" in str(d) for d in environment.all_dependencies_complex)
+        assert "refers to extra `tset`, which local project `my-app` does not define" in capsys.readouterr().err
+
     def test_dev_mode_true_returns_editable(self, temp_dir, isolated_data_dir, platform, temp_application):
         """Verify dev-mode=true creates editable local dependency."""
         # Create a pyproject.toml file so skip_install defaults to False


### PR DESCRIPTION
I’m tired. Complete whack-a-mole …

This once again fixes regressions caused by a previous fix (this time both are mine).

It also fixes a latent bug around extra name normalization.

----

This is *still* not the ideal state. For that, we could resolve in `Project.get_dependencies()`, so Hatch has exactly one place that turns raw `optional-dependencies` into resolved ones, and `all_dependencies_complex` just consumes it. There are a bunch of callers though, so we shouldn’t do it as part of this bugfix.