### PR TITLE
Fix version metadata to preserve leading zeros in CalVer

### DIFF
--- a/backend/src/hatchling/metadata/core.py
+++ b/backend/src/hatchling/metadata/core.py
@@ -57,6 +57,7 @@ class ProjectMetadata(Generic[PluginManagerBound]):
         self._dynamic: list[str] | None = None
         self._name: str | None = None
         self._version: str | None = None
+        self._original_version: str | None = None
         self._project_file: str | None = None
 
         # App already loaded config
@@ -152,6 +153,20 @@ class ProjectMetadata(Generic[PluginManagerBound]):
                 self.core.dynamic.remove("version")
 
         return self._version
+
+    @property
+    def original_version(self) -> str:
+        """
+        The version as written by the user, before PEP 440 normalization.
+
+        The normalized `version` is used for distribution file names and `.dist-info`
+        directories, but core metadata records the original string so that stylized
+        versions (e.g. CalVer `2026.08.10`) appear as intended on package indexes.
+        """
+        if self._original_version is None:
+            self._version = self._get_version()
+
+        return cast(str, self._original_version)
 
     @property
     def config(self) -> dict[str, Any]:
@@ -260,6 +275,7 @@ class ProjectMetadata(Generic[PluginManagerBound]):
             message = f"Invalid version `{version}` from {source}, see https://peps.python.org/pep-0440/"
             raise ValueError(message) from None
         else:
+            self._original_version = version
             return normalized_version
 
     def validate_fields(self) -> None:

--- a/backend/src/hatchling/metadata/spec.py
+++ b/backend/src/hatchling/metadata/spec.py
@@ -222,7 +222,7 @@ def construct_metadata_file_1_2(metadata: ProjectMetadata, extra_dependencies: t
     """
     metadata_file = "Metadata-Version: 1.2\n"
     metadata_file += f"Name: {metadata.core.raw_name}\n"
-    metadata_file += f"Version: {metadata.version}\n"
+    metadata_file += f"Version: {metadata.original_version}\n"
 
     if metadata.core.description:
         metadata_file += f"Summary: {metadata.core.description}\n"
@@ -283,7 +283,7 @@ def construct_metadata_file_2_1(metadata: ProjectMetadata, extra_dependencies: t
     """
     metadata_file = "Metadata-Version: 2.1\n"
     metadata_file += f"Name: {metadata.core.raw_name}\n"
-    metadata_file += f"Version: {metadata.version}\n"
+    metadata_file += f"Version: {metadata.original_version}\n"
 
     if metadata.core.description:
         metadata_file += f"Summary: {metadata.core.description}\n"
@@ -360,7 +360,7 @@ def construct_metadata_file_2_2(metadata: ProjectMetadata, extra_dependencies: t
     """
     metadata_file = "Metadata-Version: 2.2\n"
     metadata_file += f"Name: {metadata.core.raw_name}\n"
-    metadata_file += f"Version: {metadata.version}\n"
+    metadata_file += f"Version: {metadata.original_version}\n"
 
     if metadata.core.dynamic:
         # Ordered set
@@ -446,7 +446,7 @@ def construct_metadata_file_2_3(metadata: ProjectMetadata, extra_dependencies: t
     """
     metadata_file = "Metadata-Version: 2.3\n"
     metadata_file += f"Name: {metadata.core.raw_name}\n"
-    metadata_file += f"Version: {metadata.version}\n"
+    metadata_file += f"Version: {metadata.original_version}\n"
 
     if metadata.core.dynamic:
         # Ordered set
@@ -532,7 +532,7 @@ def construct_metadata_file_2_4(metadata: ProjectMetadata, extra_dependencies: t
     """
     metadata_file = "Metadata-Version: 2.4\n"
     metadata_file += f"Name: {metadata.core.raw_name}\n"
-    metadata_file += f"Version: {metadata.version}\n"
+    metadata_file += f"Version: {metadata.original_version}\n"
 
     if metadata.core.dynamic:
         # Ordered set
@@ -623,7 +623,7 @@ def construct_metadata_file_2_5(metadata: ProjectMetadata, extra_dependencies: t
     """
     metadata_file = "Metadata-Version: 2.5\n"
     metadata_file += f"Name: {metadata.core.raw_name}\n"
-    metadata_file += f"Version: {metadata.version}\n"
+    metadata_file += f"Version: {metadata.original_version}\n"
 
     if metadata.core.import_names is not None:
         if not metadata.core.import_names and not metadata.core.import_namespaces:

--- a/tests/backend/metadata/test_core.py
+++ b/tests/backend/metadata/test_core.py
@@ -228,6 +228,12 @@ class TestVersion:
         assert metadata.version == metadata.version == "0.1.0.0rc1"
         assert metadata.core.version == metadata.core.version == "0.1.0.0-rc.1"
 
+    def test_original_version_preserved(self, isolation):
+        metadata = ProjectMetadata(str(isolation), None, {"project": {"version": "2026.08.10"}})
+
+        assert metadata.version == "2026.8.10"
+        assert metadata.original_version == metadata.original_version == "2026.08.10"
+
     def test_dynamic_missing(self, isolation):
         metadata = ProjectMetadata(str(isolation), None, {"project": {"dynamic": ["version"]}, "tool": {"hatch": {}}})
 

--- a/tests/backend/metadata/test_spec.py
+++ b/tests/backend/metadata/test_spec.py
@@ -2400,6 +2400,17 @@ class TestCoreMetadataV24:
 
 @pytest.mark.parametrize("constructor", [get_core_metadata_constructors()["2.5"]])
 class TestCoreMetadataV25:
+    def test_original_version_preserved(self, constructor, isolation, helpers):
+        metadata = ProjectMetadata(str(isolation), None, {"project": {"name": "My.App", "version": "2026.08.10"}})
+
+        assert constructor(metadata) == helpers.dedent(
+            """
+            Metadata-Version: 2.5
+            Name: My.App
+            Version: 2026.08.10
+            """
+        )
+
     def test_import_names(self, constructor, isolation, helpers):
         metadata = ProjectMetadata(
             str(isolation),


### PR DESCRIPTION
Closes #2384 

Preserve the leading zeros in CalVer by just capturing the original input of the version to pass directly into the `Version: ` field. 