### PR TITLE
Preserve original version strings in core metadata

### DIFF
--- a/backend/src/hatchling/metadata/core.py
+++ b/backend/src/hatchling/metadata/core.py
@@ -57,6 +57,7 @@ class ProjectMetadata(Generic[PluginManagerBound]):
         self._dynamic: list[str] | None = None
         self._name: str | None = None
         self._version: str | None = None
+        self._raw_version: str | None = None
         self._project_file: str | None = None
 
         # App already loaded config
@@ -152,6 +153,12 @@ class ProjectMetadata(Generic[PluginManagerBound]):
                 self.core.dynamic.remove("version")
 
         return self._version
+
+    @property
+    def raw_version(self) -> str:
+        """Return the version string before PEP 440 normalization."""
+        _ = self.version
+        return cast(str, self._raw_version)
 
     @property
     def config(self) -> dict[str, Any]:
@@ -260,6 +267,7 @@ class ProjectMetadata(Generic[PluginManagerBound]):
             message = f"Invalid version `{version}` from {source}, see https://peps.python.org/pep-0440/"
             raise ValueError(message) from None
         else:
+            self._raw_version = version
             return normalized_version
 
     def validate_fields(self) -> None:

--- a/backend/src/hatchling/metadata/spec.py
+++ b/backend/src/hatchling/metadata/spec.py
@@ -222,7 +222,7 @@ def construct_metadata_file_1_2(metadata: ProjectMetadata, extra_dependencies: t
     """
     metadata_file = "Metadata-Version: 1.2\n"
     metadata_file += f"Name: {metadata.core.raw_name}\n"
-    metadata_file += f"Version: {metadata.version}\n"
+    metadata_file += f"Version: {metadata.raw_version}\n"
 
     if metadata.core.description:
         metadata_file += f"Summary: {metadata.core.description}\n"
@@ -283,7 +283,7 @@ def construct_metadata_file_2_1(metadata: ProjectMetadata, extra_dependencies: t
     """
     metadata_file = "Metadata-Version: 2.1\n"
     metadata_file += f"Name: {metadata.core.raw_name}\n"
-    metadata_file += f"Version: {metadata.version}\n"
+    metadata_file += f"Version: {metadata.raw_version}\n"
 
     if metadata.core.description:
         metadata_file += f"Summary: {metadata.core.description}\n"
@@ -360,7 +360,7 @@ def construct_metadata_file_2_2(metadata: ProjectMetadata, extra_dependencies: t
     """
     metadata_file = "Metadata-Version: 2.2\n"
     metadata_file += f"Name: {metadata.core.raw_name}\n"
-    metadata_file += f"Version: {metadata.version}\n"
+    metadata_file += f"Version: {metadata.raw_version}\n"
 
     if metadata.core.dynamic:
         # Ordered set
@@ -446,7 +446,7 @@ def construct_metadata_file_2_3(metadata: ProjectMetadata, extra_dependencies: t
     """
     metadata_file = "Metadata-Version: 2.3\n"
     metadata_file += f"Name: {metadata.core.raw_name}\n"
-    metadata_file += f"Version: {metadata.version}\n"
+    metadata_file += f"Version: {metadata.raw_version}\n"
 
     if metadata.core.dynamic:
         # Ordered set
@@ -532,7 +532,7 @@ def construct_metadata_file_2_4(metadata: ProjectMetadata, extra_dependencies: t
     """
     metadata_file = "Metadata-Version: 2.4\n"
     metadata_file += f"Name: {metadata.core.raw_name}\n"
-    metadata_file += f"Version: {metadata.version}\n"
+    metadata_file += f"Version: {metadata.raw_version}\n"
 
     if metadata.core.dynamic:
         # Ordered set
@@ -623,7 +623,7 @@ def construct_metadata_file_2_5(metadata: ProjectMetadata, extra_dependencies: t
     """
     metadata_file = "Metadata-Version: 2.5\n"
     metadata_file += f"Name: {metadata.core.raw_name}\n"
-    metadata_file += f"Version: {metadata.version}\n"
+    metadata_file += f"Version: {metadata.raw_version}\n"
 
     if metadata.core.import_names is not None:
         if not metadata.core.import_names and not metadata.core.import_namespaces:

--- a/tests/backend/metadata/test_core.py
+++ b/tests/backend/metadata/test_core.py
@@ -226,6 +226,7 @@ class TestVersion:
         metadata = ProjectMetadata(str(isolation), None, {"project": {"version": "0.1.0.0-rc.1"}})
 
         assert metadata.version == metadata.version == "0.1.0.0rc1"
+        assert metadata.raw_version == metadata.raw_version == "0.1.0.0-rc.1"
         assert metadata.core.version == metadata.core.version == "0.1.0.0-rc.1"
 
     def test_dynamic_missing(self, isolation):
@@ -1665,6 +1666,13 @@ class TestHatchPersonalProjectConfigFile:
 
 
 class TestMetadataConversion:
+    def test_version_preserves_original_string(self, isolation, latest_spec):
+        raw_metadata = {"name": "My.App", "version": "2026.08.10"}
+        metadata = ProjectMetadata(str(isolation), None, {"project": raw_metadata})
+
+        core_metadata = latest_spec(metadata)
+        assert project_metadata_from_core_metadata(core_metadata) == raw_metadata
+
     def test_required_only(self, isolation, latest_spec):
         raw_metadata = {"name": "My.App", "version": "0.0.1"}
         metadata = ProjectMetadata(str(isolation), None, {"project": raw_metadata})


### PR DESCRIPTION
Fixes #2384

## Summary

- Preserve the original project version string in generated Core Metadata.
- Retain the normalized PEP 440 version for internal version handling and distribution naming.
- Add a regression test for 2026.08.10 and metadata round-tripping.

## Tests

- Hatch metadata test suite: 334 passed.

This PR was prepared with AI assistance and the implementation and test results were reviewed locally.