### PR TITLE
Build wheel from sdist when both targets are requested

### DIFF
--- a/backend/src/hatchling/builders/sdist_wheel.py
+++ b/backend/src/hatchling/builders/sdist_wheel.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import os
+import tarfile
+from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+def unpack_sdist(sdist_path: str, destination: str) -> str:
+    """Extract a gzipped sdist and return the path to its single top-level directory."""
+    with tarfile.open(sdist_path, "r:gz") as archive:
+        archive.extractall(destination, filter="data")
+
+    children = [os.path.join(destination, name) for name in os.listdir(destination)]
+    if len(children) != 1 or not os.path.isdir(children[0]):
+        message = f"Expected a single top-level directory in sdist `{sdist_path}`, found {len(children)} entries"
+        raise RuntimeError(message)
+
+    return children[0]
+
+
+def build_wheel_from_sdist(
+    *,
+    sdist_path: str,
+    wheel_builder_class: type,
+    plugin_manager,
+    app,
+    directory: str | None,
+    versions: list[str],
+    hooks_only: bool,
+    clean: bool,
+    clean_hooks_after: bool,
+    clean_only: bool,
+) -> Generator[str, None, None]:
+    """Build a wheel using the contents of an sdist as the project root."""
+    with TemporaryDirectory() as temp_dir:
+        project_root = unpack_sdist(sdist_path, temp_dir)
+        builder = wheel_builder_class(
+            project_root,
+            plugin_manager=plugin_manager,
+            app=app,
+        )
+        yield from builder.build(
+            directory=directory,
+            versions=versions,
+            hooks_only=hooks_only,
+            clean=clean,
+            clean_hooks_after=clean_hooks_after,
+            clean_only=clean_only,
+        )

--- a/backend/src/hatchling/cli/build/__init__.py
+++ b/backend/src/hatchling/cli/build/__init__.py
@@ -4,6 +4,22 @@ import argparse
 from typing import Any
 
 
