### PR TITLE
Fix `hatch.cli.application.Application.ensure_plugin_dependencies` PyApp Compatibility

### DIFF
--- a/docs/history/hatch.md
+++ b/docs/history/hatch.md
@@ -8,13 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-**Fixed:**
+***Fixed:***
 
-- Fix syncing environment plugin requirements failing with
-  `ERROR: The --python option must be placed before the pip subcommand name`
-  on the standalone binary. The `--python` option is now only passed to `uv`,
-  since the self-management command already targets its own installation and
-  may forward to `pip`, which requires that option to precede the subcommand.
+- Fix syncing environment plugin requirements on standalone binaries built to forward to `pip`
 
 ## [1.18.0](https://github.com/pypa/hatch/releases/tag/hatch-v1.18.0) - 2026-08-11 ## {: #hatch-v1.18.0 }
 

--- a/docs/history/hatch.md
+++ b/docs/history/hatch.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+**Fixed:**
+
+- Fix syncing environment plugin requirements failing with
+  `ERROR: The --python option must be placed before the pip subcommand name`
+  on the standalone binary. The `--python` option is now only passed to `uv`,
+  since the self-management command already targets its own installation and
+  may forward to `pip`, which requires that option to precede the subcommand.
+
 ## [1.18.0](https://github.com/pypa/hatch/releases/tag/hatch-v1.18.0) - 2026-08-11 ## {: #hatch-v1.18.0 }
 
 ***Changed:***

--- a/src/hatch/cli/application.py
+++ b/src/hatch/cli/application.py
@@ -166,23 +166,16 @@ class Application(Terminal):
         from hatch.dep.sync import InstalledDistributions
         from hatch.env.utils import add_verbosity_flag
 
-        pip_command: list[str]
         if app_path := os.environ.get("PYAPP"):
             from hatch.utils.env import PythonInfo
 
-            management_command = os.environ["PYAPP_COMMAND_NAME"]
+            management_command = os.environ.get("PYAPP_COMMAND_NAME", "self")
             executable = self.platform.check_command_output([app_path, management_command, "python-path"]).strip()
             python_info = PythonInfo(self.platform, executable=executable)
             distributions = InstalledDistributions(sys_path=python_info.sys_path)
             if distributions.dependencies_in_sync(dependencies):
                 return
-            pip_command = [
-                app_path,
-                management_command,
-                "pip",
-                "install",
-                "--disable-pip-version-check",
-            ]
+            pip_command = [app_path, management_command, "pip", "install", "--disable-pip-version-check"]
         else:
             distributions = InstalledDistributions()
             if distributions.dependencies_in_sync(dependencies):
@@ -191,13 +184,7 @@ class Application(Terminal):
             from uv import find_uv_bin
 
             uv_bin = find_uv_bin()
-            pip_command = [
-                uv_bin,
-                "pip",
-                "install",
-                "--python",
-                sys.executable,
-            ]
+            pip_command = [uv_bin, "pip", "install", "--python", sys.executable]
 
         # Default to -1 verbosity
         add_verbosity_flag(pip_command, self.verbosity, adjustment=-1)

--- a/src/hatch/cli/application.py
+++ b/src/hatch/cli/application.py
@@ -163,11 +163,10 @@ class Application(Terminal):
         if not dependencies:
             return
 
-        from uv import find_uv_bin
-
         from hatch.dep.sync import InstalledDistributions
         from hatch.env.utils import add_verbosity_flag
 
+        pip_command: list[str]
         if app_path := os.environ.get("PYAPP"):
             from hatch.utils.env import PythonInfo
 
@@ -177,17 +176,28 @@ class Application(Terminal):
             distributions = InstalledDistributions(sys_path=python_info.sys_path)
             if distributions.dependencies_in_sync(dependencies):
                 return
-
-            pip_command = [app_path, management_command, "pip"]
+            pip_command = [
+                app_path,
+                management_command,
+                "pip",
+                "install",
+                "--disable-pip-version-check",
+            ]
         else:
             distributions = InstalledDistributions()
             if distributions.dependencies_in_sync(dependencies):
                 return
 
-            uv_bin = find_uv_bin()
-            pip_command = [uv_bin, "pip"]
+            from uv import find_uv_bin
 
