### PR TITLE
Strip the free-threaded suffix before handing a version to uv

### DIFF
--- a/docs/history/hatch.md
+++ b/docs/history/hatch.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Fixed:***
+
+- Strip the free-threaded suffix from the environment's `python` setting before passing it to uv's `--python-version`, which takes a version rather than a build and rejects selectors like `3.14t`
+
 ## [1.18.0](https://github.com/pypa/hatch/releases/tag/hatch-v1.18.0) - 2026-08-11 ## {: #hatch-v1.18.0 }
 
 ***Changed:***

--- a/src/hatch/env/lockers/uv.py
+++ b/src/hatch/env/lockers/uv.py
@@ -76,6 +76,8 @@ class UvLocker(LockerInterface):
         lock_groups: tuple[str, ...],
         requirements_file: Path | None,
     ) -> None:
+        from hatch.python.resolve import normalize_distribution_name
+
         pyproject = environment.root / "pyproject.toml"
         command = [environment.uv_path, "pip", "compile"]
 
@@ -107,7 +109,10 @@ class UvLocker(LockerInterface):
         for pkg in upgrade_packages:
             command.extend(["--upgrade-package", pkg])
 
-        python_version = environment.config.get("python", "")
+        # uv resolves for a version, not for a build, and rejects a free-threaded
+        # selector like `3.14t` outright. The base version is what it wants, and
+        # hatch-test ships `3.14t` in its default matrix.
+        python_version = normalize_distribution_name(environment.config.get("python", ""))
         if python_version:
             command.extend(["--python-version", python_version])
 

--- a/src/hatch/env/virtual.py
+++ b/src/hatch/env/virtual.py
@@ -203,6 +203,8 @@ class VirtualEnvironment(EnvironmentInterface):
             )
 
     def uv_pip_sync_command(self, lockfile_path: Path, *, dry_run: bool = False) -> list[str]:
+        from hatch.python.resolve import normalize_distribution_name
+
         command = [self.uv_path, "pip", "sync", str(lockfile_path)]
         for extra in self.features:
             command.extend(["--extra", extra])
@@ -211,7 +213,8 @@ class VirtualEnvironment(EnvironmentInterface):
         add_verbosity_flag(command, self.verbosity, adjustment=-1)
         if dry_run:
             command.append("--dry-run")
-        python_version = self.config.get("python", "")
+        # See the note in hatch.env.lockers.uv: uv rejects a free-threaded selector.
+        python_version = normalize_distribution_name(self.config.get("python", ""))
         if python_version:
             command.extend(["--python-version", python_version])
         return command


### PR DESCRIPTION
Fixes #2393.

Both places that build a uv command pass the environment's `python` setting straight to `--python-version`:

- `src/hatch/env/lockers/uv.py` (`uv pip compile`)
- `src/hatch/env/virtual.py` (`uv pip sync`)

uv resolves for a *version*, not for a build, so a free-threaded selector is not something it can parse:

```console
$ uv pip compile pyproject.toml --python-version 3.14t
error: invalid value '3.14t' for '--python-version <PYTHON_VERSION>': Python version `3.14t`
could not be parsed: after parsing `3.14`, found `t`, which is not part of a valid version
```

`hatch-test` lists `3.14t` in its default matrix (`src/hatch/env/internal/test.py`), so this is hit without any custom configuration.

## The change

Run the value through `normalize_distribution_name` first. It is already used for exactly this in `virtual.py::_get_available_distribution`, and it only drops the suffix when the base version really has a free-threaded variant:

| setting | passed to uv |
|---|---|
| `3.14t` | `3.14` |
| `3.13t` | `3.13` |
| `3.14` | `3.14` |
| `3.9t` | `3.9t` — 3.9 has no free-threaded build, left alone |
| `pypy3.10` | `pypy3.10` |

Checked against uv 0.12.5: `--python-version 3.14` compiles, `3.14t` is the error above.

## Tests

I did not add one. There is no existing harness for these two command builders — nothing in `tests/` constructs a `VirtualEnvironment` or calls `UVLocker._compile` — and `normalize_distribution_name` is the tested part. Happy to add coverage if you would like it, but I did not want to stand up a fixture for it uninvited.

`tests/env` reports the same 187 collection errors before and after this change on my machine, so I could not use it as a signal either way; they look like a missing environment variable in my local setup rather than anything from this.