### PR TITLE
Fix a couple of tests when no “python” in path

### DIFF
--- a/tests/cli/run/test_run.py
+++ b/tests/cli/run/test_run.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import signal
 import sys
 import sysconfig
@@ -722,7 +723,14 @@ def test_scripts_no_environment(hatch, helpers, temp_dir, config_file):
 
     project = Project(project_path)
     config = dict(project.raw_config)
-    config["tool"]["hatch"]["scripts"] = {"py": "python -c {args}"}
+    # Try to handle testing on systems where there is no "python", only e.g.
+    # "python3". Ideally we would use the absolute path from sys.executable
+    # path, but then we are much more likely to have problems due to things
+    # like whitespace in the directory path, considering we are not attempting
+    # shell escaping. Even the executable name could have these issues, but
+    # this should be good enough for testing purposes.
+    py = pathlib.Path(sys.executable).name
+    config["tool"]["hatch"]["scripts"] = {"py": f"{py} -c {{args}}"}
     project.save_config(config)
 
     with project_path.as_cwd(env_vars={ConfigEnvVars.DATA: str(data_path)}):
@@ -761,7 +769,14 @@ def test_interrupt_signal_not_inherited(hatch, temp_dir, config_file):
 
     project = Project(project_path)
     config = dict(project.raw_config)
-    config["tool"]["hatch"]["scripts"] = {"py": "python -c {args}"}
+    # Try to handle testing on systems where there is no "python", only e.g.
+    # "python3". Ideally we would use the absolute path from sys.executable
+    # path, but then we are much more likely to have problems due to things
+    # like whitespace in the directory path, considering we are not attempting
+    # shell escaping. Even the executable name could have these issues, but
+    # this should be good enough for testing purposes.
+    py = pathlib.Path(sys.executable).name
+    config["tool"]["hatch"]["scripts"] = {"py": f"{py} -c {{args}}"}
     project.save_config(config)
 
     original_handler = signal.getsignal(signal.SIGINT)

--- a/tests/cli/run/test_run.py
+++ b/tests/cli/run/test_run.py
@@ -723,12 +723,9 @@ def test_scripts_no_environment(hatch, helpers, temp_dir, config_file):
 
     project = Project(project_path)
     config = dict(project.raw_config)
-    # Try to handle testing on systems where there is no "python", only e.g.
-    # "python3". Ideally we would use the absolute path from sys.executable
-    # path, but then we are much more likely to have problems due to things
-    # like whitespace in the directory path, considering we are not attempting
-    # shell escaping. Even the executable name could have these issues, but
-    # this should be good enough for testing purposes.
+    # Handle systems where the interpreter is not called "python", but e.g.
+    # "python3". Still inadequate if we need the full path or the name contains
+    # whitespace, but should be good enough for testing.
     py = pathlib.Path(sys.executable).name
     config["tool"]["hatch"]["scripts"] = {"py": f"{py} -c {{args}}"}
     project.save_config(config)
@@ -769,12 +766,9 @@ def test_interrupt_signal_not_inherited(hatch, temp_dir, config_file):
 
     project = Project(project_path)
     config = dict(project.raw_config)
-    # Try to handle testing on systems where there is no "python", only e.g.
-    # "python3". Ideally we would use the absolute path from sys.executable
-    # path, but then we are much more likely to have problems due to things
-    # like whitespace in the directory path, considering we are not attempting
-    # shell escaping. Even the executable name could have these issues, but
-    # this should be good enough for testing purposes.
+    # Handle systems where the interpreter is not called "python", but e.g.
+    # "python3". Still inadequate if we need the full path or the name contains
+    # whitespace, but should be good enough for testing.
     py = pathlib.Path(sys.executable).name
     config["tool"]["hatch"]["scripts"] = {"py": f"{py} -c {{args}}"}
     project.save_config(config)


### PR DESCRIPTION
These CLI tests assume a “python” executable is available outside of a virtualenv, which is not necessarily true (e.g. Fedora has only “python3” if the `python-unversioned-command` package is not installed). Use the value of `sys.executable` in the script configs for these tests instead.

I found this while working on Hatch 1.18.0 for Fedora because the new test `test_interrupt_signal_not_inherited` failed; I hadn’t noticed that it already affected `test_scripts_no_environment` because our builds are offline and  `test_scripts_no_environment` has `@pytest.mark.requires_internet`.