-        pip_command.extend(["install", "--disable-pip-version-check", "--python", sys.executable])
+            uv_bin = find_uv_bin()
+            pip_command = [
+                uv_bin,
+                "pip",
+                "install",
+                "--python",
+                sys.executable,
+            ]
 
         # Default to -1 verbosity
         add_verbosity_flag(pip_command, self.verbosity, adjustment=-1)

--- a/tests/cli/env/test_create.py
+++ b/tests/cli/env/test_create.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import os
 import sys
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -10,6 +13,16 @@ from hatch.utils.structures import EnvVars
 from hatch.venv.core import UVVirtualEnv, VirtualEnv
 from hatchling.utils.constants import DEFAULT_BUILD_SCRIPT, DEFAULT_CONFIG_FILE
 from hatchling.utils.fs import path_to_uri
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from types import ModuleType
+    from unittest.mock import MagicMock
+
+    from click.testing import Result
+
+    from hatch.config.user import ConfigFile
+    from hatch.utils.fs import Path
 
 
 def test_undefined(hatch, helpers, temp_dir, config_file):
@@ -1755,6 +1768,102 @@ def test_plugin_dependencies_unmet(hatch, config_file, helpers, temp_dir, mock_p
 
     env_path = env_dirs[0]
 
+    assert env_path.name == project_path.name
+
+
+def test_plugin_dependencies_unmet_pyapp(
+    hatch: Callable[..., Result],
+    config_file: ConfigFile,
+    helpers: ModuleType,
+    temp_dir: Path,
+    mock_plugin_installation: MagicMock,
+) -> None:
+    """
+    This test is a PyApp counterpart to `test_plugin_dependencies_unmet`.
+
+    This difference is materially relevant because, for PyApp binaries,
+    environment plugin requirements are installed through the standalone
+    binary's own self-management command, which forwards to either `pip` or
+    `uv pip`, depending on how the binary was built, and these commands
+    disagree about where the `--python` parameter belongs.
+    """
+    config_file.model.template.plugins["default"]["tests"] = False
+    config_file.save()
+    project_name: str = "My.PyApp"
+    with temp_dir.as_cwd():
+        result: Result = hatch("new", project_name)
+    assert result.exit_code == 0, result.output
+    project_path: Path = temp_dir / "my-pyapp"
+    data_path: Path = temp_dir / "data"
+    data_path.mkdir(exist_ok=True)
+    # A random dependency ensures a real install is forced
+    dependency: str = os.urandom(16).hex()
+    (project_path / DEFAULT_CONFIG_FILE).write_text(
+        helpers.dedent(
+            f"""
+            [env]
+            requires = ["{dependency}"]
+            """
+        )
+    )
+    # Skip the install so the environment is created without building the
+    # project itself (we only care about the plugin requirement sync)
+    project: Project = Project(project_path)
+    helpers.update_project_environment(
+        project,
+        "default",
+        {"skip-install": True, **project.config.envs["default"]},
+    )
+    # The exposed management command is not always named `self`, so use
+    # whatever the isolation fixture randomized it to
+    management_command: str = os.environ["PYAPP_COMMAND_NAME"]
+    # `PYAPP` is what makes Hatch believe it is running as a binary, and it
+    # doubles as the path invoked for the self-management command
+    env_vars: dict[str, str] = {
+        ConfigEnvVars.DATA: str(data_path),
+        "PYAPP": sys.executable,
+    }
+    with project_path.as_cwd(env_vars=env_vars):
+        result = hatch("env", "create")
+    assert result.exit_code == 0, result.output
+    assert result.output == helpers.dedent(
+        """
+        Syncing environment plugin requirements
+        Creating environment: default
+        Checking dependencies
+        """
+    )
+    # No `--python` may appear here, and the flags must reach the binary in
+    # an order both `pip` and `uv` accept
+    helpers.assert_plugin_installation(
+        mock_plugin_installation,
+        [dependency],
+        app_command=[sys.executable, management_command],
+    )
+    # Dependencies must be resolved against the interpreter the binary
+    # manages, which is discovered rather than assumed. This pins that the
+    # probe is performed — without it, replacing the whole chain with a
+    # bare `InstalledDistributions()` leaves the test green. It does not
+    # pin that the probed path is the one used, since the fixture returns
+    # `sys.executable` and so the two are indistinguishable here
+    probe: MagicMock = mock_plugin_installation.python_path
+    expected: list[str] = [sys.executable, management_command, "python-path"]
+
+    assert probe.call_count == 1
+    assert probe.call_args.args[0] == expected
+    # The sync must not stop the environment from being created, mirroring
+    # the assertions made by the non-PyApp counterpart
+    env_data_path: Path = data_path / "env" / "virtual"
+    assert env_data_path.is_dir()
+    project_data_path: Path = env_data_path / project_path.name
+    assert project_data_path.is_dir()
+    storage_dirs: tuple[Path, ...] = tuple(project_data_path.iterdir())
+    assert len(storage_dirs) == 1
+    storage_path: Path = storage_dirs[0]
+    assert len(storage_path.name) == 8
+    env_dirs: tuple[Path, ...] = tuple(storage_path.iterdir())
+    assert len(env_dirs) == 1
+    env_path: Path = env_dirs[0]
     assert env_path.name == project_path.name
 
 

--- a/tests/cli/env/test_create.py
+++ b/tests/cli/env/test_create.py
@@ -1,8 +1,5 @@
-from __future__ import annotations
-
 import os
 import sys
-from typing import TYPE_CHECKING
 
 import pytest
 
@@ -13,16 +10,6 @@ from hatch.utils.structures import EnvVars
 from hatch.venv.core import UVVirtualEnv, VirtualEnv
 from hatchling.utils.constants import DEFAULT_BUILD_SCRIPT, DEFAULT_CONFIG_FILE
 from hatchling.utils.fs import path_to_uri
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
-    from types import ModuleType
-    from unittest.mock import MagicMock
-
-    from click.testing import Result
-
-    from hatch.config.user import ConfigFile
-    from hatch.utils.fs import Path
 
 
 def test_undefined(hatch, helpers, temp_dir, config_file):
@@ -1772,26 +1759,23 @@ def test_plugin_dependencies_unmet(hatch, config_file, helpers, temp_dir, mock_p
 
 
 def test_plugin_dependencies_unmet_pyapp(
-    hatch: Callable[..., Result],
-    config_file: ConfigFile,
-    helpers: ModuleType,
-    temp_dir: Path,
-    mock_plugin_installation: MagicMock,
-    mock_python_path: MagicMock,
-) -> None:
-    """
-    This test is a PyApp counterpart to `test_plugin_dependencies_unmet`.
-    """
+    hatch, config_file, helpers, temp_dir, mock_plugin_installation, mock_python_path
+):
     config_file.model.template.plugins["default"]["tests"] = False
     config_file.save()
-    project_name: str = "My.PyApp"
+
+    project_name = "My.PyApp"
+
     with temp_dir.as_cwd():
-        result: Result = hatch("new", project_name)
+        result = hatch("new", project_name)
+
     assert result.exit_code == 0, result.output
-    project_path: Path = temp_dir / "my-pyapp"
-    data_path: Path = temp_dir / "data"
+
+    project_path = temp_dir / "my-pyapp"
+    data_path = temp_dir / "data"
     data_path.mkdir()
-    dependency: str = os.urandom(16).hex()
+
+    dependency = os.urandom(16).hex()
     (project_path / DEFAULT_CONFIG_FILE).write_text(
         helpers.dedent(
             f"""
@@ -1800,11 +1784,14 @@ def test_plugin_dependencies_unmet_pyapp(
             """
         )
     )
-    project: Project = Project(project_path)
+
+    project = Project(project_path)
     helpers.update_project_environment(project, "default", {"skip-install": True, **project.config.envs["default"]})
-    management_command: str = os.environ["PYAPP_COMMAND_NAME"]
+
+    management_command = os.environ["PYAPP_COMMAND_NAME"]
     with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path), "PYAPP": sys.executable}):
         result = hatch("env", "create")