+def _display_artifact(app: Any, artifact: str, root: str, directory: str | None) -> None:
+    import os
+
+    if os.path.isfile(artifact):
+        candidates = [root]
+        if directory:
+            candidates.append(os.path.dirname(os.path.abspath(directory)))
+
+        for candidate in candidates:
+            if candidate and (artifact == candidate or artifact.startswith(candidate + os.sep)):
+                app.display_info(os.path.relpath(artifact, candidate))
+                return
+
+    app.display_info(artifact)  # no cov
+
+
 def build_impl(
     *,
     called_by_app: bool,  # noqa: ARG001
@@ -19,7 +35,8 @@ def build_impl(
     import os
 
     from hatchling.bridge.app import Application
-    from hatchling.builders.constants import BuildEnvVars
+    from hatchling.builders.constants import DEFAULT_BUILD_DIRECTORY, BuildEnvVars
+    from hatchling.builders.sdist_wheel import build_wheel_from_sdist
     from hatchling.metadata.core import ProjectMetadata
     from hatchling.plugin.manager import PluginManager
 
@@ -60,8 +77,33 @@ def build_impl(
     if no_hooks:
         os.environ[BuildEnvVars.NO_HOOKS] = "true"
 
+    # When both targets are requested, build the wheel from the sdist so the
+    # published artifacts match what installers produce from the sdist alone.
+    build_wheel_via_sdist = (
+        not clean_only
+        and not show_dynamic_deps
+        and not hooks_only
+        and "sdist" in target_data
+        and "wheel" in target_data
+    )
+    if build_wheel_via_sdist:
+        ordered_targets = [(name, versions) for name, versions in target_data.items() if name != "wheel"]
+        ordered_targets.append(("wheel", target_data["wheel"]))
+    else:
+        ordered_targets = list(target_data.items())
+
+    # Resolve the output directory against the original project before any
+    # temporary sdist extraction changes the effective project root.
+    if directory:
+        output_directory: str | None = os.path.abspath(directory)
+    elif build_wheel_via_sdist:
+        output_directory = os.path.join(root, DEFAULT_BUILD_DIRECTORY)
+    else:
+        output_directory = None
+
     dynamic_dependencies: dict[str, None] = {}
-    for i, (target_name, versions) in enumerate(target_data.items()):
+    sdist_artifact: str | None = None
+    for i, (target_name, versions) in enumerate(ordered_targets):
         # Separate targets with a blank line
         if not (clean_only or show_dynamic_deps) and i != 0:  # no cov
             app.display_info()
@@ -72,25 +114,49 @@ def build_impl(
         if not (clean_only or show_dynamic_deps) and len(target_data) > 1:
             app.display_mini_header(target_name)
 
-        builder = builder_class(root, plugin_manager=plugin_manager, metadata=metadata, app=app.get_safe_application())
         if show_dynamic_deps:
+            builder = builder_class(
+                root, plugin_manager=plugin_manager, metadata=metadata, app=app.get_safe_application()
+            )
             for dependency in builder.config.dynamic_dependencies:
                 dynamic_dependencies[dependency] = None
 
             continue
 
-        for artifact in builder.build(
-            directory=directory,
-            versions=versions,
-            hooks_only=hooks_only,
-            clean=clean,
-            clean_hooks_after=clean_hooks_after,
-            clean_only=clean_only,
-        ):
-            if os.path.isfile(artifact) and artifact.startswith(root):
-                app.display_info(os.path.relpath(artifact, root))
-            else:  # no cov
-                app.display_info(artifact)
+        if build_wheel_via_sdist and target_name == "wheel":
+            if sdist_artifact is None:
+                app.abort("Cannot build wheel from sdist because no sdist artifact was produced")
+
+            artifacts = build_wheel_from_sdist(
+                sdist_path=sdist_artifact,
+                wheel_builder_class=builder_class,
+                plugin_manager=plugin_manager,
+                app=app.get_safe_application(),
+                directory=output_directory,
+                versions=versions,
+                hooks_only=hooks_only,
+                clean=clean,
+                clean_hooks_after=clean_hooks_after,
+                clean_only=clean_only,
+            )
+        else:
+            builder = builder_class(
+                root, plugin_manager=plugin_manager, metadata=metadata, app=app.get_safe_application()
+            )
+            artifacts = builder.build(
+                directory=output_directory if output_directory is not None else directory,
+                versions=versions,
+                hooks_only=hooks_only,
+                clean=clean,
+                clean_hooks_after=clean_hooks_after,
+                clean_only=clean_only,
+            )
+
+        for artifact in artifacts:
+            if target_name == "sdist":
+                sdist_artifact = artifact
+
+            _display_artifact(app, artifact, root, output_directory if output_directory is not None else directory)
 
     if show_dynamic_deps:
         app.display(str(list(dynamic_dependencies)))

--- a/backend/src/hatchling/cli/build/__init__.py
+++ b/backend/src/hatchling/cli/build/__init__.py
@@ -126,19 +126,19 @@ def build_impl(
         if build_wheel_via_sdist and target_name == "wheel":
             if sdist_artifact is None:
                 app.abort("Cannot build wheel from sdist because no sdist artifact was produced")
-
-            artifacts = build_wheel_from_sdist(
-                sdist_path=sdist_artifact,
-                wheel_builder_class=builder_class,
-                plugin_manager=plugin_manager,
-                app=app.get_safe_application(),
-                directory=output_directory,
-                versions=versions,
-                hooks_only=hooks_only,
-                clean=clean,
-                clean_hooks_after=clean_hooks_after,
-                clean_only=clean_only,
-            )
+            else:
+                artifacts = build_wheel_from_sdist(
+                    sdist_path=sdist_artifact,
+                    wheel_builder_class=builder_class,
+                    plugin_manager=plugin_manager,
+                    app=app.get_safe_application(),
+                    directory=output_directory,
+                    versions=versions,
+                    hooks_only=hooks_only,
+                    clean=clean,
+                    clean_hooks_after=clean_hooks_after,
+                    clean_only=clean_only,
+                )
         else:
             builder = builder_class(
                 root, plugin_manager=plugin_manager, metadata=metadata, app=app.get_safe_application()

--- a/docs/build.md
+++ b/docs/build.md
@@ -30,6 +30,8 @@ dist/hatch_demo-1rc0.tar.gz
 dist/hatch_demo-1rc0-py3-none-any.whl
 ```
 
+When both targets are built with the Hatchling backend, the wheel is produced **from the sdist** (the same path installers use) rather than directly from the project tree. Build only the wheel with `-t wheel` if you need to package directly from the checkout.
+
 To only build specific targets, use the `-t`/`--target` option:
 
 ```console

--- a/src/hatch/cli/build/__init__.py
+++ b/src/hatch/cli/build/__init__.py
@@ -151,13 +151,28 @@ def _build_project(
     from hatch.utils.structures import EnvVars
 
     build_dir = Path(location).resolve() if location else None
+    target_list = list(targets)
+    build_backend = project.metadata.build.build_backend
+    target_names = [target.partition(":")[0] for target in target_list]
+    build_wheel_via_sdist = (
+        build_backend == BUILD_BACKEND
+        and not clean_only
+        and not hooks_only
+        and "sdist" in target_names
+        and "wheel" in target_names
+    )
+    if build_wheel_via_sdist:
+        # Always produce the sdist before the wheel so the wheel can be built from it.
+        target_list = [target for target in target_list if target.partition(":")[0] != "wheel"] + [
+            target for target in target_list if target.partition(":")[0] == "wheel"
+        ]
 
     with EnvVars(env_vars):
-        project.prepare_build_environment(targets=[target.split(":")[0] for target in targets])
+        project.prepare_build_environment(targets=[target.split(":")[0] for target in target_list])
 
-    build_backend = project.metadata.build.build_backend
+    sdist_artifact = None
     with project.location.as_cwd(), project.build_env.get_env_vars():
-        for target in targets:
+        for target in target_list:
             target_name, _, _ = target.partition(":")
             if not clean_only:
                 app.display_header(target_name)
@@ -181,11 +196,15 @@ def _build_project(
                 )
             else:
                 command = ["python", "-u", "-m", "hatchling", "build", "--target", target]
+                command_env = dict(env_vars)
 
                 # We deliberately pass the location unchanged so that absolute paths may be non-local
                 # and reflect wherever builds actually take place
                 if location:
                     command.extend(("--directory", str(location)))
+                elif build_wheel_via_sdist and target_name == "wheel" and sdist_artifact is not None:
+                    # Keep the wheel alongside the sdist in the original project dist directory.
+                    command.extend(("--directory", str((project.location / DEFAULT_BUILD_DIRECTORY).resolve())))
 
                 if hooks_only or env_var_enabled(BuildEnvVars.HOOKS_ONLY):
                     command.append("--hooks-only")
@@ -202,7 +221,27 @@ def _build_project(
                 if clean_only:
                     command.append("--clean-only")
 
-                context = ExecutionContext(project.build_env)
-                context.add_shell_command(command)
-                context.env_vars.update(env_vars)
-                app.execute_context(context)
+                if build_wheel_via_sdist and target_name == "wheel" and sdist_artifact is not None:
+                    from tempfile import TemporaryDirectory
+
+                    from hatchling.builders.sdist_wheel import unpack_sdist
+
+                    with TemporaryDirectory() as temp_dir:
+                        project_root = Path(unpack_sdist(str(sdist_artifact), temp_dir))
+                        context = ExecutionContext(project.build_env)
+                        context.add_shell_command(command)
+                        context.env_vars.update(command_env)
+                        with project_root.as_cwd():
+                            app.execute_context(context)
+                else:
+                    context = ExecutionContext(project.build_env)
+                    context.add_shell_command(command)
+                    context.env_vars.update(command_env)
+                    app.execute_context(context)
+
+                if target_name == "sdist":
+                    dist_directory = build_dir or project.location / DEFAULT_BUILD_DIRECTORY
+                    if dist_directory.is_dir():
+                        sdists = sorted(dist_directory.glob("*.tar.gz"), key=lambda path: path.stat().st_mtime)
+                        if sdists:
+                            sdist_artifact = sdists[-1]

--- a/tests/cli/build/test_build.py
+++ b/tests/cli/build/test_build.py
@@ -1,5 +1,6 @@
 import os
 import re
+import zipfile
 
 import pytest
 
@@ -322,6 +323,53 @@ def test_default(hatch, temp_dir, helpers):
         {wheel_path.relative_to(path)}
         """
     )
+
+
+@pytest.mark.requires_internet
+def test_wheel_built_from_sdist(hatch, temp_dir):
+    """Default builds should package the wheel from the sdist, not the project tree."""
+    project_name = "My.App"
+
+    with temp_dir.as_cwd():
+        result = hatch("new", project_name)
+        assert result.exit_code == 0, result.output
+
+    path = temp_dir / "my-app"
+    package_dir = path / "src" / "my_app"
+    if not package_dir.is_dir():
+        package_dir = path / "my_app"
+    tree_only = package_dir / "tree_only.py"
+    tree_only.write_text("value = 1\n")
+    exclude_path = tree_only.relative_to(path).as_posix()
+
+    project = Project(path)
+    config = dict(project.raw_config)
+    config.setdefault("tool", {}).setdefault("hatch", {}).setdefault("build", {}).setdefault("targets", {})
+    config["tool"]["hatch"]["build"]["targets"]["sdist"] = {"exclude": [exclude_path]}
+    project.save_config(config)
+
+    with path.as_cwd():
+        result = hatch("build")
+        assert result.exit_code == 0, result.output
+
+    build_directory = path / "dist"
+    wheel_path = next(artifact for artifact in build_directory.iterdir() if artifact.name.endswith(".whl"))
+    with zipfile.ZipFile(wheel_path) as archive:
+        names = archive.namelist()
+
+    assert "my_app/__init__.py" in names
+    assert "my_app/tree_only.py" not in names
+
+    build_directory.remove()
+    with path.as_cwd():
+        result = hatch("build", "-t", "wheel")
+        assert result.exit_code == 0, result.output
+
+    wheel_path = next(artifact for artifact in (path / "dist").iterdir() if artifact.name.endswith(".whl"))
+    with zipfile.ZipFile(wheel_path) as archive:
+        names = archive.namelist()
+
+    assert "my_app/tree_only.py" in names
 
 
 @pytest.mark.requires_internet


### PR DESCRIPTION
## Summary
- When both `sdist` and `wheel` are requested with the Hatchling backend, build the wheel from the unpacked sdist (same path `python -m build` / pip use) instead of from the live checkout.
- `hatch build -t wheel` still packages directly from the project tree.
- Adds `test_wheel_built_from_sdist` and a short docs note.

Closes #767.

## Test plan
- [x] `hatch test tests/cli/build/test_build.py::test_wheel_built_from_sdist`
- [x] `hatch test tests/cli/build/test_build.py::test_default`
- [x] `ruff check` on touched files

## AI disclosure
Assisted by **Cursor**. I directed the change, reviewed the packaging approach (wheel-from-sdist for reproducibility), and verified the tests above. No `Co-authored-by` LLM trailer.

Made with [Cursor](https://cursor.com)