### PR TITLE
Mark a few more tests that require Internet access

### DIFF
--- a/tests/cli/build/test_build.py
+++ b/tests/cli/build/test_build.py
@@ -1465,6 +1465,7 @@ workspace.members = ["packages/*"]
             """
         )
 
+    @pytest.mark.requires_internet
     def test_default(self, hatch, temp_dir):
         workspace_root = self._create_workspace(hatch, temp_dir)
 
@@ -1491,6 +1492,7 @@ workspace.members = ["packages/*"]
         for member_name in ("member1", "member2"):
             assert not (workspace_root / "packages" / member_name / "dist").is_dir()
 
+    @pytest.mark.requires_internet
     def test_virtual_root(self, hatch, temp_dir):
         workspace_root = temp_dir / "workspace"
         workspace_root.mkdir()
@@ -1523,6 +1525,7 @@ workspace.members = ["packages/*"]
             "member2-0.0.1.tar.gz",
         ]
 
+    @pytest.mark.requires_internet
     def test_explicit_targets(self, hatch, temp_dir):
         workspace_root = self._create_workspace(hatch, temp_dir)
 
@@ -1540,6 +1543,7 @@ workspace.members = ["packages/*"]
             "workspace_root-0.0.1-py3-none-any.whl",
         ]
 
+    @pytest.mark.requires_internet
     def test_explicit_directory(self, hatch, temp_dir):
         workspace_root = self._create_workspace(hatch, temp_dir)
         build_directory = temp_dir / "artifacts"

--- a/tests/cli/version/test_version.py
+++ b/tests/cli/version/test_version.py
@@ -37,6 +37,7 @@ class TestNoProject:
         )
 
 
+@pytest.mark.requires_internet
 def test_other_backend_show(hatch, temp_dir, helpers):
     project_name = "My.App"
 


### PR DESCRIPTION
I identified these while testing 1.18.0 for Fedora. Previously, I was skipping some entire test modules with `--ignore` since there were a large number of tests that failed in offline environments, but at some point the coverage of `@pytest.mark.requires_internet` improved to the point that it became practical for me to propose a PR for the few tests that still needed it.