+
     assert result.exit_code == 0, result.output
     assert result.output == helpers.dedent(
         """

--- a/tests/cli/env/test_create.py
+++ b/tests/cli/env/test_create.py
@@ -1777,15 +1777,10 @@ def test_plugin_dependencies_unmet_pyapp(
     helpers: ModuleType,
     temp_dir: Path,
     mock_plugin_installation: MagicMock,
+    mock_python_path: MagicMock,
 ) -> None:
     """
     This test is a PyApp counterpart to `test_plugin_dependencies_unmet`.
-
-    This difference is materially relevant because, for PyApp binaries,
-    environment plugin requirements are installed through the standalone
-    binary's own self-management command, which forwards to either `pip` or
-    `uv pip`, depending on how the binary was built, and these commands
-    disagree about where the `--python` parameter belongs.
     """
     config_file.model.template.plugins["default"]["tests"] = False
     config_file.save()
@@ -1795,8 +1790,7 @@ def test_plugin_dependencies_unmet_pyapp(
     assert result.exit_code == 0, result.output
     project_path: Path = temp_dir / "my-pyapp"
     data_path: Path = temp_dir / "data"
-    data_path.mkdir(exist_ok=True)
-    # A random dependency ensures a real install is forced
+    data_path.mkdir()
     dependency: str = os.urandom(16).hex()
     (project_path / DEFAULT_CONFIG_FILE).write_text(
         helpers.dedent(
@@ -1806,24 +1800,10 @@ def test_plugin_dependencies_unmet_pyapp(
             """
         )
     )
