### PR TITLE
Fix pip --python flag ordering in PYAPP-mode plugin dependency sync

### DIFF
--- a/src/hatch/cli/application.py
+++ b/src/hatch/cli/application.py
@@ -179,6 +179,11 @@ class Application(Terminal):
                 return
 
             pip_command = [app_path, management_command, "pip"]
+            # pip requires --python before the subcommand name, so it cannot
+            # share a single argument ordering with uv (which requires it
+            # after the subcommand) (#2389).
+            pip_command.extend(["--python", sys.executable])
+            pip_command.extend(["install", "--disable-pip-version-check"])
         else:
             distributions = InstalledDistributions()
             if distributions.dependencies_in_sync(dependencies):
@@ -186,8 +191,7 @@ class Application(Terminal):
 
             uv_bin = find_uv_bin()
             pip_command = [uv_bin, "pip"]
-
-        pip_command.extend(["install", "--disable-pip-version-check", "--python", sys.executable])
+            pip_command.extend(["install", "--disable-pip-version-check", "--python", sys.executable])
 
         # Default to -1 verbosity
         add_verbosity_flag(pip_command, self.verbosity, adjustment=-1)

--- a/tests/cli/test_application.py
+++ b/tests/cli/test_application.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from hatch.dep.sync import Dependency
+
+
+@pytest.fixture
+def app(global_application):
+    return global_application
+
+
+class TestEnsurePluginDependencies:
+    def test_uv_branch_orders_python_flag_after_subcommand(self, app, mocker):
+        """uv rejects --python before the subcommand, so it must come after install."""
+        mocker.patch("hatch.dep.sync.InstalledDistributions.dependencies_in_sync", return_value=False)
+        mocker.patch("uv.find_uv_bin", return_value="/fake/uv")
+        commands = []
+        mocker.patch.object(app.platform, "check_command", side_effect=commands.append)
+
+        app.ensure_plugin_dependencies([Dependency("foo")], wait_message="sync")
+
+        assert commands == [
+            [
+                "/fake/uv",
+                "pip",
+                "install",
+                "--disable-pip-version-check",
+                "--python",
+                os.sys.executable,
+                "-q",
+                "foo",
+            ]
+        ]
+
+    def test_pyapp_branch_orders_python_flag_before_subcommand(self, app, mocker):
+        """pip requires --python before the subcommand name (#2389)."""
+        mocker.patch.dict(
+            os.environ,
+            {"PYAPP": "/fake/app", "PYAPP_COMMAND_NAME": "fake-app"},
+        )
+        mocker.patch("hatch.dep.sync.InstalledDistributions.dependencies_in_sync", return_value=False)
+        mocker.patch.object(app.platform, "check_command_output", return_value="/fake/python")
+        commands = []
+
+        def check_command(cmd, **kwargs):
+            if kwargs.get("capture_output"):
+                # Simulates the PythonInfo dep-check subprocess stdout.
+                process = mocker.Mock()
+                process.stdout = b"{'environment': {}, 'sys_path': []}"
+                return process
+            commands.append(cmd)
+            return None
+
+        mocker.patch.object(app.platform, "check_command", side_effect=check_command)
+
+        app.ensure_plugin_dependencies([Dependency("foo")], wait_message="sync")
+
+        assert commands == [
+            [
+                "/fake/app",
+                "fake-app",
+                "pip",
+                "--python",
+                os.sys.executable,
+                "install",
+                "--disable-pip-version-check",
+                "-q",
+                "foo",
+            ]
+        ]


### PR DESCRIPTION
## Summary

When a plugin declares dependencies and hatch needs to sync them, the built `pip`/`uv` command appended `install --disable-pip-version-check --python <executable>` **after** the subcommand name — the correct order for uv, but not for pip.

pip requires global options like `--python` to come **before** the subcommand:

```
# uv (works):
uv pip install --disable-pip-version-check --python <exe> foo

# pip (silently ignores --python, installs into wrong env):
pip install --disable-pip-version-check --python <exe> foo
# correct:
pip --python <exe> install --disable-pip-version-check foo
```

This is only reachable in PYAPP mode (`PYAPP` + `PYAPP_COMMAND_NAME` set), where the pip backend is used — uv's ordering was already correct. The flag was being parsed as a pip *install* option, which pip rejects unknown `--python` for, so the dependency sync failed (or worse, installed into the wrong environment when a compatible Python was found).

## Changes

- Split the argument construction per backend:
  - **pip (PYAPP mode):** `--python <exe>` before `install`
  - **uv:** unchanged (`install` before `--python`)
- Added regression tests for both branches asserting the exact command ordering.

## Test Plan

- `pytest tests/cli/test_application.py` — 2 passed
- Full suite: 2511 passed; the 25 failures (flit-core / build-frontend / venv) reproduce identically on clean `master` and are environment-related.
- `ruff check` and `ruff format --check` clean on changed files.

Fixes #2389
