### PR TITLE
Fix env var formatting in `get_env_var()` function

### DIFF
--- a/src/hatch/env/utils.py
+++ b/src/hatch/env/utils.py
@@ -6,7 +6,7 @@ from hatch.config.constants import AppEnvVars
 
 
 def get_env_var(*, plugin_name: str, option: str) -> str:
-    return f"{AppEnvVars.ENV_OPTION_PREFIX}{plugin_name}_{option.replace('-', '_')}".upper()
+    return f"{AppEnvVars.ENV_OPTION_PREFIX}{plugin_name.replace('-', '_')}_{option.replace('-', '_')}".upper()
 
 
 def get_env_var_option(*, plugin_name: str, option: str, default: str = "") -> str:

--- a/tests/env/test_utils.py
+++ b/tests/env/test_utils.py
@@ -4,25 +4,25 @@ from hatch.env.utils import get_env_var
 
 
 @pytest.mark.parametrize(
-  ("plugin_name", "option", "expected"),
-  [
-    ("virtual", "uv-path", "HATCH_ENV_TYPE_VIRTUAL_UV_PATH"),
-    ("virtual", "uv_path", "HATCH_ENV_TYPE_VIRTUAL_UV_PATH"),
-    ("my-plugin", "my-option", "HATCH_ENV_TYPE_MY_PLUGIN_MY_OPTION"),
-    ("MY-plugin", "Some-Option", "HATCH_ENV_TYPE_MY_PLUGIN_SOME_OPTION"),
-    ("a-b-c", "d-e-f", "HATCH_ENV_TYPE_A_B_C_D_E_F"),
-  ],
-  ids=[
-    "hyphenated-plugin",
-    "underscored-plugin",
-    "hyphenated-both",
-    "mixed-case-and-hyphens",
-    "multiple-hyphens",
-  ],
+    ("plugin_name", "option", "expected"),
+    [
+        ("virtual", "uv-path", "HATCH_ENV_TYPE_VIRTUAL_UV_PATH"),
+        ("virtual", "uv_path", "HATCH_ENV_TYPE_VIRTUAL_UV_PATH"),
+        ("my-plugin", "my-option", "HATCH_ENV_TYPE_MY_PLUGIN_MY_OPTION"),
+        ("MY-plugin", "Some-Option", "HATCH_ENV_TYPE_MY_PLUGIN_SOME_OPTION"),
+        ("a-b-c", "d-e-f", "HATCH_ENV_TYPE_A_B_C_D_E_F"),
+    ],
+    ids=[
+        "hyphenated-plugin",
+        "underscored-plugin",
+        "hyphenated-both",
+        "mixed-case-and-hyphens",
+        "multiple-hyphens",
+    ],
 )
 def test_get_env_var(
-  plugin_name: str,
-  option: str,
-  expected: str,
+    plugin_name: str,
+    option: str,
+    expected: str,
 ):
-  assert get_env_var(plugin_name, option) == expected
+    assert get_env_var(plugin_name, option) == expected

--- a/tests/env/test_utils.py
+++ b/tests/env/test_utils.py
@@ -2,6 +2,7 @@ import pytest
 
 from hatch.env.utils import get_env_var
 
+
 @pytest.mark.parametrize(
   ("plugin_name", "option", "expected"),
   [

--- a/tests/env/test_utils.py
+++ b/tests/env/test_utils.py
@@ -1,0 +1,27 @@
+import pytest
+
+from hatch.env.utils import get_env_var
+
+@pytest.mark.parametrize(
+  ("plugin_name", "option", "expected"),
+  [
+    ("virtual", "uv-path", "HATCH_ENV_TYPE_VIRTUAL_UV_PATH"),
+    ("virtual", "uv_path", "HATCH_ENV_TYPE_VIRTUAL_UV_PATH"),
+    ("my-plugin", "my-option", "HATCH_ENV_TYPE_MY_PLUGIN_MY_OPTION"),
+    ("MY-plugin", "Some-Option", "HATCH_ENV_TYPE_MY_PLUGIN_SOME_OPTION"),
+    ("a-b-c", "d-e-f", "HATCH_ENV_TYPE_A_B_C_D_E_F"),
+  ],
+  ids=[
+    "hyphenated-plugin",
+    "underscored-plugin",
+    "hyphenated-both",
+    "mixed-case-and-hyphens",
+    "multiple-hyphens",
+  ],
+)
+def test_get_env_var(
+  plugin_name: str,
+  option: str,
+  expected: str,
+):
+  assert get_env_var(plugin_name, option) == expected

--- a/tests/env/test_utils.py
+++ b/tests/env/test_utils.py
@@ -25,7 +25,10 @@ def test_get_env_var(
     option: str,
     expected: str,
 ):
-    assert get_env_var(
-        plugin_name=plugin_name,
-        option=option,
-    ) == expected
+    assert (
+        get_env_var(
+            plugin_name=plugin_name,
+            option=option,
+        )
+        == expected
+    )

--- a/tests/env/test_utils.py
+++ b/tests/env/test_utils.py
@@ -8,11 +8,15 @@ from hatch.env.utils import get_env_var
     [
         ("virtual", "uv-path", "HATCH_ENV_TYPE_VIRTUAL_UV_PATH"),
         ("virtual", "uv_path", "HATCH_ENV_TYPE_VIRTUAL_UV_PATH"),
+        ("pip-compile", "installer", "HATCH_ENV_TYPE_PIP_COMPILE_INSTALLER"),
+        ("pip_compile", "installer", "HATCH_ENV_TYPE_PIP_COMPILE_INSTALLER"),
         ("my-plugin", "my-option", "HATCH_ENV_TYPE_MY_PLUGIN_MY_OPTION"),
         ("MY-plugin", "Some-Option", "HATCH_ENV_TYPE_MY_PLUGIN_SOME_OPTION"),
         ("a-b-c", "d-e-f", "HATCH_ENV_TYPE_A_B_C_D_E_F"),
     ],
     ids=[
+        "hyphenated-option",
+        "underscored-option",
         "hyphenated-plugin",
         "underscored-plugin",
         "hyphenated-both",

--- a/tests/env/test_utils.py
+++ b/tests/env/test_utils.py
@@ -25,4 +25,7 @@ def test_get_env_var(
     option: str,
     expected: str,
 ):
-    assert get_env_var(plugin_name, option) == expected
+    assert get_env_var(
+        plugin_name=plugin_name,
+        option=option,
+    ) == expected


### PR DESCRIPTION
`PLUGIN_NAME` might contain dashes, for example [`pip-compile`](https://github.com/juftin/hatch-pip-compile/blob/main/hatch_pip_compile%2Fplugin.py#L33). This PR replaces dashes with underscores in the plugin name when formatting the environment variable for a Hatch environment option.

Closes #2402