### PR TITLE
Lazy import of commands startup perf

### DIFF
--- a/src/hatch/cli/__init__.py
+++ b/src/hatch/cli/__init__.py
@@ -6,33 +6,36 @@ from typing import cast
 import click
 
 from hatch._version import __version__
-from hatch.cli.application import Application
-from hatch.cli.build import build
-from hatch.cli.check import check
-from hatch.cli.clean import clean
-from hatch.cli.config import config
-from hatch.cli.dep import dep
-from hatch.cli.env import env
-from hatch.cli.fmt import fmt
-from hatch.cli.lock_cmd import lock_command
-from hatch.cli.new import new
-from hatch.cli.project import project
-from hatch.cli.publish import publish
-from hatch.cli.python import python
-from hatch.cli.run import run
-from hatch.cli.self import self_command
-from hatch.cli.shell import shell
-from hatch.cli.status import status
-from hatch.cli.test import test
-from hatch.cli.version import version
+from hatch.cli.lazy import LazyGroup
 from hatch.config.constants import AppEnvVars, ConfigEnvVars
-from hatch.project.core import Project
 from hatch.utils.ci import running_in_ci
 from hatch.utils.fs import Path
 
+_LAZY_SUBCOMMANDS = {
+    "build": "hatch.cli.build:build",
+    "check": "hatch.cli.check:check",
+    "clean": "hatch.cli.clean:clean",
+    "config": "hatch.cli.config:config",
+    "dep": "hatch.cli.dep:dep",
+    "env": "hatch.cli.env:env",
+    "fmt": "hatch.cli.fmt:fmt",
+    "lock": "hatch.cli.lock_cmd:lock_command",
+    "new": "hatch.cli.new:new",
+    "project": "hatch.cli.project:project",
+    "publish": "hatch.cli.publish:publish",
+    "python": "hatch.cli.python:python",
+    "run": "hatch.cli.run:run",
+    "shell": "hatch.cli.shell:shell",
+    "status": "hatch.cli.status:status",
+    "test": "hatch.cli.test:test",
+    "version": "hatch.cli.version:version",
+}
 
 @click.group(
-    context_settings={"help_option_names": ["-h", "--help"], "max_content_width": 120}, invoke_without_command=True
+    cls=LazyGroup,
+    lazy_subcommands=_LAZY_SUBCOMMANDS,
+    context_settings={"help_option_names": ["-h", "--help"], "max_content_width": 120},
+    invoke_without_command=True,
 )
 @click.option(
     "--env",
@@ -124,7 +127,11 @@ def hatch(
     if interactive is None and running_in_ci():
         interactive = False
 
+    from hatch.cli.application import Application
+    from hatch.project.core import Project
+
     app = Application(ctx.exit, verbosity=verbose - quiet, enable_color=color, interactive=interactive)
+
     app.env_active = os.environ.get(AppEnvVars.ENV_ACTIVE)
     if (
         app.env_active
@@ -218,25 +225,8 @@ def hatch(
         return
 
 
-hatch.add_command(build)
-hatch.add_command(check)
-hatch.add_command(clean)
-hatch.add_command(config)
-hatch.add_command(dep)
-hatch.add_command(env)
-hatch.add_command(fmt)
-hatch.add_command(lock_command)
-hatch.add_command(new)
-hatch.add_command(project)
-hatch.add_command(publish)
-hatch.add_command(python)
-hatch.add_command(run)
+from hatch.cli.self import self_command
 hatch.add_command(self_command)
-hatch.add_command(shell)
-hatch.add_command(status)
-hatch.add_command(test)
-hatch.add_command(version)
-
 
 def main():  # no cov
     try:

--- a/src/hatch/cli/__init__.py
+++ b/src/hatch/cli/__init__.py
@@ -7,6 +7,7 @@ import click
 
 from hatch._version import __version__
 from hatch.cli.lazy import LazyGroup
+from hatch.cli.self import self_command
 from hatch.config.constants import AppEnvVars, ConfigEnvVars
 from hatch.utils.ci import running_in_ci
 from hatch.utils.fs import Path
@@ -225,7 +226,6 @@ def hatch(
         return
 
 
-from hatch.cli.self import self_command
 hatch.add_command(self_command)
 
 def main():  # no cov

--- a/src/hatch/cli/__init__.py
+++ b/src/hatch/cli/__init__.py
@@ -32,6 +32,7 @@ _LAZY_SUBCOMMANDS = {
     "version": "hatch.cli.version:version",
 }
 
+
 @click.group(
     cls=LazyGroup,
     lazy_subcommands=_LAZY_SUBCOMMANDS,
@@ -227,6 +228,7 @@ def hatch(
 
 
 hatch.add_command(self_command)
+
 
 def main():  # no cov
     try:

--- a/src/hatch/cli/check/__init__.py
+++ b/src/hatch/cli/check/__init__.py
@@ -10,6 +10,7 @@ _LAZY_SUBCOMMANDS = {
     "types": "hatch.cli.check.types:types",
 }
 
+
 @click.group(
     cls=LazyGroup,
     lazy_subcommands=_LAZY_SUBCOMMANDS,
@@ -17,7 +18,6 @@ _LAZY_SUBCOMMANDS = {
     invoke_without_command=True,
     short_help="Check source code",
 )
-
 @click.option("--fix", is_flag=True, help="Fix issues rather than just reporting them")
 @click.pass_context
 def check(ctx: click.Context, *, fix: bool):

--- a/src/hatch/cli/check/__init__.py
+++ b/src/hatch/cli/check/__init__.py
@@ -35,4 +35,3 @@ def check(ctx: click.Context, *, fix: bool):
     ctx.invoke(code, fix=fix)
     ctx.invoke(fmt, fix=fix)
     ctx.invoke(types)
-

--- a/src/hatch/cli/check/__init__.py
+++ b/src/hatch/cli/check/__init__.py
@@ -2,12 +2,22 @@ from __future__ import annotations
 
 import click
 
-from hatch.cli.check.code import code
-from hatch.cli.check.fmt import fmt
-from hatch.cli.check.types import types
+from hatch.cli.lazy import LazyGroup
 
+_LAZY_SUBCOMMANDS = {
+    "code": "hatch.cli.check.code:code",
+    "fmt": "hatch.cli.check.fmt:fmt",
+    "types": "hatch.cli.check.types:types",
+}
 
-@click.group(short_help="Check source code", invoke_without_command=True)
+@click.group(
+    cls=LazyGroup,
+    lazy_subcommands=_LAZY_SUBCOMMANDS,
+    context_settings={"help_option_names": ["-h", "--help"], "max_content_width": 120},
+    invoke_without_command=True,
+    short_help="Check source code",
+)
+
 @click.option("--fix", is_flag=True, help="Fix issues rather than just reporting them")
 @click.pass_context
 def check(ctx: click.Context, *, fix: bool):
@@ -18,11 +28,11 @@ def check(ctx: click.Context, *, fix: bool):
     if ctx.invoked_subcommand is not None:
         return
 
+    from hatch.cli.check.code import code
+    from hatch.cli.check.fmt import fmt
+    from hatch.cli.check.types import types
+
     ctx.invoke(code, fix=fix)
     ctx.invoke(fmt, fix=fix)
     ctx.invoke(types)
 
-
-check.add_command(code)
-check.add_command(fmt)
-check.add_command(types)

--- a/src/hatch/cli/env/__init__.py
+++ b/src/hatch/cli/env/__init__.py
@@ -20,4 +20,3 @@ _LAZY_SUBCOMMANDS = {
 )
 def env():
     pass
-

--- a/src/hatch/cli/env/__init__.py
+++ b/src/hatch/cli/env/__init__.py
@@ -12,6 +12,7 @@ _LAZY_SUBCOMMANDS = {
     "show": "hatch.cli.env.show:show",
 }
 
+
 @click.group(
     cls=LazyGroup,
     lazy_subcommands=_LAZY_SUBCOMMANDS,

--- a/src/hatch/cli/env/__init__.py
+++ b/src/hatch/cli/env/__init__.py
@@ -1,23 +1,23 @@
 import click
 
-from hatch.cli.env.create import create
-from hatch.cli.env.find import find
-from hatch.cli.env.lock import lock
-from hatch.cli.env.prune import prune
-from hatch.cli.env.remove import remove
-from hatch.cli.env.run import run
-from hatch.cli.env.show import show
+from hatch.cli.lazy import LazyGroup
 
+_LAZY_SUBCOMMANDS = {
+    "create": "hatch.cli.env.create:create",
+    "find": "hatch.cli.env.find:find",
+    "lock": "hatch.cli.env.lock:lock",
+    "prune": "hatch.cli.env.prune:prune",
+    "remove": "hatch.cli.env.remove:remove",
+    "run": "hatch.cli.env.run:run",
+    "show": "hatch.cli.env.show:show",
+}
 
-@click.group(short_help="Manage project environments")
+@click.group(
+    cls=LazyGroup,
+    lazy_subcommands=_LAZY_SUBCOMMANDS,
+    context_settings={"help_option_names": ["-h", "--help"], "max_content_width": 120},
+    invoke_without_command=True,
+)
 def env():
     pass
 
-
-env.add_command(create)
-env.add_command(find)
-env.add_command(lock)
-env.add_command(prune)
-env.add_command(remove)
-env.add_command(run)
-env.add_command(show)

--- a/src/hatch/cli/lazy.py
+++ b/src/hatch/cli/lazy.py
@@ -22,7 +22,7 @@ class LazyGroup(click.Group):
         eager = super().list_commands(ctx)
         return sorted(set(eager) | set(self._lazy_subcommands))
 
-    def get_command(self, ctx: click.Context, cmd_name: str) -> click.BaseCommand | None:
+    def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
         # Check eagerly-registered commands first
         if cmd := super().get_command(ctx, cmd_name):
             return cmd

--- a/src/hatch/cli/lazy.py
+++ b/src/hatch/cli/lazy.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+class LazyGroup(click.Group):
+    """A click Group that defers subcommand imports until invocation time.
+
+    Commands are registered as dotted import paths (e.g. "hatch.cli.build:build")
+    and only imported when actually invoked or when help listing forces enumeration.
+    """
+
+    def __init__(self, *args, lazy_subcommands: dict[str, str] | None = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Map of command-name -> "module.path:attribute"
+        self._lazy_subcommands: dict[str, str] = lazy_subcommands or {}
+
+    def list_commands(self, ctx: click.Context) -> list[str]:
+        # Merge eagerly-added commands with lazy ones, sorted
+        eager = super().list_commands(ctx)
+        return sorted(set(eager) | set(self._lazy_subcommands))
+
+    def get_command(self, ctx: click.Context, cmd_name: str) -> click.BaseCommand | None:
+        # Check eagerly-registered commands first
+        if cmd := super().get_command(ctx, cmd_name):
+            return cmd
+
+        if cmd_name not in self._lazy_subcommands:
+            return None
+
+        # Import on demand
+        import_path = self._lazy_subcommands[cmd_name]
+        module_path, attr_name = import_path.rsplit(":", 1)
+        module = importlib.import_module(module_path)
+        cmd = getattr(module, attr_name)
+
+        # Cache it so subsequent calls don't re-import
+        self.add_command(cmd, cmd_name)
+        return cmd

--- a/src/hatch/cli/lazy.py
+++ b/src/hatch/cli/lazy.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
 import importlib
-from typing import TYPE_CHECKING
 
 import click
 
-if TYPE_CHECKING:
-    from collections.abc import Sequence
 
 class LazyGroup(click.Group):
     """A click Group that defers subcommand imports until invocation time.

--- a/src/hatch/cli/python/__init__.py
+++ b/src/hatch/cli/python/__init__.py
@@ -1,6 +1,5 @@
 import click
 
-
 from hatch.cli.lazy import LazyGroup
 
 _LAZY_SUBCOMMANDS = {
@@ -20,4 +19,3 @@ _LAZY_SUBCOMMANDS = {
 )
 def python():
     pass
-

--- a/src/hatch/cli/python/__init__.py
+++ b/src/hatch/cli/python/__init__.py
@@ -1,19 +1,23 @@
 import click
 
-from hatch.cli.python.find import find
-from hatch.cli.python.install import install
-from hatch.cli.python.remove import remove
-from hatch.cli.python.show import show
-from hatch.cli.python.update import update
 
+from hatch.cli.lazy import LazyGroup
 
-@click.group(short_help="Manage Python installations")
+_LAZY_SUBCOMMANDS = {
+    "find": "hatch.cli.python.find:find",
+    "install": "hatch.cli.python.install:install",
+    "update": "hatch.cli.python.update:update",
+    "remove": "hatch.cli.python.remove:remove",
+    "show": "hatch.cli.python.show:show",
+}
+
+@click.group(
+    cls=LazyGroup,
+    lazy_subcommands=_LAZY_SUBCOMMANDS,
+    context_settings={"help_option_names": ["-h", "--help"], "max_content_width": 120},
+    invoke_without_command=True,
+    short_help="Manage Python installations",
+)
 def python():
     pass
 
-
-python.add_command(find)
-python.add_command(install)
-python.add_command(remove)
-python.add_command(show)
-python.add_command(update)

--- a/src/hatch/cli/python/__init__.py
+++ b/src/hatch/cli/python/__init__.py
@@ -10,6 +10,7 @@ _LAZY_SUBCOMMANDS = {
     "show": "hatch.cli.python.show:show",
 }
 
+
 @click.group(
     cls=LazyGroup,
     lazy_subcommands=_LAZY_SUBCOMMANDS,


### PR DESCRIPTION
Use a LazyGroup pattern to reduce overhead at startup for hatch. 


Metric | Before (hatch 1.18.0) | After (LazyGroup) | Improvement
-- | -- | -- | --
--version mean | 94.6 ms | 52.2 ms | 1.8x faster