-    # Skip the install so the environment is created without building the
-    # project itself (we only care about the plugin requirement sync)
     project: Project = Project(project_path)
-    helpers.update_project_environment(
-        project,
-        "default",
-        {"skip-install": True, **project.config.envs["default"]},
-    )
-    # The exposed management command is not always named `self`, so use
-    # whatever the isolation fixture randomized it to
+    helpers.update_project_environment(project, "default", {"skip-install": True, **project.config.envs["default"]})
     management_command: str = os.environ["PYAPP_COMMAND_NAME"]
-    # `PYAPP` is what makes Hatch believe it is running as a binary, and it
-    # doubles as the path invoked for the self-management command
-    env_vars: dict[str, str] = {
-        ConfigEnvVars.DATA: str(data_path),
-        "PYAPP": sys.executable,
-    }
-    with project_path.as_cwd(env_vars=env_vars):
+    with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path), "PYAPP": sys.executable}):
         result = hatch("env", "create")
     assert result.exit_code == 0, result.output
     assert result.output == helpers.dedent(
@@ -1841,30 +1821,9 @@ def test_plugin_dependencies_unmet_pyapp(
         app_command=[sys.executable, management_command],
     )
     # Dependencies must be resolved against the interpreter the binary
-    # manages, which is discovered rather than assumed. This pins that the
-    # probe is performed — without it, replacing the whole chain with a
-    # bare `InstalledDistributions()` leaves the test green. It does not
-    # pin that the probed path is the one used, since the fixture returns
-    # `sys.executable` and so the two are indistinguishable here
-    probe: MagicMock = mock_plugin_installation.python_path
-    expected: list[str] = [sys.executable, management_command, "python-path"]
-
-    assert probe.call_count == 1
-    assert probe.call_args.args[0] == expected
-    # The sync must not stop the environment from being created, mirroring
-    # the assertions made by the non-PyApp counterpart
-    env_data_path: Path = data_path / "env" / "virtual"
-    assert env_data_path.is_dir()
-    project_data_path: Path = env_data_path / project_path.name
-    assert project_data_path.is_dir()
-    storage_dirs: tuple[Path, ...] = tuple(project_data_path.iterdir())
-    assert len(storage_dirs) == 1
-    storage_path: Path = storage_dirs[0]
-    assert len(storage_path.name) == 8
-    env_dirs: tuple[Path, ...] = tuple(storage_path.iterdir())
-    assert len(env_dirs) == 1
-    env_path: Path = env_dirs[0]
-    assert env_path.name == project_path.name
+    # manages
+    assert mock_python_path.call_count == 1
+    assert mock_python_path.call_args.args[0] == [sys.executable, management_command, "python-path"]
 
 
 @pytest.mark.usefixtures("mock_plugin_installation")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -480,15 +480,16 @@ def mock_backend_process_output(request, mocker):
 
 
 @pytest.fixture
-def mock_plugin_installation(mocker):
+def mock_python_path(mocker):
+    return mocker.MagicMock(returncode=0, stdout=sys.executable.encode())
+
+
+@pytest.fixture
+def mock_plugin_installation(mocker, mock_python_path):
     from uv import find_uv_bin
 
     subprocess_run = subprocess.run
     mocked_subprocess_run = mocker.MagicMock(returncode=0)
-    mocked_python_path = mocker.MagicMock(
-        returncode=0,
-        stdout=sys.executable.encode(),
-    )
 
     def _mock(command, **kwargs):
         if isinstance(command, list):
@@ -506,14 +507,12 @@ def mock_plugin_installation(mocker):
 
             # Mirror how the self-management command is derived, rather
             # than assuming the exposed command is named `self`
-            app_path: str | None = os.environ.get("PYAPP")
-            command_name: str | None = os.environ.get("PYAPP_COMMAND_NAME")
-            if app_path and command_name:
-                app_command: list[str] = [app_path, command_name]
+            if app_path := os.environ.get("PYAPP"):
+                app_command = [app_path, os.environ.get("PYAPP_COMMAND_NAME", "self")]
 
                 if command[:3] == [*app_command, "python-path"]:
-                    mocked_python_path(command, **kwargs)
-                    return mocked_python_path
+                    mock_python_path(command, **kwargs)
+                    return mock_python_path
 
                 if command[:4] == [*app_command, "pip", "install"]:
                     mocked_subprocess_run(command, **kwargs)
@@ -523,7 +522,6 @@ def mock_plugin_installation(mocker):
 
     mocker.patch("subprocess.run", side_effect=_mock)
 
-    mocked_subprocess_run.python_path = mocked_python_path
     return mocked_subprocess_run
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -485,6 +485,10 @@ def mock_plugin_installation(mocker):
 
     subprocess_run = subprocess.run
     mocked_subprocess_run = mocker.MagicMock(returncode=0)
+    mocked_python_path = mocker.MagicMock(
+        returncode=0,
+        stdout=sys.executable.encode(),
+    )
 
     def _mock(command, **kwargs):
         if isinstance(command, list):
@@ -500,13 +504,26 @@ def mock_plugin_installation(mocker):
                 mocked_subprocess_run(command, **kwargs)
                 return mocked_subprocess_run
 
-            if command[:3] == [sys.executable, "self", "python-path"]:
-                return mocker.MagicMock(returncode=0, stdout=sys.executable.encode())
+            # Mirror how the self-management command is derived, rather
+            # than assuming the exposed command is named `self`
+            app_path: str | None = os.environ.get("PYAPP")
+            command_name: str | None = os.environ.get("PYAPP_COMMAND_NAME")
+            if app_path and command_name:
+                app_command: list[str] = [app_path, command_name]
 
-        return subprocess_run(command, **kwargs)  # no cov
+                if command[:3] == [*app_command, "python-path"]:
+                    mocked_python_path(command, **kwargs)
+                    return mocked_python_path
+
+                if command[:4] == [*app_command, "pip", "install"]:
+                    mocked_subprocess_run(command, **kwargs)
+                    return mocked_subprocess_run
+
+        return subprocess_run(command, **kwargs)
 
     mocker.patch("subprocess.run", side_effect=_mock)
 
+    mocked_subprocess_run.python_path = mocked_python_path
     return mocked_subprocess_run
 
 

--- a/tests/helpers/helpers.py
+++ b/tests/helpers/helpers.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from functools import lru_cache
 from textwrap import dedent as _dedent
 from typing import TYPE_CHECKING
-from unittest.mock import call
+from unittest.mock import MagicMock, call
 
 import tomli_w
 
@@ -47,18 +47,35 @@ def get_current_timestamp():
     return datetime.now(timezone.utc).timestamp()
 
 
-def assert_plugin_installation(subprocess_run, dependencies: list[str], *, verbosity=0, count=1):
-    from uv import find_uv_bin
+def assert_plugin_installation(
+    subprocess_run: MagicMock,
+    dependencies: list[str],
+    *,
+    verbosity: int = 0,
+    count: int = 1,
+    app_command: list[str] | None = None,
+) -> None:
+    command: list[str]
+    if app_command is None:
+        from uv import find_uv_bin
 
-    uv_bin = find_uv_bin()
-    command = [
-        uv_bin,
-        "pip",
-        "install",
-        "--disable-pip-version-check",
-        "--python",
-        sys.executable,
-    ]
+        command = [
+            find_uv_bin(),
+            "pip",
+            "install",
+            "--python",
+            sys.executable,
+        ]
+    else:
+        # The self-management command targets its own installation, so
+        # the interpreter is never selected explicitly
+        command = [
+            *app_command,
+            "pip",
+            "install",
+            "--disable-pip-version-check",
+        ]
+
     add_verbosity_flag(command, verbosity, adjustment=-1)
     command.extend(dependencies)
 

--- a/tests/helpers/helpers.py
+++ b/tests/helpers/helpers.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from functools import lru_cache
 from textwrap import dedent as _dedent
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, call
+from unittest.mock import call
 
 import tomli_w
 
@@ -47,34 +47,13 @@ def get_current_timestamp():
     return datetime.now(timezone.utc).timestamp()
 
 
-def assert_plugin_installation(
-    subprocess_run: MagicMock,
-    dependencies: list[str],
-    *,
-    verbosity: int = 0,
-    count: int = 1,
-    app_command: list[str] | None = None,
-) -> None:
-    command: list[str]
+def assert_plugin_installation(subprocess_run, dependencies: list[str], *, verbosity=0, count=1, app_command=None):
     if app_command is None:
         from uv import find_uv_bin
 
-        command = [
-            find_uv_bin(),
-            "pip",
-            "install",
-            "--python",
-            sys.executable,
-        ]
+        command = [find_uv_bin(), "pip", "install", "--python", sys.executable]
     else:
-        # The self-management command targets its own installation, so
-        # the interpreter is never selected explicitly
-        command = [
-            *app_command,
-            "pip",
-            "install",
-            "--disable-pip-version-check",
-        ]
+        command = [*app_command, "pip", "install", "--disable-pip-version-check"]
 
     add_verbosity_flag(command, verbosity, adjustment=-1)
     command.extend(dependencies)


### PR DESCRIPTION
Fixes #2389.

## What's the problem?

On the standalone PyApp binary, syncing environment plugin requirements was failing:

```
ERROR: The --python option must be placed before the pip subcommand name
```

`hatch.cli.application.Application.ensure_plugin_dependencies` builds `<binary> <management-command> pip …` in
the PyApp branch and `uv pip …` otherwise, but b1af6e83 (#1882) appended
uv-shaped arguments on a line shared by *both* branches:

```python
pip_command.extend(["install", "--disable-pip-version-check", "--python", sys.executable])
```

`--python` is accepted by both tools, but in opposite positions:

| Invocation | Result |
| --- | --- |
| `uv pip install --python X …` | works |
| `uv pip --python X install …` | `error: unexpected argument '--python' found` |
| `pip install --python X …` | `ERROR: The --python option must be placed before the pip subcommand name` |
| `pip --python X install …` | works |

So no single argument order can serve both branches.

## Why didn't the CI catch this issue previously?

`hatch self pip …` is not always uv. PyApp's `pip_base_command()` returns
`uv pip` only when `PYAPP_UV_ENABLED` is set, and otherwise
`<managed python> -m pip`. `.github/workflows/build-hatch.yml:227` sets
`PYAPP_UV_ENABLED=false` for tagged release builds of the `use-dist` targets —
five of eight, including `x86_64-unknown-linux-gnu`, which is what the
`pypa/hatch` action installs on `ubuntu-latest`. Those binaries run real pip.

The test suite always took the non-PyApp branch, which really is uv, so the
broken path had no coverage at all.

## How does this change _fix_ the problem?

Each branch now owns its own flags. The PyApp branch passes no `--python` — it
is redundant there regardless of which tool PyApp forwards to, since PyApp
already aims its installer at the managed interpreter via
`UV_SYSTEM_PYTHON`/`VIRTUAL_ENV` and `PATH`. The uv branch keeps `--python`
after `install`, and drops `--disable-pip-version-check`, which uv answers with
`warning: pip's '--disable-pip-version-check' has no effect` on every
invocation.

`from uv import find_uv_bin` also moves into the branch that uses it, matching
the lazy-import convention in the rest of the function.

## How do we test this fix?

`test_plugin_dependencies_unmet_pyapp` covers the PyApp branch with unmet
requirements — the case that had no coverage, and the reason this regression
shipped. Supporting changes: `assert_plugin_installation` takes an
`app_command` argument, and `mock_plugin_installation` derives the command
prefix from `PYAPP`/`PYAPP_COMMAND_NAME` rather than assuming the management
command is named `self`, so the test honors the randomized name from the
`isolation` fixture.

## AI assistance

I used Claude Code to diagnose the error, draft an initial (terrible) issue description, review my changes locally prior to opening this pull request, and to assemble a first draft of this pull request description.