### PR TITLE
Strip the build variant when passing a Python version to uv

### DIFF
--- a/src/hatch/env/lockers/uv.py
+++ b/src/hatch/env/lockers/uv.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 from hatch.env.lockers.interface import LockerInterface
 from hatch.env.utils import add_verbosity_flag
+from hatch.python.resolve import normalize_distribution_name
 from hatch.utils.fs import Path
 
 if TYPE_CHECKING:
@@ -109,7 +110,7 @@ class UvLocker(LockerInterface):
 
         python_version = environment.config.get("python", "")
         if python_version:
-            command.extend(["--python-version", python_version])
+            command.extend(["--python-version", normalize_distribution_name(python_version)])
 
         with environment.command_context():
             environment.platform.check_command(command)

--- a/src/hatch/env/virtual.py
+++ b/src/hatch/env/virtual.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from hatch.config.constants import AppEnvVars
 from hatch.env.plugin.interface import EnvironmentInterface
 from hatch.env.utils import add_verbosity_flag
+from hatch.python.resolve import normalize_distribution_name
 from hatch.utils.fs import Path
 from hatch.utils.shells import ShellManager
 from hatch.utils.structures import EnvVars
@@ -213,7 +214,7 @@ class VirtualEnvironment(EnvironmentInterface):
             command.append("--dry-run")
         python_version = self.config.get("python", "")
         if python_version:
-            command.extend(["--python-version", python_version])
+            command.extend(["--python-version", normalize_distribution_name(python_version)])
         return command
 
     def dependencies_in_sync(self):

--- a/tests/env/lockers/test_uv.py
+++ b/tests/env/lockers/test_uv.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from hatch.env.lockers.uv import UvLocker
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        pytest.param("3.14t", "3.14", id="freethreaded"),
+        pytest.param("3.12", "3.12", id="plain"),
+        pytest.param("pypy3.10", "pypy3.10", id="pypy"),
+    ],
+)
+def test_compile_strips_build_variant_from_python_version(tmp_path, configured, expected):
+    """uv's --python-version rejects the build variant suffix."""
+    environment = MagicMock()
+    environment.root = tmp_path
+    environment.uv_path = "uv"
+    environment.verbosity = 0
+    environment.config = {"python": configured}
+    environment.get_source_install_args.return_value = []
+
+    UvLocker._compile(  # noqa: SLF001
+        environment,
+        tmp_path / "requirements.txt",
+        upgrade=False,
+        upgrade_packages=(),
+        layered=False,
+        lock_extras=(),
+        lock_groups=(),
+        requirements_file=None,
+    )
+
+    command = environment.platform.check_command.call_args[0][0]
+    assert command[command.index("--python-version") + 1] == expected


### PR DESCRIPTION

Closes #2393

Both places that build a `--python-version` argument pass the configured `python` value through unchanged:

- `src/hatch/env/lockers/uv.py` — `uv pip compile`, used by `hatch env lock`
- `src/hatch/env/virtual.py` — `uv pip sync`

uv's `--python-version` does not accept a build-variant suffix (astral-sh/uv#21149), so a free-threaded version such as `3.14t` is rejected. `3.14t` appears in the default `hatch-test` matrix, which is how `hatch env lock` ends up failing on a default configuration.

### Change

Both call sites now pass the value through `normalize_distribution_name()` from `hatch.python.resolve`, which is already the function hatch uses to turn a distribution name into its base name:

```python
>>> normalize_distribution_name("3.14t")
'3.14'
>>> normalize_distribution_name("3.12")
'3.12'
>>> normalize_distribution_name("pypy3.10")
'pypy3.10'
```

It only strips the suffix when the base distribution actually supports the free-threaded variant, so an unknown name like `3.99t` is left alone rather than being silently rewritten.

### Tests

`tests/env/lockers/test_uv.py` covers the `uv pip compile` path — the one in the report — parametrized over a free-threaded version, a plain version and a PyPy version. The free-threaded case fails before this change and passes after; the other two pass either way and pin that normalization does not disturb ordinary versions.

The `uv pip sync` call site is fixed identically but is not covered by a new test: it is an instance method on `VirtualEnvironment` and there is no existing harness in the test suite for asserting on commands built there. Happy to add one if you would like it covered.

`tests/env` and `tests/cli/env` show no change against `main` — 273 passed with this change versus 272 plus the new failing test without it, and the same 24 pre-existing errors (`test_plugin_dependencies_unmet`) in both runs. `ruff check` and `ruff format --check` are clean on the changed files.




### AI disclosure

Per the [AI contributions policy](https://hatch.pypa.io/latest/community/contributing/#ai-contributions): this change was written with AI assistance (Claude Code). The extent — the fix at both call sites, the tests, and this description were AI-drafted; I reviewed the diff and the reasoning before opening, and the test suite was run locally rather than assumed.
