### PR TITLE
Honor .git/info/exclude when excluding files based on version control

### DIFF
--- a/backend/src/hatchling/builders/config.py
+++ b/backend/src/hatchling/builders/config.py
@@ -752,6 +752,12 @@ class BuilderConfig:
     def vcs_exclusion_files(self) -> dict[str, list[str]]:
         exclusion_files: dict[str, list[str]] = {"git": [], "hg": []}
 
+        # Listed before `.gitignore` because Git gives the latter higher precedence, and the
+        # last matching pattern is the one that decides: https://git-scm.com/docs/gitignore
+        local_git_exclude = locate_file(self.root, os.path.join(".git", "info", "exclude"), boundary=".git")
+        if local_git_exclude is not None:
+            exclusion_files["git"].append(local_git_exclude)
+
         local_gitignore = locate_file(self.root, ".gitignore", boundary=".git")
         if local_gitignore is not None:
             exclusion_files["git"].append(local_gitignore)

--- a/docs/config/build.md
+++ b/docs/config/build.md
@@ -29,7 +29,7 @@ Hatchling is a standards-compliant[^1] build backend and is a dependency of Hatc
 
 ### VCS
 
-By default, Hatch will respect the first `.gitignore` or `.hgignore` file found in your project's root directory or parent directories. Set `ignore-vcs` to `true` to disable this behavior:
+By default, Hatch will respect the first `.gitignore` or `.hgignore` file found in your project's root directory or parent directories, as well as the repository's `.git/info/exclude` file. As in Git, patterns in `.gitignore` take precedence over those in `.git/info/exclude`. Set `ignore-vcs` to `true` to disable this behavior:
 
 ```toml config-example
 [tool.hatch.build.targets.sdist]

--- a/docs/history/hatchling.md
+++ b/docs/history/hatchling.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Fixed:***
+
+- Patterns in `.git/info/exclude` are now honored alongside `.gitignore` when excluding files based on version control
+
 ## [1.32.0](https://github.com/pypa/hatch/releases/tag/hatchling-v1.32.0) - 2026-08-11 ## {: #hatchling-v1.32.0 }
 
 ***Changed:***

--- a/tests/backend/builders/test_config.py
+++ b/tests/backend/builders/test_config.py
@@ -1889,6 +1889,36 @@ class TestPatternExclude:
             assert builder.config.path_is_excluded(f"foo{separator}bar") is True
 
     @pytest.mark.parametrize("separator", ["/", "\\"])
+    def test_vcs_git_info_exclude(self, temp_dir, separator, platform):
+        if separator == "\\" and not platform.windows:
+            pytest.skip("Not running on Windows")
+
+        with temp_dir.as_cwd():
+            config = {"tool": {"hatch": {"build": {"exclude": ["foo"]}}}}
+            builder = MockBuilder(str(temp_dir), config=config)
+
+            git_info_dir = temp_dir / ".git" / "info"
+            git_info_dir.mkdir(parents=True)
+            (git_info_dir / "exclude").write_text("/bar\n*.pyc")
+
+            assert builder.config.exclude_spec.match_file(f"foo{separator}file.py")
+            assert builder.config.exclude_spec.match_file(f"bar{separator}file.py")
+            assert builder.config.exclude_spec.match_file(f"baz{separator}bar{separator}file.pyc")
+            assert not builder.config.exclude_spec.match_file(f"baz{separator}bar{separator}file.py")
+
+    def test_vcs_git_info_exclude_lower_precedence_than_gitignore(self, temp_dir):
+        with temp_dir.as_cwd():
+            builder = MockBuilder(str(temp_dir), config={})
+
+            git_info_dir = temp_dir / ".git" / "info"
+            git_info_dir.mkdir(parents=True)
+            (git_info_dir / "exclude").write_text("*.tmp")
+            (temp_dir / ".gitignore").write_text("!keep.tmp")
+
+            assert builder.config.exclude_spec.match_file("other.tmp")
+            assert not builder.config.exclude_spec.match_file("keep.tmp")
+
+    @pytest.mark.parametrize("separator", ["/", "\\"])
     def test_vcs_mercurial(self, temp_dir, separator, platform):
         if separator == "\\" and not platform.windows:
             pytest.skip("Not running on Windows")


### PR DESCRIPTION
---

Closes #2204

Git reads per-repository ignore patterns from two places — `.gitignore` and `.git/info/exclude` — but Hatchling's VCS exclusion only reads the first. Paths a developer excludes locally through `.git/info/exclude` are therefore invisible to Git and still shipped in the distribution. Both reporters on the issue hit exactly that, one of them catching it just before a release.

### Change

`vcs_exclusion_files` now also locates `.git/info/exclude`, using the same `locate_file(..., boundary=".git")` walk as `.gitignore`, so it stops at the repository root rather than escaping it.

It is listed **before** `.gitignore` deliberately. Git gives `.gitignore` the higher precedence of the two, and `pathspec` resolves a path by the last matching pattern, so the lower-precedence file has to come first for a negation like `!keep.tmp` in `.gitignore` to override `*.tmp` in `.git/info/exclude`. There is a test for that ordering — reversing the two lines fails it.

A `.git` that is a file rather than a directory (worktrees and submodules, where it holds a `gitdir:` pointer) is not resolved. Nothing is found in that case and behaviour is exactly as it is today, so this is not a regression; it just leaves that case for a follow-up.

Global excludes via `core.excludesFile` are out of scope — they are user-level rather than per-repository, and the issue is about the latter.

### Tests

- `test_vcs_git_info_exclude` — patterns in `.git/info/exclude` are applied, mirroring the existing `test_vcs_git` case.
- `test_vcs_git_info_exclude_lower_precedence_than_gitignore` — `!keep.tmp` in `.gitignore` wins over `*.tmp` in `.git/info/exclude`, pinning the ordering above.

Both fail before this change and pass after. The full `tests/backend/builders/` suite passes: 425 passed, 55 skipped. `ruff format --check` and `ruff check` are clean on the changed files.

Note on the second test: it deliberately uses `.tmp` rather than `.pyc`. Hatchling's default global exclusions already contain `*.py[cdo]`, which made an earlier version of the test pass without the fix — it was matching the default, not the new behaviour.

### AI disclosure

Per the [AI contributions policy](https://hatch.pypa.io/latest/community/contributing/#ai-contributions): this change was written with AI assistance (Claude Code). The extent — the fix, the tests, the docs and history entries, and this description were AI-drafted; I reviewed the diff and the reasoning before opening, and the tests were run locally, including confirming that each new test fails without the source change.
